### PR TITLE
Remove unused forward declaration is alias header

### DIFF
--- a/src/alias.h
+++ b/src/alias.h
@@ -11,17 +11,11 @@
 #include "sync.h"
 #include "script/script.h"
 #include "serialize.h"
-class CWalletTx;
+
 class CTransaction;
 class CTxOut;
 class COutPoint;
-class CReserveKey;
-class CCoinsViewCache;
-class CCoins;
-class CBlock;
 class CSyscoinAddress;
-class COutPoint;
-class CCoinControl;
 struct CRecipient;
 
 static const unsigned int MAX_GUID_LENGTH = 71;


### PR DESCRIPTION
`class COutPoint;` declared twice; others not used in alias header file.