### PR TITLE
Trivial/asset: Change to make asset name uppercased rather than lowercased.

### DIFF
--- a/src/asset.cpp
+++ b/src/asset.cpp
@@ -655,7 +655,7 @@ UniValue assetnew(const UniValue& params, bool fHelp) {
 						+ HelpRequiringPassphrase());
     vector<unsigned char> vchName = vchFromString(params[0].get_str());
 	string strName = stringFromVch(vchName);
-	boost::algorithm::to_lower(strName);
+	boost::algorithm::to_upper(strName);
 	vector<unsigned char> vchAlias = vchFromValue(params[1]);
 	vector<unsigned char> vchPubData = vchFromString(params[2].get_str());
 	string strCategory = "assets";

--- a/src/test/syscoin_asset_tests.cpp
+++ b/src/test/syscoin_asset_tests.cpp
@@ -328,15 +328,15 @@ BOOST_AUTO_TEST_CASE(generate_assetuppercase)
 	printf("Running generate_assetuppercase...\n");
 	UniValue r;
 	AliasNew("node1", "jagassetuppercase", "data");
-	BOOST_CHECK_NO_THROW(r = CallRPC("node1", "assetnew UPPERCASE jagassetuppercase data assets 8 false 1 1 0 false ''"));
+	BOOST_CHECK_NO_THROW(r = CallRPC("node1", "assetnew changetouppercase jagassetuppercase data assets 8 false 1 1 0 false ''"));
 	UniValue arr = r.get_array();
 	BOOST_CHECK_NO_THROW(r = CallRPC("node1", "signrawtransaction " + arr[0].get_str()));
 	string hex_str = find_value(r.get_obj(), "hex").get_str();
 	BOOST_CHECK_NO_THROW(r = CallRPC("node1", "syscoinsendrawtransaction " + hex_str));
 
 	GenerateBlocks(5);
-	BOOST_CHECK_THROW(r = CallRPC("node1", "assetinfo UPPERCASE false"), runtime_error);
-	BOOST_CHECK_NO_THROW(r = CallRPC("node1", "assetinfo uppercase false"));
+	BOOST_CHECK_THROW(r = CallRPC("node1", "assetinfo changetouppercase false"), runtime_error);
+	BOOST_CHECK_NO_THROW(r = CallRPC("node1", "assetinfo CHANGETOUPPERCASE false"));
 }
 BOOST_AUTO_TEST_CASE(generate_asset_collect_interest)
 {


### PR DESCRIPTION
Figured that this was a simple enough task to get my feet wet:
Yesterday encountered problem where asset names given to _assetnew_ were being lowercased rather than uppercased.  This should repair that issue.

Obviously test changed as well.