### PR TITLE
Dev 3.x zmq topic fix

### DIFF
--- a/src/alias.cpp
+++ b/src/alias.cpp
@@ -1057,7 +1057,7 @@ void CAliasDB::WriteAliasIndex(const CAliasIndex& alias, const int &op) {
 	oName.push_back(Pair("expires_on", alias.nExpireTime));
 	oName.push_back(Pair("encryption_privatekey", HexStr(alias.vchEncryptionPrivateKey)));
 	oName.push_back(Pair("encryption_publickey", HexStr(alias.vchEncryptionPublicKey)));
-	GetMainSignals().NotifySyscoinUpdate(oName.write().c_str(), "alias");
+	GetMainSignals().NotifySyscoinUpdate(oName.write().c_str(), "aliasrecord");
 	WriteAliasIndexHistory(alias, op);
 }
 void CAliasDB::WriteAliasIndexHistory(const CAliasIndex& alias, const int &op) {

--- a/src/asset.cpp
+++ b/src/asset.cpp
@@ -92,7 +92,7 @@ void CAsset::Serialize( vector<unsigned char> &vchData) {
 void CAssetDB::WriteAssetIndex(const CAsset& asset, const int& op) {
 	UniValue oName(UniValue::VOBJ);
 	if (BuildAssetIndexerJson(asset, oName)) {
-		GetMainSignals().NotifySyscoinUpdate(oName.write().c_str(), "asset");
+		GetMainSignals().NotifySyscoinUpdate(oName.write().c_str(), "assetrecord");
 	}
 	WriteAssetIndexHistory(asset, op);
 }

--- a/src/cert.cpp
+++ b/src/cert.cpp
@@ -99,7 +99,7 @@ void CCert::Serialize( vector<unsigned char> &vchData) {
 void CCertDB::WriteCertIndex(const CCert& cert, const int& op) {
 	UniValue oName(UniValue::VOBJ);
 	if (BuildCertIndexerJson(cert, oName)) {
-		GetMainSignals().NotifySyscoinUpdate(oName.write().c_str(), "cert");
+		GetMainSignals().NotifySyscoinUpdate(oName.write().c_str(), "certrecord");
 	}
 
 	WriteCertIndexHistory(cert, op);

--- a/src/escrow.cpp
+++ b/src/escrow.cpp
@@ -207,13 +207,13 @@ void CEscrow::Serialize(vector<unsigned char>& vchData) {
 void CEscrowDB::WriteEscrowIndex(const COffer& offer, const CEscrow& escrow, const std::vector<std::vector<unsigned char> > &vvchArgs) {
 	UniValue oName(UniValue::VOBJ);
 	if (BuildEscrowIndexerJson(offer, escrow, oName)) {
-		GetMainSignals().NotifySyscoinUpdate(oName.write().c_str(), "escrow");
+		GetMainSignals().NotifySyscoinUpdate(oName.write().c_str(), "escrowrecord");
 	}
 }
 void CEscrowDB::WriteEscrowFeedbackIndex(const COffer &offer, const CEscrow& escrow) {
 	UniValue oName(UniValue::VOBJ);
 	BuildFeedbackJson(offer, escrow, oName);
-	GetMainSignals().NotifySyscoinUpdate(oName.write().c_str(), "feedback");
+	GetMainSignals().NotifySyscoinUpdate(oName.write().c_str(), "escrowfeedback");
 }
 void CEscrowDB::WriteEscrowBidIndex(const COffer& offer, const CEscrow& escrow, const string& status) {
 	if (escrow.op != OP_ESCROW_ACTIVATE)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -537,19 +537,19 @@ std::string HelpMessage(HelpMessageMode mode)
 	strUsage += HelpMessageOpt("-zmqpubrawblock=<address>", _("Enable publish raw block in <address>"));
 	strUsage += HelpMessageOpt("-zmqpubrawtx=<address>", _("Enable publish raw transaction in <address>"));
 	strUsage += HelpMessageOpt("-zmqpubrawtxlock=<address>", _("Enable publish raw transaction (locked via InstantSend) in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubaliasrecord=<address>", _("Enable publish raw alias payload in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubaliashistory=<address>", _("Enable publish raw alias history payload in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubaliastxhistory=<address>", _("Enable publish raw alias transaction history payload in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubofferrecord=<address>", _("Enable publish raw offer payload in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubofferhistory=<address>", _("Enable publish raw offer history payload in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubescrowrecord=<address>", _("Enable publish raw escrow payload in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubescrowbid=<address>", _("Enable publish raw escrow bid payload in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubescrowfeedback=<address>", _("Enable publish raw escrow feedback payload in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubcertrecord=<address>", _("Enable publish raw certificate payload in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubcerthistory=<address>", _("Enable publish raw certificate history payload in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubassetrecord=<address>", _("Enable publish raw asset payload in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubassethistory=<address>", _("Enable publish raw asset history payload in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubassetallocation=<address>", _("Enable publish raw asset allocation payload in <address>"));
+    strUsage += HelpMessageOpt("-zmqpubaliashistory=<address>", _("Enable publish raw alias history payload in <address>"));
+    strUsage += HelpMessageOpt("-zmqpubaliasrecord=<address>", _("Enable publish raw alias payload in <address>"));
+    strUsage += HelpMessageOpt("-zmqpubaliastxhistory=<address>", _("Enable publish raw alias transaction history payload in <address>"));
+    strUsage += HelpMessageOpt("-zmqpubassetallocation=<address>", _("Enable publish raw asset allocation payload in <address>"));
+    strUsage += HelpMessageOpt("-zmqpubassethistory=<address>", _("Enable publish raw asset history payload in <address>"));
+    strUsage += HelpMessageOpt("-zmqpubassetrecord=<address>", _("Enable publish raw asset payload in <address>"));
+    strUsage += HelpMessageOpt("-zmqpubcerthistory=<address>", _("Enable publish raw certificate history payload in <address>"));
+    strUsage += HelpMessageOpt("-zmqpubcertrecord=<address>", _("Enable publish raw certificate payload in <address>"));
+    strUsage += HelpMessageOpt("-zmqpubescrowbid=<address>", _("Enable publish raw escrow bid payload in <address>"));
+    strUsage += HelpMessageOpt("-zmqpubescrowfeedback=<address>", _("Enable publish raw escrow feedback payload in <address>"));
+    strUsage += HelpMessageOpt("-zmqpubescrowrecord=<address>", _("Enable publish raw escrow payload in <address>"));
+    strUsage += HelpMessageOpt("-zmqpubofferhistory=<address>", _("Enable publish raw offer history payload in <address>"));
+    strUsage += HelpMessageOpt("-zmqpubofferrecord=<address>", _("Enable publish raw offer payload in <address>"));
 #endif
 
     strUsage += HelpMessageGroup(_("Debugging/Testing options:"));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -537,17 +537,17 @@ std::string HelpMessage(HelpMessageMode mode)
 	strUsage += HelpMessageOpt("-zmqpubrawblock=<address>", _("Enable publish raw block in <address>"));
 	strUsage += HelpMessageOpt("-zmqpubrawtx=<address>", _("Enable publish raw transaction in <address>"));
 	strUsage += HelpMessageOpt("-zmqpubrawtxlock=<address>", _("Enable publish raw transaction (locked via InstantSend) in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubalias=<address>", _("Enable publish raw alias payload in <address>"));
+	strUsage += HelpMessageOpt("-zmqpubaliasrecord=<address>", _("Enable publish raw alias payload in <address>"));
 	strUsage += HelpMessageOpt("-zmqpubaliashistory=<address>", _("Enable publish raw alias history payload in <address>"));
 	strUsage += HelpMessageOpt("-zmqpubaliastxhistory=<address>", _("Enable publish raw alias transaction history payload in <address>"));
-	strUsage += HelpMessageOpt("-zmqpuboffer=<address>", _("Enable publish raw offer payload in <address>"));
+	strUsage += HelpMessageOpt("-zmqpubofferrecord=<address>", _("Enable publish raw offer payload in <address>"));
 	strUsage += HelpMessageOpt("-zmqpubofferhistory=<address>", _("Enable publish raw offer history payload in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubescrow=<address>", _("Enable publish raw escrow payload in <address>"));
+	strUsage += HelpMessageOpt("-zmqpubescrowrecord=<address>", _("Enable publish raw escrow payload in <address>"));
 	strUsage += HelpMessageOpt("-zmqpubescrowbid=<address>", _("Enable publish raw escrow bid payload in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubfeedback=<address>", _("Enable publish raw escrow feedback payload in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubcert=<address>", _("Enable publish raw certificate payload in <address>"));
+	strUsage += HelpMessageOpt("-zmqpubescrowfeedback=<address>", _("Enable publish raw escrow feedback payload in <address>"));
+	strUsage += HelpMessageOpt("-zmqpubcertrecord=<address>", _("Enable publish raw certificate payload in <address>"));
 	strUsage += HelpMessageOpt("-zmqpubcerthistory=<address>", _("Enable publish raw certificate history payload in <address>"));
-	strUsage += HelpMessageOpt("-zmqpubasset=<address>", _("Enable publish raw asset payload in <address>"));
+	strUsage += HelpMessageOpt("-zmqpubassetrecord=<address>", _("Enable publish raw asset payload in <address>"));
 	strUsage += HelpMessageOpt("-zmqpubassethistory=<address>", _("Enable publish raw asset history payload in <address>"));
 	strUsage += HelpMessageOpt("-zmqpubassetallocation=<address>", _("Enable publish raw asset allocation payload in <address>"));
 #endif

--- a/src/offer.cpp
+++ b/src/offer.cpp
@@ -1162,7 +1162,7 @@ UniValue offerupdate(const JSONRPCRequest& request) {
 void COfferDB::WriteOfferIndex(const COffer& offer, const int &op) {
 	UniValue oName(UniValue::VOBJ);
 	if (BuildOfferIndexerJson(offer, oName)) {
-		GetMainSignals().NotifySyscoinUpdate(oName.write().c_str(), "offer");
+		GetMainSignals().NotifySyscoinUpdate(oName.write().c_str(), "offerrecord");
 	}
 	WriteOfferIndexHistory(offer, op);
 }

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -41,16 +41,16 @@ CZMQNotificationInterface* CZMQNotificationInterface::Create()
     factories["pubrawblock"] = CZMQAbstractNotifier::Create<CZMQPublishRawBlockNotifier>;
     factories["pubrawtx"] = CZMQAbstractNotifier::Create<CZMQPublishRawTransactionNotifier>;
     factories["pubrawtxlock"] = CZMQAbstractNotifier::Create<CZMQPublishRawTransactionLockNotifier>;
-	factories["pubalias"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+	factories["pubaliasrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
 	factories["pubaliashistory"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
 	factories["pubaliastxhistory"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
-	factories["puboffer"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+	factories["pubofferrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
 	factories["pubofferhistory"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
-	factories["pubescrow"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
-	factories["pubfeedback"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
-	factories["pubcert"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+    factories["pubescrowrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+	factories["pubescrowfeedback"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+	factories["pubcertrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
 	factories["pubcerthistory"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
-	factories["pubasset"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+	factories["pubassetrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
 	factories["pubassethistory"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
 	factories["pubassetallocation"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
 

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -41,19 +41,19 @@ CZMQNotificationInterface* CZMQNotificationInterface::Create()
     factories["pubrawblock"] = CZMQAbstractNotifier::Create<CZMQPublishRawBlockNotifier>;
     factories["pubrawtx"] = CZMQAbstractNotifier::Create<CZMQPublishRawTransactionNotifier>;
     factories["pubrawtxlock"] = CZMQAbstractNotifier::Create<CZMQPublishRawTransactionLockNotifier>;
-	factories["pubaliasrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
-	factories["pubaliashistory"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
-	factories["pubaliastxhistory"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
-	factories["pubofferrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
-	factories["pubofferhistory"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
-    factories["pubescrowrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+    factories["pubaliashistory"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+    factories["pubaliasrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+    factories["pubaliastxhistory"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+    factories["pubassetallocation"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+    factories["pubassethistory"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+    factories["pubassetrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+    factories["pubcerthistory"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+    factories["pubcertrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
     factories["pubescrowbid"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
-	factories["pubescrowfeedback"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
-	factories["pubcertrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
-	factories["pubcerthistory"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
-	factories["pubassetrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
-	factories["pubassethistory"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
-	factories["pubassetallocation"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+    factories["pubescrowfeedback"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+    factories["pubescrowrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+    factories["pubofferhistory"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+    factories["pubofferrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
 
     for (std::map<std::string, CZMQNotifierFactory>::const_iterator i=factories.begin(); i!=factories.end(); ++i)
     {

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -47,6 +47,7 @@ CZMQNotificationInterface* CZMQNotificationInterface::Create()
 	factories["pubofferrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
 	factories["pubofferhistory"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
     factories["pubescrowrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
+    factories["pubescrowbid"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
 	factories["pubescrowfeedback"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
 	factories["pubcertrecord"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;
 	factories["pubcerthistory"] = CZMQAbstractNotifier::Create<CZMQPublishRawSyscoinNotifier>;


### PR DESCRIPTION
Update for ZMQ message queues. 

Fixes #188 


```
subscribed to syscoin topic alias
subscribed to syscoin topic asset
subscribed to syscoin topic offer
subscribed to syscoin topic escrow
subscribed to syscoin topic cert
messages 0 aliases 0 {}
messages 9739 aliases 3246 { aliastxhistory: 3247, aliasrecord: 3246, aliashistory: 3246 }
messages 21600 aliases 7200 { aliastxhistory: 7200, aliasrecord: 7200, aliashistory: 7200 }
messages 33951 aliases 11317 { aliastxhistory: 11317,
  aliasrecord: 11317,
  aliashistory: 11317 }
messages 44064 aliases 13381 { aliastxhistory: 14688,
  aliasrecord: 13871,
  aliashistory: 13871,
  certrecord: 88,
  certhistory: 88,
  offerrecord: 729,
  offerhistory: 729 }
messages 82407 aliases 13381 { aliastxhistory: 27469,
  aliasrecord: 26652,
  aliashistory: 26652,
  certrecord: 88,
  certhistory: 88,
  offerrecord: 729,
  offerhistory: 729 }
```