### PR TITLE
Dev 3.x get syscoin transaction description

### DIFF
--- a/src/alias.cpp
+++ b/src/alias.cpp
@@ -2574,135 +2574,147 @@ bool COfferLinkWhitelist::GetLinkEntryByHash(const std::vector<unsigned char> &a
 }
 string GetSyscoinTransactionDescription(const CTransaction& tx, const int op, string& responseEnglish, const char &type, string& responseGUID)
 {
-	string strResponse = "";
-	if (op == OP_ALIAS_ACTIVATE) {
-		strResponse = _("Alias Activated");
-		responseEnglish = "Alias Activated";
-	}
-	else if (op == OP_ALIAS_UPDATE) {
-		strResponse = _("Alias Updated");
-		responseEnglish = "Alias Updated";
-	}
-	else if (op == OP_OFFER_ACTIVATE) {
-		strResponse = _("Offer Activated");
-		responseEnglish = "Offer Activated";
-	}
-	else if (op == OP_OFFER_UPDATE) {
-		strResponse = _("Offer Updated");
-		responseEnglish = "Offer Updated";
-	}
-	else if (op == OP_CERT_ACTIVATE) {
-		strResponse = _("Certificate Activated");
-		responseEnglish = "Certificate Activated";
-	}
-	else if (op == OP_CERT_UPDATE) {
-		strResponse = _("Certificate Updated");
-		responseEnglish = "Certificate Updated";
-	}
-	else if (op == OP_CERT_TRANSFER) {
-		strResponse = _("Certificate Transferred");
-		responseEnglish = "Certificate Transferred";
-	}
-	else if (op == OP_ASSET_ACTIVATE) {
-		strResponse = _("Asset Activated");
-		responseEnglish = "Asset Activated";
-	}
-	else if (op == OP_ASSET_UPDATE) {
-		strResponse = _("Asset Updated");
-		responseEnglish = "Asset Updated";
-	}
-	else if (op == OP_ASSET_TRANSFER) {
-		strResponse = _("Asset Transferred");
-		responseEnglish = "Asset Transferred";
-	}
-	else if (op == OP_ASSET_SEND) {
-		strResponse = _("Asset Sent");
-		responseEnglish = "Asset Sent";
-	}
-	else if (op == OP_ASSET_ALLOCATION_SEND) {
-		strResponse = _("Asset Allocation Sent");
-		responseEnglish = "Asset Allocation Sent";
-	}
-	else if (op == OP_ASSET_COLLECT_INTEREST) {
-		strResponse = _("Asset Collect Interest");
-		responseEnglish = "Asset Collect Interest";
-	}
-	else if (op == OP_ESCROW_ACTIVATE) {
-		strResponse = _("Escrow Activated");
-		responseEnglish = "Escrow Activated";
-	}
-	else if (op == OP_ESCROW_ACKNOWLEDGE) {
-		strResponse = _("Escrow Acknowledged");
-		responseEnglish = "Escrow Acknowledged";
-	}
-	else if (op == OP_ESCROW_RELEASE) {
-		strResponse = _("Escrow Released");
-		responseEnglish = "Escrow Released";
-	}
-	else if (op == OP_ESCROW_RELEASE_COMPLETE) {
-		strResponse = _("Escrow Release Complete");
-		responseEnglish = "Escrow Release Complete";
-	}
-	else if (op == OP_ESCROW_FEEDBACK) {
-		strResponse = _("Escrow Feedback");
-		responseEnglish = "Escrow Feedback";
-	}
-	else if (op == OP_ESCROW_BID) {
-		strResponse = _("Escrow Bid");
-		responseEnglish = "Escrow Bid";
-	}
-	else if (op == OP_ESCROW_ADD_SHIPPING) {
-		strResponse = _("Escrow Add Shipping");
-		responseEnglish = "Escrow Add Shipping";
-	}
-	else if (op == OP_ESCROW_REFUND) {
-		strResponse = _("Escrow Refunded");
-		responseEnglish = "Escrow Refunded";
-	}
-	else if (op == OP_ESCROW_REFUND_COMPLETE) {
-		strResponse = _("Escrow Refund Complete");
-		responseEnglish = "Escrow Refund Complete";
-	}
-	if (tx.IsNull())
+	if (tx.IsNull()) {
 		return "";
+	}
+	string strResponse = "";
 	if (type == ALIAS) {
+		// message from op code
+		if (op == OP_ALIAS_ACTIVATE) {
+			strResponse = _("Alias Activated");
+			responseEnglish = "Alias Activated";
+		} else
+		if (op == OP_ALIAS_UPDATE) {
+			strResponse = _("Alias Updated");
+			responseEnglish = "Alias Updated";
+		}
+
 		CAliasIndex alias(tx);
 		if (!alias.IsNull()) {
 			responseGUID = stringFromVch(alias.vchAlias);
 		}
-	}
-	else if (type == OFFER) {
+	} else 
+	if (type == OFFER) {
+		// message from op code
+		if (op == OP_OFFER_ACTIVATE) {
+			strResponse = _("Offer Activated");
+			responseEnglish = "Offer Activated";
+		} else
+		if (op == OP_OFFER_UPDATE) {
+			strResponse = _("Offer Updated");
+			responseEnglish = "Offer Updated";
+		}
+
 		COffer offer(tx);
 		if (!offer.IsNull()) {
 			responseGUID = stringFromVch(offer.vchOffer);
 		}		
-	}
-	else if (type == CERT) {
+	} else 
+	if (type == CERT) {
+		// message from op code
+		if (op == OP_CERT_ACTIVATE) {
+			strResponse = _("Certificate Activated");
+			responseEnglish = "Certificate Activated";
+		} else
+		if (op == OP_CERT_UPDATE) {
+			strResponse = _("Certificate Updated");
+			responseEnglish = "Certificate Updated";
+		} else
+		if (op == OP_CERT_TRANSFER) {
+			strResponse = _("Certificate Transferred");
+			responseEnglish = "Certificate Transferred";
+		}
 		CCert cert(tx);
 		if (!cert.IsNull()) {
 			responseGUID = stringFromVch(cert.vchCert);
 		}	
-	}
-	else if (type == ASSET) {
+	} else
+	if (type == ASSET) {
+		// message from op code
+		if (op == OP_ASSET_ACTIVATE) {
+			strResponse = _("Asset Activated");
+			responseEnglish = "Asset Activated";
+		} else
+		if (op == OP_ASSET_UPDATE) {
+			strResponse = _("Asset Updated");
+			responseEnglish = "Asset Updated";
+		} else 
+		if (op == OP_ASSET_TRANSFER) {
+			strResponse = _("Asset Transferred");
+			responseEnglish = "Asset Transferred";
+		} else
+		if (op == OP_ASSET_SEND) {
+			strResponse = _("Asset Sent");
+			responseEnglish = "Asset Sent";
+		}
+
 		CAsset asset(tx);
 		if (!asset.IsNull()) {
 			responseGUID = stringFromVch(asset.vchAsset);
 		}		
-	}
-	else if (type == ASSETALLOCATION) {
+	} else 
+	if (type == ASSETALLOCATION) {
+		// message from op code
+		if (op == OP_ASSET_ALLOCATION_SEND) {
+			strResponse = _("Asset Allocation Sent");
+			responseEnglish = "Asset Allocation Sent";
+		} else
+		if (op == OP_ASSET_COLLECT_INTEREST) {
+			strResponse = _("Asset Interest Collected");
+			responseEnglish = "Asset Interest Collected";
+		}
+
 		CAssetAllocation assetallocation(tx);
 		if (!assetallocation.IsNull()) {
 			responseGUID = stringFromVch(assetallocation.vchAsset);
 		}
-	}
-	else if (type == ESCROW) {
+	} else
+	if (type == ESCROW) {
+		// message from op code
+		if (op == OP_ESCROW_ACTIVATE) {
+			strResponse = _("Escrow Activated");
+			responseEnglish = "Escrow Activated";
+		} else
+		if (op == OP_ESCROW_ACKNOWLEDGE) {
+			strResponse = _("Escrow Acknowledged");
+			responseEnglish = "Escrow Acknowledged";
+		} else
+		if (op == OP_ESCROW_RELEASE) {
+			strResponse = _("Escrow Released");
+			responseEnglish = "Escrow Released";
+		} else
+		if (op == OP_ESCROW_RELEASE_COMPLETE) {
+			strResponse = _("Escrow Release Complete");
+			responseEnglish = "Escrow Release Complete";
+		} else
+		if (op == OP_ESCROW_FEEDBACK) {
+			strResponse = _("Escrow Feedback");
+			responseEnglish = "Escrow Feedback";
+		} else
+		if (op == OP_ESCROW_BID) {
+			strResponse = _("Escrow Bid");
+			responseEnglish = "Escrow Bid";
+		} else
+		if (op == OP_ESCROW_ADD_SHIPPING) {
+			strResponse = _("Escrow Add Shipping");
+			responseEnglish = "Escrow Add Shipping";
+		} else
+		if (op == OP_ESCROW_REFUND) {
+			strResponse = _("Escrow Refunded");
+			responseEnglish = "Escrow Refunded";
+		} else
+		if (op == OP_ESCROW_REFUND_COMPLETE) {
+			strResponse = _("Escrow Refund Complete");
+			responseEnglish = "Escrow Refund Complete";
+		}
+		
 		CEscrow escrow(tx);
 		if (!escrow.IsNull()) {
 			responseGUID = stringFromVch(escrow.vchEscrow);
 		}
-	}
-	else{
-		return "";
+	} 
+	else {
+		return "Unknown Op Type" + " " + type;
 	}
 	return strResponse + " " + responseGUID;
 }

--- a/src/alias.cpp
+++ b/src/alias.cpp
@@ -2575,7 +2575,7 @@ bool COfferLinkWhitelist::GetLinkEntryByHash(const std::vector<unsigned char> &a
 string GetSyscoinTransactionDescription(const CTransaction& tx, const int op, string& responseEnglish, const char &type, string& responseGUID)
 {
 	if (tx.IsNull()) {
-		return "";
+		return "Null Tx";
 	}
 	string strResponse = "";
 	if (type == ALIAS) {


### PR DESCRIPTION
SYS-167 #comment 
Fix `GetSyscoinTransactionDescription` by checking `type` before setting message
Add unkown message for type when not found
For OP_ASSET_COLLECT_INTEREST use "Asset Interest Collected" to maintain consistency
Show null message instead of empty string