### PR TITLE
bash completions for syscoin-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ syscoin-cli
 syscoind
 syscoin-qt
 make
+contrib/devtools/split-debug.sh

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -54,3 +54,10 @@ tests each pull and when master is tested using jenkins.
 
 ### [Verify SF Binaries](/contrib/verifysfbinaries) ###
 This script attempts to download and verify the signature file SHA256SUMS.asc from SourceForge.
+
+Command Line Tools
+---------------------
+
+### [Bash Completion](/contrib/bash-completion.md) ###
+Bash completion scripts for `syscoind` and `syscoin-cli`.
+

--- a/contrib/_osx.bash-completion
+++ b/contrib/_osx.bash-completion
@@ -1,0 +1,18 @@
+# This function checks whether we have a given program on the system.
+# https://stackoverflow.com/a/12874971/1427161
+#
+_have()
+{
+    # Completions for system administrator commands are installed as well in
+    # case completion is attempted via `sudo command ...'.
+    PATH=$PATH:/usr/sbin:/sbin:/usr/local/sbin type $1 &>/dev/null
+}
+
+# Backwards compatibility for compat completions that use have().
+# @deprecated should no longer be used; generally not needed with dynamically
+#             loaded completions, and _have is suitable for runtime use.
+have()
+{
+    unset -v have
+    _have $1 && have=yes
+}

--- a/contrib/bash-completion.md
+++ b/contrib/bash-completion.md
@@ -1,0 +1,32 @@
+Bash Completion
+---------------------
+
+The following script provide bash completion functionality for `sycoind` and `syscoin-cli`.
+
+* `contrib/syscoind.bash-completion`
+* `contrib/syscoin-cli.bash-completion`
+* `contrib/_osx.bash-completion`
+
+### OSX ###
+Use `brew` to install `bash-completion` then update `~/.bashrc` to include the completion scripts and helper functions to provide `have()` and `_have()` on OSX.
+
+The example assumes Syscoin was compiled in `~/syscoin` and the scripts will be availabe in `~/syscoin/contrib`, however they can be moved to a different location.
+
+```
+brew install bash-completion
+
+# syscoind.service config
+BASHRC=$(cat <<EOF
+if [ -f $(brew --prefix)/etc/bash_completion ]; then
+. $(brew --prefix)/etc/bash_completion
+fi
+source ~/syscoin/contrib/_osx.bash-completion
+source ~/syscoin/contrib/syscoind.bash-completion
+source ~/syscoin/contrib/syscoin-cli.bash-completion
+EOF
+)
+
+grep -q "/etc/bash_completion" || echo "$BASHRC" >> ~/.bashrc
+. ~/.bashrc
+
+```

--- a/contrib/bash-completion.md
+++ b/contrib/bash-completion.md
@@ -17,11 +17,11 @@ brew install bash-completion
 
 BASHRC=$(cat <<EOF
 if [ -f $(brew --prefix)/etc/bash_completion ]; then
-. $(brew --prefix)/etc/bash_completion
+  . $(brew --prefix)/etc/bash_completion
 fi
-source ~/syscoin/contrib/_osx.bash-completion
-source ~/syscoin/contrib/syscoind.bash-completion
-source ~/syscoin/contrib/syscoin-cli.bash-completion
+. ~/syscoin/contrib/_osx.bash-completion
+. ~/syscoin/contrib/syscoind.bash-completion
+. ~/syscoin/contrib/syscoin-cli.bash-completion
 EOF
 )
 

--- a/contrib/bash-completion.md
+++ b/contrib/bash-completion.md
@@ -15,7 +15,6 @@ The example assumes Syscoin was compiled in `~/syscoin` and the scripts will be 
 ```
 brew install bash-completion
 
-# syscoind.service config
 BASHRC=$(cat <<EOF
 if [ -f $(brew --prefix)/etc/bash_completion ]; then
 . $(brew --prefix)/etc/bash_completion
@@ -26,7 +25,7 @@ source ~/syscoin/contrib/syscoin-cli.bash-completion
 EOF
 )
 
-grep -q "/etc/bash_completion" || echo "$BASHRC" >> ~/.bashrc
+grep -q "/etc/bash_completion" ~/.bashrc || echo "$BASHRC" >> ~/.bashrc
 . ~/.bashrc
 
 ```

--- a/contrib/debian/syscoind.bash-completion
+++ b/contrib/debian/syscoind.bash-completion
@@ -1,1 +1,2 @@
 contrib/syscoind.bash-completion	syscoind
+contrib/syscoin-cli.bash-completion syscoin-cli

--- a/contrib/syscoin-cli.bash-completion
+++ b/contrib/syscoin-cli.bash-completion
@@ -1,0 +1,154 @@
+# bash programmable completion for syscoin-cli(1)
+# Copyright (c) 2012-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# call $syscoin-cli for RPC
+_syscoin_rpc() {
+    # determine already specified args necessary for RPC
+    local rpcargs=()
+    for i in ${COMP_LINE}; do
+        case "$i" in
+            -conf=*|-datadir=*|-regtest|-rpc*|-testnet)
+                rpcargs=( "${rpcargs[@]}" "$i" )
+                ;;
+        esac
+    done
+    $syscoin_cli "${rpcargs[@]}" "$@"
+}
+
+# Add wallet accounts to COMPREPLY
+_syscoin_accounts() {
+    local accounts
+    accounts=$(_syscoin_rpc listaccounts | awk -F '"' '{ print $2 }')
+    COMPREPLY=( "${COMPREPLY[@]}" $( compgen -W "$accounts" -- "$cur" ) )
+}
+
+_syscoin_cli() {
+    local cur prev words=() cword
+    local syscoin_cli
+
+    # save and use original argument to invoke syscoin-cli for -help, help and RPC
+    # as syscoin-cli might not be in $PATH
+    syscoin_cli="$1"
+
+    COMPREPLY=()
+    _get_comp_words_by_ref -n = cur prev words cword
+
+    if ((cword > 5)); then
+        case ${words[cword-5]} in
+            sendtoaddress)
+                COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
+                return 0
+                ;;
+        esac
+    fi
+
+    if ((cword > 4)); then
+        case ${words[cword-4]} in
+            importaddress|listtransactions|setban)
+                COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
+                return 0
+                ;;
+            signrawtransaction)
+                COMPREPLY=( $( compgen -W "ALL NONE SINGLE ALL|ANYONECANPAY NONE|ANYONECANPAY SINGLE|ANYONECANPAY" -- "$cur" ) )
+                return 0
+                ;;
+        esac
+    fi
+
+    if ((cword > 3)); then
+        case ${words[cword-3]} in
+            addmultisigaddress)
+                _syscoin_accounts
+                return 0
+                ;;
+            getbalance|gettxout|importaddress|importpubkey|importprivkey|listreceivedbyaccount|listreceivedbyaddress|listsinceblock)
+                COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
+                return 0
+                ;;
+        esac
+    fi
+
+    if ((cword > 2)); then
+        case ${words[cword-2]} in
+            addnode)
+                COMPREPLY=( $( compgen -W "add remove onetry" -- "$cur" ) )
+                return 0
+                ;;
+            setban)
+                COMPREPLY=( $( compgen -W "add remove" -- "$cur" ) )
+                return 0
+                ;;
+            fundrawtransaction|getblock|getblockheader|getmempoolancestors|getmempooldescendants|getrawtransaction|gettransaction|listaccounts|listreceivedbyaccount|listreceivedbyaddress|sendrawtransaction)
+                COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
+                return 0
+                ;;
+            move|setaccount)
+                _syscoin_accounts
+                return 0
+                ;;
+        esac
+    fi
+
+    case "$prev" in
+        backupwallet|dumpwallet|importwallet)
+            _filedir
+            return 0
+            ;;
+        getaddednodeinfo|getrawmempool|lockunspent|setgenerate)
+            COMPREPLY=( $( compgen -W "true false" -- "$cur" ) )
+            return 0
+            ;;
+        getaccountaddress|getaddressesbyaccount|getbalance|getnewaddress|getreceivedbyaccount|listtransactions|move|sendfrom|sendmany)
+            _syscoin_accounts
+            return 0
+            ;;
+    esac
+
+    case "$cur" in
+        -conf=*)
+            cur="${cur#*=}"
+            _filedir
+            return 0
+            ;;
+        -datadir=*)
+            cur="${cur#*=}"
+            _filedir -d
+            return 0
+            ;;
+        -*=*) # prevent nonsense completions
+            return 0
+            ;;
+        *)
+            local helpopts commands
+
+            # only parse -help if senseful
+            if [[ -z "$cur" || "$cur" =~ ^- ]]; then
+                helpopts=$($syscoin_cli -help 2>&1 | awk '$1 ~ /^-/ { sub(/=.*/, "="); print $1 }' )
+            fi
+
+            # only parse help if senseful
+            if [[ -z "$cur" || "$cur" =~ ^[a-z] ]]; then
+                commands=$(_syscoin_rpc help 2>/dev/null | awk '$1 ~ /^[a-z]/ { print $1; }')
+            fi
+
+            COMPREPLY=( $( compgen -W "$helpopts $commands" -- "$cur" ) )
+
+            # Prevent space if an argument is desired
+            if [[ $COMPREPLY == *= ]]; then
+                compopt -o nospace
+            fi
+            return 0
+            ;;
+    esac
+} &&
+complete -F _syscoin_cli syscoin-cli
+
+# Local variables:
+# mode: shell-script
+# sh-basic-offset: 4
+# sh-indent-comment: t
+# indent-tabs-mode: nil
+# End:
+# ex: ts=4 sw=4 et filetype=sh


### PR DESCRIPTION
Test on mac using brew:

```
brew install bash-completion
. $(brew --prefix)/etc/bash_completion
. contrib/syscoin-cli.bash-completion
```
