### PR TITLE
[SYS-252] listassetallocationtransactions

### DIFF
--- a/src/assetallocation.cpp
+++ b/src/assetallocation.cpp
@@ -1318,9 +1318,9 @@ bool CAssetAllocationTransactionsDB::ScanAssetAllocationIndex(const int count, c
 			}
 			if (assetValue.read(indexItem.second))
 				oRes.push_back(assetValue);
-			if (index >= count + from)
-				break;
 		}
+		if (index >= count + from)
+			break;
 	}
 	return true;
 }


### PR DESCRIPTION
Fixed an issue with default count always being used when calling listassetallocationtransactions.

When using the syscoin-cli command listassetallocationtransactions, the system should return the number of transactions up to matching the first argument passed into the command, with the default being 10 if no argument is passed.

Formating e.g.:

listassetallocationtransactions

This should return up to 10 transactions

<img width="818" alt="screen shot 2018-07-24 at 2 19 23 pm" src="https://user-images.githubusercontent.com/10374261/43480496-4d92cc94-94b8-11e8-9fb1-0f923620a264.png">

list assetallocationtransactions

This should return up to 2 transactions

<img width="600" alt="screen shot 2018-07-24 at 2 18 46 pm" src="https://user-images.githubusercontent.com/10374261/43480508-59780a06-94b8-11e8-9a9e-bbd8dcac2a17.png">
