### PR TITLE
Sys 320 options preflight

### DIFF
--- a/qa/rpc-tests/multi_rpc.py
+++ b/qa/rpc-tests/multi_rpc.py
@@ -116,6 +116,42 @@ class HTTPBasicsTest (SyscoinTestFramework):
         assert_equal(resp.status==401, True)
         conn.close()
 
+        #Preflight - all access control headers
+        headers = {"Origin": "http://localhost", "Access-Control-Request-Method": "POST", "Authorization": "Basic " + str_to_b64str(authpairnew)}
 
+        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn.connect()
+        conn.request('OPTIONS', '/', None, headers)
+        resp = conn.getresponse()
+        assert_equal(resp.status==401, False)
+        assert_equal(resp.getheader("access-control-allow-origin"), "http://localhost")
+        assert_equal(resp.getheader("access-control-allow-methods"), "POST")
+        assert_equal(resp.getheader("access-control-allow-headers"), "authorization,content-type")
+        assert_equal(resp.getheader("access-control-allow-credentials"), "true")
+        conn.close()
+
+        #Simple Cross Origin - no Origin
+        headers = {"Access-Control-Request-Method": "POST", "Authorization": "Basic " + str_to_b64str(authpairnew)}
+
+        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn.connect()
+        conn.request('OPTIONS', '/', None, headers)
+        resp = conn.getresponse()
+        assert_equal(resp.status==401, False)
+        assert_equal(resp.getheader("access-control-allow-origin"), None)
+        conn.close()
+
+        #Simple Cross Origin - no OPTIONS
+        headers = {"Origin": "http://localhost", "Access-Control-Request-Method": "POST", "Authorization": "Basic " + str_to_b64str(authpairnew)}
+
+        conn = httplib.HTTPConnection(url.hostname, url.port)
+        conn.connect()
+        conn.request('POST', '/', None, headers)
+        resp = conn.getresponse()
+        assert_equal(resp.status==401, True)
+        assert_equal(resp.getheader("access-control-allow-origin"), "http://localhost")
+        assert_equal(resp.getheader("access-control-allow-methods"), None)
+        conn.close()
+        
 if __name__ == '__main__':
     HTTPBasicsTest ().main ()

--- a/qa/rpc-tests/multi_rpc.py
+++ b/qa/rpc-tests/multi_rpc.py
@@ -127,7 +127,6 @@ class HTTPBasicsTest (SyscoinTestFramework):
         assert_equal(resp.getheader("access-control-allow-origin"), "http://localhost")
         assert_equal(resp.getheader("access-control-allow-methods"), "POST")
         assert_equal(resp.getheader("access-control-allow-headers"), "authorization,content-type")
-        assert_equal(resp.getheader("access-control-allow-credentials"), "true")
         conn.close()
 
         #Simple Cross Origin - no Origin

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -147,8 +147,135 @@ static bool RPCAuthorized(const std::string& strAuth, std::string& strAuthUserna
     return multiUserAuthorized(strUserPass);
 }
 
+static bool checkCORS(HTTPRequest* req)
+{
+    // https://www.w3.org/TR/cors/#resource-requests
+
+    // 1. If the Origin header is not present terminate this set of steps.
+    // The request is outside the scope of this specification.
+    std::pair<bool, std::string> origin = req->GetHeader("origin");
+    if (!origin.first) {
+        return false;
+    }
+
+    // 2. If the value of the Origin header is not a case-sensitive match for
+    // any of the values in list of origins do not set any additional headers
+    // and terminate this set of steps.
+    // Note: Always matching is acceptable since the list of origins can be
+    // unbounded.
+    // if (origin.second != strRPCCORSDomain) {
+    //     return false;
+    // }
+
+    if (req->GetRequestMethod() == HTTPRequest::OPTIONS) {
+        // 6.2 Preflight Request
+        // In response to a preflight request the resource indicates which
+        // methods and headers (other than simple methods and simple
+        // headers) it is willing to handle and whether it supports
+        // credentials.
+        // Resources must use the following set of steps to determine which
+        // additional headers to use in the response:
+
+        // 3. Let method be the value as result of parsing the
+        // Access-Control-Request-Method header.
+        // If there is no Access-Control-Request-Method header or if parsing
+        // failed, do not set any additional headers and terminate this set
+        // of steps. The request is outside the scope of this specification.
+        std::pair<bool, std::string> method =
+            req->GetHeader("access-control-request-method");
+        if (!method.first) {
+            return false;
+        }
+
+        // 4. Let header field-names be the values as result of parsing
+        // the Access-Control-Request-Headers headers.
+        // If there are no Access-Control-Request-Headers headers let header
+        // field-names be the empty list.
+        // If parsing failed do not set any additional headers and terminate
+        // this set of steps. The request is outside the scope of this
+        // specification.
+        std::pair<bool, std::string> header_field_names =
+            req->GetHeader("access-control-request-headers");
+
+        // 5. If method is not a case-sensitive match for any of the
+        // values in list of methods do not set any additional headers
+        // and terminate this set of steps.
+        // Note: Always matching is acceptable since the list of methods
+        // can be unbounded.
+        if (method.second != "POST") {
+            return false;
+        }
+
+        // 6. If any of the header field-names is not a ASCII case-
+        // insensitive match for any of the values in list of headers do not
+        // set any additional headers and terminate this set of steps.
+        // Note: Always matching is acceptable since the list of headers can
+        // be unbounded.
+        const std::string& list_of_headers = "authorization,content-type";
+
+        // 7. If the resource supports credentials add a single
+        // Access-Control-Allow-Origin header, with the value of the Origin
+        // header as value, and add a single
+        // Access-Control-Allow-Credentials header with the case-sensitive
+        // string "true" as value.
+        req->WriteHeader("Access-Control-Allow-Origin", origin.second);
+        req->WriteHeader("Access-Control-Allow-Credentials", "true");
+
+        // 8. Optionally add a single Access-Control-Max-Age header with as
+        // value the amount of seconds the user agent is allowed to cache
+        // the result of the request.
+
+        // 9. If method is a simple method this step may be skipped.
+        // Add one or more Access-Control-Allow-Methods headers consisting
+        // of (a subset of) the list of methods.
+        // If a method is a simple method it does not need to be listed, but
+        // this is not prohibited.
+        // Note: Since the list of methods can be unbounded, simply
+        // returning the method indicated by
+        // Access-Control-Request-Method (if supported) can be enough.
+        req->WriteHeader("Access-Control-Allow-Methods", method.second);
+
+        // 10. If each of the header field-names is a simple header and none
+        // is Content-Type, this step may be skipped.
+        // Add one or more Access-Control-Allow-Headers headers consisting
+        // of (a subset of) the list of headers.
+        req->WriteHeader(
+            "Access-Control-Allow-Headers",
+            header_field_names.first ? header_field_names.second
+                                        : list_of_headers);
+        req->WriteReply(HTTP_OK);
+        return true;
+    }
+
+    // 6.1 Simple Cross-Origin Request, Actual Request, and Redirects
+    // In response to a simple cross-origin request or actual request the
+    // resource indicates whether or not to share the response.
+    // If the resource has been relocated, it indicates whether to share its
+    // new URL.
+    // Resources must use the following set of steps to determine which
+    // additional headers to use in the response:
+
+    // 3. If the resource supports credentials add a single
+    // Access-Control-Allow-Origin header, with the value of the Origin
+    // header as value, and add a single Access-Control-Allow-Credentials
+    // header with the case-sensitive string "true" as value.
+    req->WriteHeader("Access-Control-Allow-Origin", origin.second);
+    req->WriteHeader("Access-Control-Allow-Credentials", "true");
+
+    // 4. If the list of exposed headers is not empty add one or more
+    // Access-Control-Expose-Headers headers, with as values the header
+    // field names given in the list of exposed headers.
+    req->WriteHeader("Access-Control-Expose-Headers", "WWW-Authenticate");
+
+    return false;
+}
+
 static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
 {
+    // First, check and/or set CORS headers
+    if (checkCORS(req)) {
+        return true;
+    }
     // JSONRPC handles only POST
     if (req->GetRequestMethod() != HTTPRequest::POST) {
         req->WriteReply(HTTP_BAD_METHOD, "JSONRPC server handles only POST requests");

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -65,6 +65,8 @@ private:
 static std::string strRPCUserColonPass;
 /* Stored RPC timer interface (for unregistration) */
 static HTTPRPCTimerInterface* httpRPCTimerInterface = 0;
+/* RPC CORS Domain, allowed Origin */
+static std::string strRPCCORSDomain;
 
 static void JSONErrorReply(HTTPRequest* req, const UniValue& objError, const UniValue& id)
 {
@@ -355,6 +357,8 @@ static bool InitRPCAuthentication()
         LogPrintf("Config options rpcuser and rpcpassword will soon be deprecated. Locally-run instances may remove rpcuser to use cookie-based auth, or may be replaced with rpcauth. Please see share/rpcuser for rpcauth auth generation.\n");
         strRPCUserColonPass = GetArg("-rpcuser", "") + ":" + GetArg("-rpcpassword", "");
     }
+
+    strRPCCORSDomain = GetArg("-rpccorsdomain", "");
     return true;
 }
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -235,16 +235,14 @@ static std::string RequestMethodString(HTTPRequest::RequestMethod m)
     switch (m) {
     case HTTPRequest::GET:
         return "GET";
-        break;
+    case HTTPRequest::OPTIONS:
+        return "OPTIONS";
     case HTTPRequest::POST:
         return "POST";
-        break;
     case HTTPRequest::HEAD:
         return "HEAD";
-        break;
     case HTTPRequest::PUT:
         return "PUT";
-        break;
     default:
         return "unknown";
     }
@@ -432,6 +430,14 @@ bool InitHTTPServer()
     evhttp_set_max_headers_size(http, MAX_HEADERS_SIZE);
     evhttp_set_max_body_size(http, MAX_SIZE);
     evhttp_set_gencb(http, http_request_cb, NULL);
+    /* Only POST and OPTIONS are supported, but we return HTTP 405 for the others */
+    evhttp_set_allowed_methods(http,
+        EVHTTP_REQ_GET |
+        EVHTTP_REQ_POST |
+        EVHTTP_REQ_HEAD |
+        EVHTTP_REQ_PUT |
+        EVHTTP_REQ_DELETE |
+        EVHTTP_REQ_OPTIONS);
 
     if (!HTTPBindAddresses(http)) {
         LogPrintf("Unable to bind any endpoint for RPC server\n");
@@ -656,21 +662,18 @@ std::string HTTPRequest::GetURI()
 HTTPRequest::RequestMethod HTTPRequest::GetRequestMethod()
 {
     switch (evhttp_request_get_command(req)) {
+    case EVHTTP_REQ_OPTIONS:
+        return OPTIONS;    
     case EVHTTP_REQ_GET:
         return GET;
-        break;
     case EVHTTP_REQ_POST:
         return POST;
-        break;
     case EVHTTP_REQ_HEAD:
         return HEAD;
-        break;
     case EVHTTP_REQ_PUT:
         return PUT;
-        break;
     default:
         return UNKNOWN;
-        break;
     }
 }
 

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -65,7 +65,8 @@ public:
         GET,
         POST,
         HEAD,
-        PUT
+        PUT,
+        OPTIONS
     };
 
     /** Get requested URI.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -661,7 +661,6 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-rpcbind=<addr>", _("Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6. This option can be specified multiple times (default: bind to all interfaces)"));
     strUsage += HelpMessageOpt("-rpccookiefile=<loc>", _("Location of the auth cookie (default: data dir)"));
     strUsage += HelpMessageOpt("-rpcuser=<user>", _("Username for JSON-RPC connections"));
-    strUsage += HelpMessageOpt("-rpccorsdomain=<value>", _("Domain from which to accept cross origin requests (browser enforced)"));
     strUsage += HelpMessageOpt("-rpcpassword=<pw>", _("Password for JSON-RPC connections"));
     strUsage += HelpMessageOpt("-rpcauth=<userpw>", _("Username and hashed password for JSON-RPC connections. The field <userpw> comes in the format: <USERNAME>:<SALT>$<HASH>. A canonical python script is included in share/rpcuser. The client then connects normally using the rpcuser=<USERNAME>/rpcpassword=<PASSWORD> pair of arguments. This option can be specified multiple times"));
     strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Listen for JSON-RPC connections on <port> (default: %u or testnet: %u)"), BaseParams(CBaseChainParams::MAIN).RPCPort(), BaseParams(CBaseChainParams::TESTNET).RPCPort()));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -661,6 +661,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-rpcbind=<addr>", _("Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6. This option can be specified multiple times (default: bind to all interfaces)"));
     strUsage += HelpMessageOpt("-rpccookiefile=<loc>", _("Location of the auth cookie (default: data dir)"));
     strUsage += HelpMessageOpt("-rpcuser=<user>", _("Username for JSON-RPC connections"));
+    strUsage += HelpMessageOpt("-rpccorsdomain=<value>", _("Domain from which to accept cross origin requests (browser enforced)"));
     strUsage += HelpMessageOpt("-rpcpassword=<pw>", _("Password for JSON-RPC connections"));
     strUsage += HelpMessageOpt("-rpcauth=<userpw>", _("Username and hashed password for JSON-RPC connections. The field <userpw> comes in the format: <USERNAME>:<SALT>$<HASH>. A canonical python script is included in share/rpcuser. The client then connects normally using the rpcuser=<USERNAME>/rpcpassword=<PASSWORD> pair of arguments. This option can be specified multiple times"));
     strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Listen for JSON-RPC connections on <port> (default: %u or testnet: %u)"), BaseParams(CBaseChainParams::MAIN).RPCPort(), BaseParams(CBaseChainParams::TESTNET).RPCPort()));


### PR DESCRIPTION
This is a redo of #283 Changing the base fork from 3.2.0 to 3.1.5 
From bitcoin#12040
Specific to the use case of rpc to localhost
The only code left out of the original bitcoin pr is setting and checking rpccors domain from config
The test is specific to syscoin rpc-tests