### PR TITLE
refactor custom outputs in favor of tx versioning

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -10,6 +10,7 @@ $(package)_config_opts=--disable-shared --enable-cxx --disable-replication
 $(package)_config_opts_mingw32=--enable-mingw
 $(package)_config_opts_linux=--with-pic
 $(package)_cxxflags=-std=c++11
+$(package)_cppflags_mingw32=-DUNICODE -D_UNICODE
 endef
 
 define $(package)_preprocess_cmds

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -102,6 +102,7 @@ SYSCOIN_TESTS =\
 if ENABLE_WALLET
 SYSCOIN_TESTS += \
   wallet/test/accounting_tests.cpp \
+  wallet/test/db_tests.cpp \
   wallet/test/psbt_wallet_tests.cpp \
   wallet/test/wallet_tests.cpp \
   wallet/test/wallet_crypto_tests.cpp \

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -33,7 +33,7 @@ static void addCoin(const CAmount& nValue, const CWallet& wallet, std::vector<Ou
 // (https://github.com/syscoin/syscoin/issues/7883#issuecomment-224807484)
 static void CoinSelection(benchmark::State& state)
 {
-    const CWallet wallet("dummy", WalletDatabase::CreateDummy());
+    const CWallet wallet(WalletLocation(), WalletDatabase::CreateDummy());
     LOCK(wallet.cs_wallet);
 
     // Add coins.
@@ -57,7 +57,7 @@ static void CoinSelection(benchmark::State& state)
 }
 
 typedef std::set<CInputCoin> CoinSet;
-static const CWallet testWallet("dummy", WalletDatabase::CreateDummy());
+static const CWallet testWallet(WalletLocation(), WalletDatabase::CreateDummy());
 std::vector<std::unique_ptr<CWalletTx>> wtxn;
 
 // Copied from src/wallet/test/coinselector_tests.cpp

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2017 The Syscoin Core developers
+﻿// Copyright (c) 2017-2017 The Syscoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -235,7 +235,7 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
     }
 
     // SYSCOIN
-    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT_SYSCOIN){
+    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT){
         if(tx.vout.size() < 2 || tx.vout.size() > 3)
             return state.DoS(100, false, REJECT_INVALID, "bad-txns-mint-outputs-wrong");
     }

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -60,7 +60,11 @@ bool BaseIndex::Init()
     }
 
     LOCK(cs_main);
-    m_best_block_index = FindForkInGlobalIndex(chainActive, locator);
+    if (locator.IsNull()) {
+        m_best_block_index = nullptr;
+    } else {
+        m_best_block_index = FindForkInGlobalIndex(chainActive, locator);
+    }
     m_synced = m_best_block_index.load() == chainActive.Tip();
     return true;
 }

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -245,6 +245,9 @@ bool TxIndex::Init()
 
 bool TxIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
 {
+    // Exclude genesis block transaction because outputs are not spendable.
+    if (pindex->nHeight == 0) return true;
+
     CDiskTxPos pos(pindex->GetBlockPos(), GetSizeOfCompactSize(block.vtx.size()));
     std::vector<std::pair<uint256, CDiskTxPos>> vPos;
     vPos.reserve(block.vtx.size());

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -13,7 +13,6 @@
 #include <tinyformat.h>
 #include <util.h>
 #include <utilstrencodings.h>
-// SYSCOIN need constant SYSCOIN_TX_VERSION_ASSET
 #include <services/asset.h>
 
 CAmount GetDustThreshold(const CTxOut& txout, const CFeeRate& dustRelayFeeIn)
@@ -80,7 +79,7 @@ bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType)
 bool IsStandardTx(const CTransaction& tx, std::string& reason)
 {
     // SYSCOIN check for syscoin or bitcoin tx
-    if ((tx.nVersion > CTransaction::MAX_STANDARD_VERSION || tx.nVersion < 1) && tx.nVersion != SYSCOIN_TX_VERSION_ASSET && tx.nVersion != SYSCOIN_TX_VERSION_MINT_SYSCOIN && tx.nVersion != SYSCOIN_TX_VERSION_MINT_ASSET) {
+    if ((tx.nVersion > CTransaction::MAX_STANDARD_VERSION || tx.nVersion < 1) && !IsSyscoinTx(tx.nVersion)) {
         reason = "version";
         return false;
     }
@@ -126,7 +125,7 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason)
         {
             // SYSCOIN if not syscoin tx and opreturn size is bigger than maxcarrier bytes, return false
             // we need this because if it is a sys tx then we allow 200x maxcarrier bytes.
-            if (tx.nVersion != SYSCOIN_TX_VERSION_ASSET && tx.nVersion != SYSCOIN_TX_VERSION_MINT_SYSCOIN && tx.nVersion != SYSCOIN_TX_VERSION_MINT_ASSET && txout.scriptPubKey.size() > nMaxDatacarrierBytes)
+            if (!IsSyscoinTx(tx.nVersion) && txout.scriptPubKey.size() > nMaxDatacarrierBytes)
             {
                 reason = "scriptpubkey";
                 return false;

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -9,7 +9,7 @@
 #include <tinyformat.h>
 #include <utilstrencodings.h>
 // SYSCOIN
-const int SYSCOIN_TX_VERSION_MINT_SYSCOIN = 0x7402;
+const int SYSCOIN_TX_VERSION_MINT = 0x7400;
 std::string COutPoint::ToString() const
 {
     return strprintf("COutPoint(%s, %u)", hash.ToString().substr(0,10), n);
@@ -100,7 +100,7 @@ CAmount CTransaction::GetValueOut() const
     bool bFirstOutput = true;
     for (const auto& tx_out : vout) {
         // SYSCOIN
-        if(bFirstOutput && nVersion == SYSCOIN_TX_VERSION_MINT_SYSCOIN){
+        if(bFirstOutput && nVersion == SYSCOIN_TX_VERSION_MINT){
             bFirstOutput = false;
             continue;
         }

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -123,16 +123,15 @@ void AskPassphraseDialog::accept()
                 {
                     QMessageBox::warning(this, tr("Wallet encrypted"),
                                          "<qt>" +
-                                         tr("%1 will close now to finish the encryption process. "
+                                         tr("Your wallet is now encrypted. "
                                          "Remember that encrypting your wallet cannot fully protect "
-                                         "your syscoins from being stolen by malware infecting your computer.").arg(tr(PACKAGE_NAME)) +
+                                         "your syscoins from being stolen by malware infecting your computer.") +
                                          "<br><br><b>" +
                                          tr("IMPORTANT: Any previous backups you have made of your wallet file "
                                          "should be replaced with the newly generated, encrypted wallet file. "
                                          "For security reasons, previous backups of the unencrypted wallet file "
                                          "will become useless as soon as you start using the new, encrypted wallet.") +
                                          "</b></qt>");
-                    QApplication::quit();
                 }
                 else
                 {

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -373,6 +373,7 @@ void openMNConfigfile()
         QDesktopServices::openUrl(QUrl::fromLocalFile(boostPathToQString(pathConfig)));
 }
 
+
 void bringToFront(QWidget* w)
 {
 #ifdef Q_OS_MAC

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -161,15 +161,21 @@ void OverviewPage::setBalance(const interfaces::WalletBalances& balances)
 {
     int unit = walletModel->getOptionsModel()->getDisplayUnit();
     m_balances = balances;
-    ui->labelBalance->setText(SyscoinUnits::formatWithUnit(unit, balances.balance, false, SyscoinUnits::separatorAlways));
-    ui->labelUnconfirmed->setText(SyscoinUnits::formatWithUnit(unit, balances.unconfirmed_balance, false, SyscoinUnits::separatorAlways));
-    ui->labelImmature->setText(SyscoinUnits::formatWithUnit(unit, balances.immature_balance, false, SyscoinUnits::separatorAlways));
-    ui->labelTotal->setText(SyscoinUnits::formatWithUnit(unit, balances.balance + balances.unconfirmed_balance + balances.immature_balance, false, SyscoinUnits::separatorAlways));
-    ui->labelWatchAvailable->setText(SyscoinUnits::formatWithUnit(unit, balances.watch_only_balance, false, SyscoinUnits::separatorAlways));
-    ui->labelWatchPending->setText(SyscoinUnits::formatWithUnit(unit, balances.unconfirmed_watch_only_balance, false, SyscoinUnits::separatorAlways));
-    ui->labelWatchImmature->setText(SyscoinUnits::formatWithUnit(unit, balances.immature_watch_only_balance, false, SyscoinUnits::separatorAlways));
-    ui->labelWatchTotal->setText(SyscoinUnits::formatWithUnit(unit, balances.watch_only_balance + balances.unconfirmed_watch_only_balance + balances.immature_watch_only_balance, false, SyscoinUnits::separatorAlways));
-
+    if (walletModel->privateKeysDisabled()) {
+        ui->labelBalance->setText(SyscoinUnits::formatWithUnit(unit, balances.watch_only_balance, false, SyscoinUnits::separatorAlways));
+        ui->labelUnconfirmed->setText(SyscoinUnits::formatWithUnit(unit, balances.unconfirmed_watch_only_balance, false, SyscoinUnits::separatorAlways));
+        ui->labelImmature->setText(SyscoinUnits::formatWithUnit(unit, balances.immature_watch_only_balance, false, SyscoinUnits::separatorAlways));
+        ui->labelTotal->setText(SyscoinUnits::formatWithUnit(unit, balances.watch_only_balance + balances.unconfirmed_watch_only_balance + balances.immature_watch_only_balance, false, SyscoinUnits::separatorAlways));
+    } else {
+        ui->labelBalance->setText(SyscoinUnits::formatWithUnit(unit, balances.balance, false, SyscoinUnits::separatorAlways));
+        ui->labelUnconfirmed->setText(SyscoinUnits::formatWithUnit(unit, balances.unconfirmed_balance, false, SyscoinUnits::separatorAlways));
+        ui->labelImmature->setText(SyscoinUnits::formatWithUnit(unit, balances.immature_balance, false, SyscoinUnits::separatorAlways));
+        ui->labelTotal->setText(SyscoinUnits::formatWithUnit(unit, balances.balance + balances.unconfirmed_balance + balances.immature_balance, false, SyscoinUnits::separatorAlways));
+        ui->labelWatchAvailable->setText(SyscoinUnits::formatWithUnit(unit, balances.watch_only_balance, false, SyscoinUnits::separatorAlways));
+        ui->labelWatchPending->setText(SyscoinUnits::formatWithUnit(unit, balances.unconfirmed_watch_only_balance, false, SyscoinUnits::separatorAlways));
+        ui->labelWatchImmature->setText(SyscoinUnits::formatWithUnit(unit, balances.immature_watch_only_balance, false, SyscoinUnits::separatorAlways));
+        ui->labelWatchTotal->setText(SyscoinUnits::formatWithUnit(unit, balances.watch_only_balance + balances.unconfirmed_watch_only_balance + balances.immature_watch_only_balance, false, SyscoinUnits::separatorAlways));
+    }
     // only show immature (newly mined) balance if it's non-zero, so as not to complicate things
     // for the non-mining users
     bool showImmature = balances.immature_balance != 0;
@@ -178,7 +184,7 @@ void OverviewPage::setBalance(const interfaces::WalletBalances& balances)
     // for symmetry reasons also show immature label when the watch-only one is shown
     ui->labelImmature->setVisible(showImmature || showWatchOnlyImmature);
     ui->labelImmatureText->setVisible(showImmature || showWatchOnlyImmature);
-    ui->labelWatchImmature->setVisible(showWatchOnlyImmature); // show watch-only immature balance
+    ui->labelWatchImmature->setVisible(!walletModel->privateKeysDisabled() && showWatchOnlyImmature); // show watch-only immature balance
 }
 
 // show/hide watch-only labels
@@ -231,8 +237,15 @@ void OverviewPage::setWalletModel(WalletModel *model)
 
         connect(model->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
 
+<<<<<<< HEAD
         updateWatchOnlyLabels(wallet.haveWatchOnly());
         connect(model, SIGNAL(notifyWatchonlyChanged(bool)), this, SLOT(updateWatchOnlyLabels(bool)));
+=======
+        updateWatchOnlyLabels(wallet.haveWatchOnly() && !model->privateKeysDisabled());
+        connect(model, &WalletModel::notifyWatchonlyChanged, [this](bool showWatchOnly) {
+            updateWatchOnlyLabels(showWatchOnly && !walletModel->privateKeysDisabled());
+        });
+>>>>>>> fe1ff5026... Hide spendable label if priveate key is disabled
     }
 
     // update the display unit, to not use the default ("SYS")

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -57,7 +57,7 @@ void EditAddressAndSubmit(
 void TestAddAddressesToSendBook()
 {
     TestChain100Setup test;
-    std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>("mock", WalletDatabase::CreateMock());
+    std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(WalletLocation(), WalletDatabase::CreateMock());
     bool firstRun;
     wallet->LoadWallet(firstRun);
 

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -133,7 +133,7 @@ void TestGUI()
     for (int i = 0; i < 5; ++i) {
         test.CreateAndProcessBlock({}, GetScriptForRawPubKey(test.coinbaseKey.GetPubKey()));
     }
-    std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>("mock", WalletDatabase::CreateMock());
+    std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(WalletLocation(), WalletDatabase::CreateMock());
     bool firstRun;
     wallet->LoadWallet(firstRun);
     {

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1467,16 +1467,8 @@ static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, 
     return true;
 }
 
-bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKeyIn, const CScriptWitness* witness, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* serror)
-{
-    // SYSCOIN
-    CScript scriptPubKey;
-    CScript scriptPubKeyOut;
-    if (RemoveSyscoinScript(scriptPubKeyIn, scriptPubKeyOut))
-        scriptPubKey = scriptPubKeyOut;
-    else
-        scriptPubKey = scriptPubKeyIn;
-        
+bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* serror)
+{     
     static const CScriptWitness emptyWitness;
     if (witness == nullptr) {
         witness = &emptyWitness;

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -192,71 +192,36 @@ unsigned int CScript::GetSigOpCount(const CScript& scriptSig) const
     CScript subscript(vData.begin(), vData.end());
     return subscript.GetSigOpCount(true);
 }
-bool CScript::IsPayToWitnessPublicKeyHash() const
-{
-    // SYSCOIN
-    CScript scriptOut;
-    CScript scriptPubKeyOut;
-    if (scriptOut.size() != 22 && RemoveSyscoinScript(*this, scriptPubKeyOut))
-        scriptOut = scriptPubKeyOut;
-    else
-        scriptOut = *this;
-    // Extra-fast test for pay-to-witness-pubkey-hash CScripts:
-    return (scriptOut.size() == 22 &&
-            scriptOut[0] == OP_0 &&
-            scriptOut[1] == 0x14);
-}
 bool CScript::IsPayToScriptHash() const
 {
-    // SYSCOIN
-    CScript scriptOut;
-    CScript scriptPubKeyOut;
-    if (scriptOut.size() != 23 && RemoveSyscoinScript(*this, scriptPubKeyOut))
-        scriptOut = scriptPubKeyOut;
-    else
-        scriptOut = *this;
     // Extra-fast test for pay-to-script-hash CScripts:
-    return (scriptOut.size() == 23 &&
-            scriptOut[0] == OP_HASH160 &&
-            scriptOut[1] == 0x14 &&
-            scriptOut[22] == OP_EQUAL);
+    return (this->size() == 23 &&
+            (*this)[0] == OP_HASH160 &&
+            (*this)[1] == 0x14 &&
+            (*this)[22] == OP_EQUAL);
 }
 
 bool CScript::IsPayToWitnessScriptHash() const
 {
-    // SYSCOIN
-    CScript scriptOut;
-    CScript scriptPubKeyOut;
-    if (scriptOut.size() != 34 && RemoveSyscoinScript(*this, scriptPubKeyOut))
-        scriptOut = scriptPubKeyOut;
-    else
-        scriptOut = *this;
     // Extra-fast test for pay-to-witness-script-hash CScripts:
-    return (scriptOut.size() == 34 &&
-            scriptOut[0] == OP_0 &&
-            scriptOut[1] == 0x20);
+    return (this->size() == 34 &&
+            (*this)[0] == OP_0 &&
+            (*this)[1] == 0x20);
 }
 
 // A witness program is any valid CScript that consists of a 1-byte push opcode
 // followed by a data push between 2 and 40 bytes.
 bool CScript::IsWitnessProgram(int& version, std::vector<unsigned char>& program) const
 {
-    // SYSCOIN
-    CScript scriptOut;
-    CScript scriptPubKeyOut;
-    if (RemoveSyscoinScript(*this, scriptPubKeyOut))
-        scriptOut = scriptPubKeyOut;
-    else
-        scriptOut = *this;
-    if (scriptOut.size() < 4 || scriptOut.size() > 42) {
+    if (this->size() < 4 || this->size() > 42) {
         return false;
     }
-    if (scriptOut[0] != OP_0 && (scriptOut[0] < OP_1 || scriptOut[0] > OP_16)) {
+    if ((*this)[0] != OP_0 && ((*this)[0] < OP_1 || (*this)[0] > OP_16)) {
         return false;
     }
-    if ((size_t)(scriptOut[1] + 2) == scriptOut.size()) {
-        version = DecodeOP_N((opcodetype)scriptOut[0]);
-        program = std::vector<unsigned char>(scriptOut.begin() + 2, scriptOut.end());
+    if ((size_t)((*this)[1] + 2) == this->size()) {
+        version = DecodeOP_N((opcodetype)(*this)[0]);
+        program = std::vector<unsigned char>(this->begin() + 2, this->end());
         return true;
     }
     return false;
@@ -359,137 +324,4 @@ bool GetScriptOp(CScriptBase::const_iterator& pc, CScriptBase::const_iterator en
 
     opcodeRet = static_cast<opcodetype>(opcode);
     return true;
-}
-// SYSCOIN
-bool RemoveSyscoinScript(const CScript& scriptPubKeyIn, CScript& scriptPubKeyOut)
-{
-    if (!RemoveAssetAllocationScriptPrefix(scriptPubKeyIn, scriptPubKeyOut)){
-        if (!RemoveAssetScriptPrefix(scriptPubKeyIn, scriptPubKeyOut)){
-            return false;
-        }
-    }
-    return true;
-}
-
-bool DecodeAssetScript(const CScript& script, int& op,
-        std::vector<std::vector<unsigned char> > &vvch, CScript::const_iterator& pc) {
-    opcodetype opcode;
-    vvch.clear();
-    if (!script.GetOp(pc, opcode)) return false;
-    if (opcode < OP_1 || opcode > OP_16) return false;
-    op = CScript::DecodeOP_N(opcode);
-    if (op != OP_SYSCOIN_ASSET)
-        return false;
-    if (!script.GetOp(pc, opcode))
-        return false;
-    if (opcode < OP_1 || opcode > OP_16)
-        return false;
-    op = CScript::DecodeOP_N(opcode);
-    if (!IsAssetOp(op))
-        return false;
-
-    bool found = false;
-    for (;;) {
-        std::vector<unsigned char> vch;
-        if (!script.GetOp(pc, opcode, vch))
-            return false;
-        if (opcode == OP_DROP || opcode == OP_2DROP)
-        {
-            found = true;
-            break;
-        }
-        if (!(opcode >= 0 && opcode <= OP_PUSHDATA4))
-            return false;
-        vvch.emplace_back(std::move(vch));
-    }
-
-    // move the pc to after any DROP or NOP
-    while (opcode == OP_DROP || opcode == OP_2DROP) {
-        if (!script.GetOp(pc, opcode))
-            break;
-    }
-
-    pc--;
-    return found;
-}
-bool DecodeAssetScript(const CScript& script, int& op,
-        std::vector<std::vector<unsigned char> > &vvch) {
-    CScript::const_iterator pc = script.begin();
-    return DecodeAssetScript(script, op, vvch, pc);
-}
-
-bool DecodeAssetAllocationScript(const CScript& script, int& op,
-        std::vector<std::vector<unsigned char> > &vvch, CScript::const_iterator& pc) {
-    opcodetype opcode;
-    vvch.clear();
-    if (!script.GetOp(pc, opcode)) return false;
-    if (opcode < OP_1 || opcode > OP_16) return false;
-    op = CScript::DecodeOP_N(opcode);
-    if (op != OP_SYSCOIN_ASSET_ALLOCATION)
-        return false;
-    if (!script.GetOp(pc, opcode))
-        return false;
-    if (opcode < OP_1 || opcode > OP_16)
-        return false;
-    op = CScript::DecodeOP_N(opcode);
-    if (!IsAssetAllocationOp(op))
-        return false;
-
-    bool found = false;
-    for (;;) {
-        std::vector<unsigned char> vch;
-        if (!script.GetOp(pc, opcode, vch))
-            return false;
-        if (opcode == OP_DROP || opcode == OP_2DROP)
-        {
-            found = true;
-            break;
-        }
-        if (!(opcode >= 0 && opcode <= OP_PUSHDATA4))
-            return false;
-        vvch.emplace_back(std::move(vch));
-    }
-
-    // move the pc to after any DROP or NOP
-    while (opcode == OP_DROP || opcode == OP_2DROP) {
-        if (!script.GetOp(pc, opcode))
-            break;
-    }
-
-    pc--;
-    return found;
-}
-bool DecodeAssetAllocationScript(const CScript& script, int& op,
-        std::vector<std::vector<unsigned char> > &vvch) {
-    CScript::const_iterator pc = script.begin();
-    return DecodeAssetAllocationScript(script, op, vvch, pc);
-}
-bool RemoveAssetAllocationScriptPrefix(const CScript& scriptIn, CScript& scriptOut) {
-    int op;
-    std::vector<std::vector<unsigned char> > vvch;
-    CScript::const_iterator pc = scriptIn.begin();
-
-    if (!DecodeAssetAllocationScript(scriptIn, op, vvch, pc))
-        return false;
-    scriptOut = CScript(pc, scriptIn.end());
-    return true;
-}
-bool RemoveAssetScriptPrefix(const CScript& scriptIn, CScript& scriptOut) {
-    int op;
-    std::vector<std::vector<unsigned char> > vvch;
-    CScript::const_iterator pc = scriptIn.begin();
-
-    if (!DecodeAssetScript(scriptIn, op, vvch, pc))
-        return false;
-    scriptOut = CScript(pc, scriptIn.end());
-    return true;
-}
-bool IsAssetOp(int op) {
-    return op == OP_ASSET_ACTIVATE
-        || op == OP_ASSET_UPDATE
-        || op == OP_ASSET_TRANSFER
-        || op == OP_ASSET_SEND;
-}
-bool IsAssetAllocationOp(int op) {
-    return op == OP_ASSET_ALLOCATION_SEND || op == OP_ASSET_ALLOCATION_BURN;
 }

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -51,21 +51,6 @@ enum opcodetype
 {    
     // push value
     OP_0 = 0x00,
-    
-
-    // distributed asset system
-    OP_ASSET_ACTIVATE = 0x01,
-    OP_ASSET_UPDATE = 0x02,
-    OP_ASSET_TRANSFER = 0x03,
-    OP_ASSET_SEND = 0x04,
-
-    OP_ASSET_ALLOCATION_SEND = 0x01,
-    OP_ASSET_ALLOCATION_BURN = 0x02,
-
-    // syscoin extended reserved 
-    OP_SYSCOIN_ASSET = 0x01,
-    OP_SYSCOIN_ASSET_ALLOCATION = 0x02,
-    OP_SYSCOIN_MINT = 0x03,
     OP_FALSE = OP_0,
     OP_PUSHDATA1 = 0x4c,
     OP_PUSHDATA2 = 0x4d,
@@ -601,11 +586,4 @@ public:
     CReserveScript() {}
     virtual ~CReserveScript() {}
 };
-// SYSCOIN
-bool RemoveSyscoinScript(const CScript& scriptPubKeyIn, CScript& scriptPubKeyOut);
-bool DecodeAssetScript(const CScript& script, int& op, std::vector<std::vector<unsigned char> > &vvch);
-bool RemoveAssetScriptPrefix(const CScript& scriptIn, CScript& scriptOut);
-bool RemoveAssetAllocationScriptPrefix(const CScript& scriptIn, CScript& scriptOut);
-bool IsAssetOp(int op);
-bool IsAssetAllocationOp(int op);
 #endif // SYSCOIN_SCRIPT_SCRIPT_H

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -176,12 +176,8 @@ static CScript PushAll(const std::vector<valtype>& values)
     return result;
 }
 
-bool ProduceSignature(const SigningProvider& provider, const BaseSignatureCreator& creator, const CScript& fromPubKeyIn, SignatureData& sigdata)
+bool ProduceSignature(const SigningProvider& provider, const BaseSignatureCreator& creator, const CScript& fromPubKeyOut, SignatureData& sigdata)
 {
-    // SYSCOIN
-    CScript fromPubKeyOut;
-    if (!RemoveSyscoinScript(fromPubKeyIn, fromPubKeyOut))
-        fromPubKeyOut = fromPubKeyIn;
     if (sigdata.complete) return true;
 
     std::vector<valtype> result;

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -84,16 +84,9 @@ static bool MatchMultisig(const CScript& script, unsigned int& required, std::ve
     return (it + 1 == script.end());
 }
 
-bool Solver(const CScript& scriptPubKeyIn, txnouttype& typeRet, std::vector<std::vector<unsigned char> >& vSolutionsRet)
+bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::vector<unsigned char> >& vSolutionsRet)
 {
     vSolutionsRet.clear();
-    // SYSCOIN check to see if this is a syscoin service transaction, if so get the scriptPubKey by extracting service specific script information
-    CScript scriptPubKey;
-    CScript scriptPubKeyOut;
-    if (RemoveSyscoinScript(scriptPubKeyIn, scriptPubKeyOut))
-        scriptPubKey = scriptPubKeyOut;
-    else
-        scriptPubKey = scriptPubKeyIn;
         
     // Shortcut for pay-to-script-hash, which are more constrained than the other types:
     // it is always OP_HASH160 20 [20 byte hash] OP_EQUAL

--- a/src/services/asset.cpp
+++ b/src/services/asset.cpp
@@ -272,7 +272,7 @@ bool CAsset::UnserializeFromTx(const CTransaction &tx) {
 bool CMintSyscoin::UnserializeFromTx(const CTransaction &tx) {
     vector<unsigned char> vchData;
     int nOut;
-    if (tx.nVersion != SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT || !GetSyscoinData(tx, vchData, nOut))
+    if (!IsSyscoinMintTx(tx.nVersion) || !GetSyscoinData(tx, vchData, nOut))
     {
         SetNull();
         return false;
@@ -656,7 +656,7 @@ UniValue syscointxfund(const JSONRPCRequest& request) {
                     }
                 }
             }
-            if (countInputs <= 0 && !fTPSTestEnabled && tx.nVersion != SYSCOIN_TX_VERSION_MINT && tx.nVersion != SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT)
+            if (countInputs <= 0 && !fTPSTestEnabled && !IsSyscoinMintTx(tx.nVersion))
             {
                 for (unsigned int i = 0; i < MAX_UPDATES_PER_BLOCK; i++){
                     nDesiredAmount += addressRecipient.nAmount;
@@ -1227,7 +1227,7 @@ bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs,
 	vector<unsigned char> vchData;
 
 	int nDataOut;
-	if(!GetSyscoinData(tx, vchData, nDataOut) || (tx.nVersion != SYSCOIN_TX_VERSION_ASSET_SEND || !theAsset.UnserializeFromData(vchData)) || (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_SEND || !theAssetAllocation.UnserializeFromData(vchData)))
+	if(!GetSyscoinData(tx, vchData, nDataOut) || (tx.nVersion != SYSCOIN_TX_VERSION_ASSET_SEND && !theAsset.UnserializeFromData(vchData)) || (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_SEND && !theAssetAllocation.UnserializeFromData(vchData)))
 	{
 		errorMessage = "SYSCOIN_ASSET_CONSENSUS_ERROR ERRCODE: 2000 - " + _("Cannot unserialize data inside of this transaction relating to an asset");
 		return error(errorMessage.c_str());
@@ -1236,7 +1236,7 @@ bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs,
 
 	if(fJustCheck)
 	{
-		if (tx.nVersion != SYSCOIN_TX_VERSION_ASSET_UPDATE) {
+		if (tx.nVersion != SYSCOIN_TX_VERSION_ASSET_SEND) {
 			if (theAsset.vchPubData.size() > MAX_VALUE_LENGTH)
 			{
 				errorMessage = "SYSCOIN_ASSET_CONSENSUS_ERROR: ERRCODE: 2004 - " + _("Asset public data too big");

--- a/src/services/asset.cpp
+++ b/src/services/asset.cpp
@@ -99,45 +99,137 @@ string stringFromVch(const vector<unsigned char> &vch) {
 	}
 	return res;
 }
-bool GetSyscoinData(const CTransaction &tx, vector<unsigned char> &vchData, int& nOut, int &op)
+bool GetSyscoinData(const CTransaction &tx, vector<unsigned char> &vchData, int& nOut)
 {
 	nOut = GetSyscoinDataOutput(tx);
 	if (nOut == -1)
 		return false;
 
 	const CScript &scriptPubKey = tx.vout[nOut].scriptPubKey;
-	return GetSyscoinData(scriptPubKey, vchData, op);
+	return GetSyscoinData(scriptPubKey, vchData);
 }
-bool GetSyscoinData(const CScript &scriptPubKey, vector<unsigned char> &vchData, int &op)
+bool GetSyscoinData(const CScript &scriptPubKey, vector<unsigned char> &vchData)
 {
-	op = 0;
 	CScript::const_iterator pc = scriptPubKey.begin();
 	opcodetype opcode;
 	if (!scriptPubKey.GetOp(pc, opcode))
 		return false;
 	if (opcode != OP_RETURN)
 		return false;
-	if (!scriptPubKey.GetOp(pc, opcode))
-		return false;
-	if (opcode < OP_1 || opcode > OP_16)
-		return false;
-	op = CScript::DecodeOP_N(opcode);
 	if (!scriptPubKey.GetOp(pc, opcode, vchData))
 		return false;
 	return true;
 }
+bool GetSyscoinBurnData(const CTransaction &tx, CAssetAllocation* theAssetAllocation)
+{   
+    if(!theAssetAllocation) 
+        return false;  
+    std::vector<unsigned char> vchBurnContract;
+    std::vector<unsigned char> vchEthAddress;
+    uint32_t nAssetFromScript;
+    uint64_t nAmountFromScript;
+    CWitnessAddress burnWitnessAddress;
+    if(!GetSyscoinBurnData(tx, nAssetFromScript, burnWitnessAddress, nAmountFromScript, vchBurnContract, vchEthAddress)){
+        return false;
+    }
+    theAssetAllocation->SetNull();
+    theAssetAllocation->assetAllocationTuple.nAsset = nAssetFromScript;
+    theAssetAllocation->assetAllocationTuple.witnessAddress = burnWitnessAddress;
+    theAssetAllocation->listSendingAllocationAmounts.push_back(make_pair(CWitnessAddress(0, vchFromString("burn")), nAmountFromScript));
+    return true;
+
+} 
+bool GetSyscoinBurnData(const CTransaction &tx, uint32_t& nAssetFromScript, CWitnessAddress& burnWitnessAddress, uint64_t &nAmountFromScript, std::vector<unsigned char> &vchContract, std::vector<unsigned char> &vchEthAddress)
+{
+    int nOut = GetSyscoinDataOutput(tx);
+    if (nOut == -1)
+        return false;
+
+    const CScript &scriptPubKey = tx.vout[nOut].scriptPubKey;
+    std::vector<std::vector< unsigned char> > vvchArgs;
+    if(!GetSyscoinBurnData(scriptPubKey, vvchArgs))
+        return false;
+        
+    if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_BURN && vvchArgs.size() != 6)
+        return false;
+          
+    if(vvchArgs[0].size() != 4)
+        return false;
+        
+    nAssetFromScript  = static_cast<uint32_t>(vvchArgs[0][3]);
+    nAssetFromScript |= static_cast<uint32_t>(vvchArgs[0][2]) << 8;
+    nAssetFromScript |= static_cast<uint32_t>(vvchArgs[0][1]) << 16;
+    nAssetFromScript |= static_cast<uint32_t>(vvchArgs[0][0]) << 24;
+            
+    if(vvchArgs[1].size() != 1)
+        return false;
+    if(vvchArgs[2].empty())
+        return false;      
+    burnWitnessAddress = CWitnessAddress(static_cast<unsigned char>(vvchArgs[1][0]), vvchArgs[2]);   
+    if(vvchArgs[3].size() != 8)
+        return false; 
+    nAmountFromScript  = static_cast<uint64_t>(vvchArgs[3][7]);
+    nAmountFromScript |= static_cast<uint64_t>(vvchArgs[3][6]) << 8;
+    nAmountFromScript |= static_cast<uint64_t>(vvchArgs[3][5]) << 16;
+    nAmountFromScript |= static_cast<uint64_t>(vvchArgs[3][4]) << 24; 
+    nAmountFromScript |= static_cast<uint64_t>(vvchArgs[3][3]) << 32;  
+    nAmountFromScript |= static_cast<uint64_t>(vvchArgs[3][2]) << 40;  
+    nAmountFromScript |= static_cast<uint64_t>(vvchArgs[3][1]) << 48;  
+    nAmountFromScript |= static_cast<uint64_t>(vvchArgs[3][0]) << 56;   
+    if(vvchArgs[4].empty())
+        return false;
+    vchContract = vvchArgs[4];
+    if(vvchArgs[5].empty())
+        return false; 
+    vchEthAddress = vvchArgs[5]; 
+    return true; 
+}
+bool GetSyscoinBurnData(const CScript &scriptPubKey, std::vector<std::vector<unsigned char> > &vchData)
+{
+    CScript::const_iterator pc = scriptPubKey.begin();
+    opcodetype opcode;
+    if (!scriptPubKey.GetOp(pc, opcode))
+        return false;
+    if (opcode != OP_RETURN)
+        return false;
+    vector<unsigned char> vchArg;
+    if (!scriptPubKey.GetOp(pc, opcode, vchArg))
+        return false;
+    vchData.push_back(vchArg);
+    vchArg.clear();
+    if (!scriptPubKey.GetOp(pc, opcode, vchArg))
+        return false;
+    vchData.push_back(vchArg);
+    vchArg.clear();       
+    if (!scriptPubKey.GetOp(pc, opcode, vchArg))
+        return false;
+    vchData.push_back(vchArg);
+    vchArg.clear();        
+    if (!scriptPubKey.GetOp(pc, opcode, vchArg))
+        return false;
+    vchData.push_back(vchArg);
+    vchArg.clear();   
+    if (!scriptPubKey.GetOp(pc, opcode, vchArg))
+        return false;
+    vchData.push_back(vchArg);
+    vchArg.clear(); 
+    if (!scriptPubKey.GetOp(pc, opcode, vchArg))
+        return false;
+    vchData.push_back(vchArg);
+    vchArg.clear();              
+    return true;
+}
 
 
-
-string assetFromOp(int op) {
-    switch (op) {
-    case OP_ASSET_ACTIVATE:
+string assetFromTx(const int &nVersion) {
+    switch (nVersion) {
+    case SYSCOIN_TX_VERSION_ASSET_ACTIVATE:
         return "assetactivate";
-    case OP_ASSET_UPDATE:
+    case SYSCOIN_TX_VERSION_ASSET_UPDATE:
         return "assetupdate";
-    case OP_ASSET_TRANSFER:
+    case SYSCOIN_TX_VERSION_ASSET_TRANSFER:
         return "assettransfer";
-	case OP_ASSET_SEND:
+	case SYSCOIN_TX_VERSION_ASSET_SEND:
 		return "assetsend";
     default:
         return "<unknown asset op>";
@@ -165,8 +257,8 @@ bool CMintSyscoin::UnserializeFromData(const vector<unsigned char> &vchData) {
 }
 bool CAsset::UnserializeFromTx(const CTransaction &tx) {
 	vector<unsigned char> vchData;
-	int nOut, op;
-	if (!GetSyscoinData(tx, vchData, nOut, op) || op != OP_SYSCOIN_ASSET)
+	int nOut;
+	if (!IsAssetTx(tx.nVersion) || !GetSyscoinData(tx, vchData, nOut))
 	{
 		SetNull();
 		return false;
@@ -179,8 +271,8 @@ bool CAsset::UnserializeFromTx(const CTransaction &tx) {
 }
 bool CMintSyscoin::UnserializeFromTx(const CTransaction &tx) {
     vector<unsigned char> vchData;
-    int nOut, op;
-    if (!GetSyscoinData(tx, vchData, nOut, op) || op != OP_SYSCOIN_MINT)
+    int nOut;
+    if (tx.nVersion != SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT || !GetSyscoinData(tx, vchData, nOut))
     {
         SetNull();
         return false;
@@ -231,12 +323,10 @@ bool FlushSyscoinDBs() {
 }
 void CTxMemPool::removeExpiredMempoolBalances(setEntries& stage){ 
     vector<vector<unsigned char> > vvch;
-    int op;
-    char type;
     int count = 0;
     for (const txiter& it : stage) {
         const CTransaction& tx = it->GetTx();
-        if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET && DecodeAndParseAssetAllocationTx(tx, op, vvch, type)){
+        if(IsAssetAllocationTx(tx.nVersion)){
             CAssetAllocation allocation(tx);
             if(allocation.assetAllocationTuple.IsNull())
                 continue;
@@ -248,14 +338,7 @@ void CTxMemPool::removeExpiredMempoolBalances(setEntries& stage){
     if(count > 0)
          LogPrint(BCLog::SYS, "removeExpiredMempoolBalances removed %d expired asset allocation transactions from mempool balances\n", count);  
 }
-bool DecodeAndParseSyscoinTx(const CTransaction& tx, int& op,
-	vector<vector<unsigned char> >& vvch, char& type)
-{
-	return
-		DecodeAndParseAssetAllocationTx
-        (tx, op, vvch, type)
-		|| DecodeAndParseAssetTx(tx, op, vvch, type);
-}
+
 bool FindAssetOwnerInTx(const CCoinsViewCache &inputs, const CTransaction& tx, const CWitnessAddress &witnessAddressToMatch) {
 	CTxDestination dest;
     int witnessversion;
@@ -372,7 +455,7 @@ UniValue SyscoinListReceived(bool includeempty = true, bool includechange = fals
 	}
 	return ret;
 }
-UniValue syscointxfund_helper(const string &vchWitness, vector<CRecipient> &vecSend, const int nVersion) {
+UniValue syscointxfund_helper(const int &nVersion, const string &vchWitness, vector<CRecipient> &vecSend) {
 	CMutableTransaction txNew;
 	txNew.nVersion = nVersion;
 
@@ -532,7 +615,7 @@ UniValue syscointxfund(const JSONRPCRequest& request) {
     const CAmount &minFee = GetFee(3000);
     if (nCurrentAmount < (nDesiredAmount + nFees)) {
         // only look for small inputs if addresses were passed in, if looking through wallet we do not want to fund via small inputs as we may end up spending small inputs inadvertently
-        if ((tx.nVersion == SYSCOIN_TX_VERSION_ASSET ||  tx.nVersion == SYSCOIN_TX_VERSION_MINT_SYSCOIN ||  tx.nVersion == SYSCOIN_TX_VERSION_MINT_ASSET) && params.size() > 1) {
+        if (IsSyscoinTx(tx.nVersion) && params.size() > 1) {
             LOCK(mempool.cs);
             int countInputs = 0;
             // fund with small inputs first
@@ -573,7 +656,7 @@ UniValue syscointxfund(const JSONRPCRequest& request) {
                     }
                 }
             }
-            if (countInputs <= 0 && !fTPSTestEnabled && tx.nVersion != SYSCOIN_TX_VERSION_MINT_SYSCOIN && tx.nVersion != SYSCOIN_TX_VERSION_MINT_ASSET)
+            if (countInputs <= 0 && !fTPSTestEnabled && tx.nVersion != SYSCOIN_TX_VERSION_MINT && tx.nVersion != SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT)
             {
                 for (unsigned int i = 0; i < MAX_UPDATES_PER_BLOCK; i++){
                     nDesiredAmount += addressRecipient.nAmount;
@@ -666,12 +749,12 @@ UniValue syscoinburn(const JSONRPCRequest& request) {
 	CScript scriptData;
 	scriptData << OP_RETURN;
 	if (bBurnToSYSX){
-		scriptData << OP_TRUE << ParseHex(ethAddress);
+		scriptData << ParseHex(ethAddress);
     }
-	else
-		scriptData << OP_FALSE;
 
 	CMutableTransaction txNew;
+    if(bBurnToSYSX)
+        txNew.nVersion = SYSCOIN_TX_VERSION_BURN;
 	CTxOut txout(nAmount, scriptData);
 	txNew.vout.push_back(txout);
        
@@ -712,7 +795,7 @@ UniValue syscoinmint(const JSONRPCRequest& request) {
 	CScript scriptPubKeyFromOrig = GetScriptForDestination(dest);
 
 	CMutableTransaction txNew;
-	txNew.nVersion = SYSCOIN_TX_VERSION_MINT_SYSCOIN;
+	txNew.nVersion = SYSCOIN_TX_VERSION_MINT;
 	txNew.vout.push_back(CTxOut(nAmount, scriptPubKeyFromOrig));
     
     CMintSyscoin mintSyscoin;
@@ -726,7 +809,7 @@ UniValue syscoinmint(const JSONRPCRequest& request) {
     mintSyscoin.Serialize(data);
     
     CScript scriptData;
-    scriptData << OP_RETURN << CScript::EncodeOP_N(OP_SYSCOIN_MINT) << data;
+    scriptData << OP_RETURN << data;
     
     CTxOut txout(0, scriptData);
     txNew.vout.push_back(txout);
@@ -767,33 +850,75 @@ UniValue syscoindecoderawtransaction(const JSONRPCRequest& request) {
         throw runtime_error("SYSCOIN_RPC_ERROR: ERRCODE: 5512 - " + _("Not a Syscoin transaction"));
 	return output;
 }
+bool IsSyscoinMintTx(const int &nVersion){
+    return nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT || nVersion == SYSCOIN_TX_VERSION_MINT;
+}
+bool IsAssetTx(const int &nVersion){
+    return nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE || nVersion == SYSCOIN_TX_VERSION_ASSET_UPDATE || nVersion == SYSCOIN_TX_VERSION_ASSET_TRANSFER || nVersion == SYSCOIN_TX_VERSION_ASSET_SEND;
+}
+bool IsAssetAllocationTx(const int &nVersion){
+    return nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT || nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_BURN || 
+        nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_SEND ;
+}
+bool IsSyscoinTx(const int &nVersion){
+    return IsAssetTx(nVersion) || IsAssetAllocationTx(nVersion) || IsSyscoinMintTx(nVersion);
+}
 bool DecodeSyscoinRawtransaction(const CTransaction& rawTx, UniValue& output){
-    int op;
     vector<vector<unsigned char> > vvch;
-    char ctype;
     bool found = false;
-    if (rawTx.nVersion == SYSCOIN_TX_VERSION_ASSET && DecodeAndParseSyscoinTx(rawTx, op, vvch, ctype)){
-        found = SysTxToJSON(op, rawTx, output, ctype);
-   }
-    else if(rawTx.nVersion == SYSCOIN_TX_VERSION_MINT_ASSET){
+    if(IsSyscoinMintTx(rawTx.nVersion)){
         found = AssetMintTxToJson(rawTx, output);
     }
-
+    else if (IsAssetTx(rawTx.nVersion) || IsAssetAllocationTx(rawTx.nVersion)){
+        found = SysTxToJSON(rawTx, output);
+    }
+    
     return found;
 }
-bool SysTxToJSON(const int &op, const CTransaction &tx, UniValue &entry, const char& type)
+bool SysTxToJSON(const CTransaction& tx, UniValue& output)
 {
     bool found = false;
-	if (type == OP_SYSCOIN_ASSET)
-		found = AssetTxToJSON(op, tx, entry);
-	else if (type == OP_SYSCOIN_ASSET_ALLOCATION)
-		found = AssetAllocationTxToJSON(op, tx, entry);
+	if (IsAssetTx(tx.nVersion))
+		found = AssetTxToJSON(tx, output);
+    else if(tx.nVersion == SYSCOIN_TX_VERSION_BURN)
+        found = SysBurnTxToJSON(tx, output);        
+	else if (IsAssetAllocationTx(tx.nVersion))
+		found = AssetAllocationTxToJSON(tx, output);
     return found;
+}
+bool SysBurnTxToJSON(const CTransaction &tx, UniValue &entry)
+{
+    int nHeight = 0;
+    uint256 hash_block;
+    CBlockIndex* blockindex = nullptr;
+    CTransactionRef txRef;
+    if (GetTransaction(tx.GetHash(), txRef, Params().GetConsensus(), hash_block, true, blockindex) && blockindex)
+        nHeight = blockindex->nHeight; 
+    entry.pushKV("txtype", "syscoinburn");
+    entry.pushKV("_id", tx.GetHash().GetHex());
+    entry.pushKV("txid", tx.GetHash().GetHex());
+    entry.pushKV("height", nHeight);
+    UniValue oOutputArray(UniValue::VARR);
+    for (const auto& txout : tx.vout){
+        CTxDestination address;
+        if (!ExtractDestination(txout.scriptPubKey, address))
+            continue;
+        UniValue oOutputObj(UniValue::VOBJ);
+        const string& strAddress = EncodeDestination(address);
+        oOutputObj.pushKV("address", strAddress);
+        oOutputObj.pushKV("amount", ValueFromAmount(txout.nValue));   
+        oOutputArray.push_back(oOutputObj);
+    }
+    
+    entry.pushKV("outputs", oOutputArray);
+    entry.pushKV("total", ValueFromAmount(tx.GetValueOut()));
+    entry.pushKV("confirmed", nHeight > 0);  
+    return true;
 }
 int GenerateSyscoinGuid()
 {
     int rand = 0;
-    while(rand <= SYSCOIN_TX_VERSION_MINT_ASSET)
+    while(rand <= SYSCOIN_TX_VERSION_MINT)
 	    rand = GetRand(std::numeric_limits<int>::max());
     return rand;
 }
@@ -877,70 +1002,7 @@ UniValue syscoinlistreceivedbyaddress(const JSONRPCRequest& request)
 
 	return SyscoinListReceived(true, false);
 }
-string GetSyscoinTransactionDescription(const CTransaction& tx, const int op, string& responseEnglish, const char &type, string& responseGUID)
-{
-	if (tx.IsNull()) {
-		return "Null Tx";
-	}
-	string strResponse = "";
 
-	if (type == OP_SYSCOIN_ASSET) {
-		// message from op code
-		if (op == OP_ASSET_ACTIVATE) {
-			strResponse = _("Asset Activated");
-			responseEnglish = "Asset Activated";
-		}
-		else if (op == OP_ASSET_UPDATE) {
-			strResponse = _("Asset Updated");
-			responseEnglish = "Asset Updated";
-		}
-		else if (op == OP_ASSET_TRANSFER) {
-			strResponse = _("Asset Transferred");
-			responseEnglish = "Asset Transferred";
-		}
-		else if (op == OP_ASSET_SEND) {
-			strResponse = _("Asset Sent");
-			responseEnglish = "Asset Sent";
-		}
-		if (op == OP_ASSET_SEND) {
-			CAssetAllocation assetallocation(tx);
-			if (!assetallocation.assetAllocationTuple.IsNull()) {
-				responseGUID = assetallocation.assetAllocationTuple.ToString();
-			}
-		}
-		else {
-			CAsset asset(tx);
-			if (!asset.IsNull()) {
-				responseGUID = boost::lexical_cast<string>(asset.nAsset);
-			}
-		}
-	}
-	else if (type == OP_SYSCOIN_ASSET_ALLOCATION) {
-		// message from op code
-		if (op == OP_ASSET_ALLOCATION_SEND) {
-			strResponse = _("Asset Allocation Sent");
-			responseEnglish = "Asset Allocation Sent";
-            CAssetAllocation assetallocation(tx);
-            if (!assetallocation.assetAllocationTuple.IsNull()) {
-                responseGUID = assetallocation.assetAllocationTuple.ToString();
-            } 
-		}
-		else if (op == OP_ASSET_ALLOCATION_BURN) {
-			strResponse = _("Asset Allocation Burned");
-			responseEnglish = "Asset Allocation Burned";
-            CAssetAllocation assetallocation(tx);
-            if (!assetallocation.assetAllocationTuple.IsNull()) {
-                responseGUID = assetallocation.assetAllocationTuple.ToString();
-            }            
-		}
-	}
-	else {
-		strResponse = _("Unknown Op Type");
-		responseEnglish = "Unknown Op Type";
-		return strResponse + " " + string(1, type);
-	}
-	return strResponse + " " + responseGUID;
-}
 bool IsOutpointMature(const COutPoint& outpoint)
 {
 	Coin coin;
@@ -990,10 +1052,10 @@ void WriteAssetIndexTXID(const uint32_t& nAsset, const uint256& txid){
     if(!passetindexdb->WriteIndexTXIDs(nAsset, page, TXIDS))
         LogPrint(BCLog::SYS, "Failed to write asset index txids\n");
 }
-void CAssetDB::WriteAssetIndex(const CTransaction& tx, const CAsset& dbAsset, const int& op, const int& nHeight) {
+void CAssetDB::WriteAssetIndex(const CTransaction& tx, const CAsset& dbAsset, const int& nHeight) {
 	if (fZMQAsset || fAssetIndex) {
 		UniValue oName(UniValue::VOBJ);
-        if(AssetTxToJSON(op, tx, dbAsset, nHeight, oName)){
+        if(AssetTxToJSON(tx, dbAsset, nHeight, oName)){
             if(fZMQAsset)
                 GetMainSignals().NotifySyscoinUpdate(oName.write().c_str(), "assetrecord");
             if(fAssetIndex)
@@ -1015,37 +1077,6 @@ bool GetAsset(const int &nAsset,
     if (passetdb == nullptr || !passetdb->ReadAsset(nAsset, txPos))
         return false;
     return true;
-}
-bool DecodeAndParseAssetTx(const CTransaction& tx, int& op,
-		vector<vector<unsigned char> >& vvch, char &type)
-{
-	if (op == OP_ASSET_SEND)
-		return false;
-	CAsset asset;
-	bool decode = DecodeAssetTx(tx, op, vvch);
-	bool parse = asset.UnserializeFromTx(tx);
-	if (decode&&parse) {
-		type = OP_SYSCOIN_ASSET;
-		return true;
-	}
-	return false;
-}
-bool DecodeAssetTx(const CTransaction& tx, int& op,
-        vector<vector<unsigned char> >& vvch) {
-    bool found = false;
-
-
-    // Strict check - bug disallowed
-    for (unsigned int i = 0; i < tx.vout.size(); i++) {
-        const CTxOut& out = tx.vout[i];
-        vector<vector<unsigned char> > vvchRead;
-        if (DecodeAssetScript(out.scriptPubKey, op, vvchRead)) {
-            found = true; vvch = vvchRead;
-            break;
-        }
-    }
-    if (!found) vvch.clear();
-    return found;
 }
 
 
@@ -1180,7 +1211,7 @@ bool DisconnectAssetActivate(const CTransaction &tx, AssetMap &mapAssets){
     }       
     return true;  
 }
-bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs, int op, const vector<vector<unsigned char> > &vvchArgs,
+bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs,
         bool fJustCheck, int nHeight, AssetMap& mapAssets, AssetAllocationMap &mapAssetAllocations, string &errorMessage, bool bSanityCheck) {
 	if (passetdb == nullptr)
 		return false;
@@ -1195,8 +1226,8 @@ bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs, int
 	CAssetAllocation theAssetAllocation;
 	vector<unsigned char> vchData;
 
-	int nDataOut, type;
-	if(!GetSyscoinData(tx, vchData, nDataOut, type) || (op != OP_ASSET_SEND && (type != OP_SYSCOIN_ASSET || !theAsset.UnserializeFromData(vchData))) || (op == OP_ASSET_SEND && (type != OP_SYSCOIN_ASSET_ALLOCATION || !theAssetAllocation.UnserializeFromData(vchData))))
+	int nDataOut;
+	if(!GetSyscoinData(tx, vchData, nDataOut) || (tx.nVersion != SYSCOIN_TX_VERSION_ASSET_SEND || !theAsset.UnserializeFromData(vchData)) || (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_SEND || !theAssetAllocation.UnserializeFromData(vchData)))
 	{
 		errorMessage = "SYSCOIN_ASSET_CONSENSUS_ERROR ERRCODE: 2000 - " + _("Cannot unserialize data inside of this transaction relating to an asset");
 		return error(errorMessage.c_str());
@@ -1205,16 +1236,16 @@ bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs, int
 
 	if(fJustCheck)
 	{
-		if (op != OP_ASSET_SEND) {
+		if (tx.nVersion != SYSCOIN_TX_VERSION_ASSET_UPDATE) {
 			if (theAsset.vchPubData.size() > MAX_VALUE_LENGTH)
 			{
 				errorMessage = "SYSCOIN_ASSET_CONSENSUS_ERROR: ERRCODE: 2004 - " + _("Asset public data too big");
-				return error(errorMessage.c_str());
+		        return error(errorMessage.c_str());
 			}
 		}
-		switch (op) {
-		case OP_ASSET_ACTIVATE:
-			if (theAsset.nAsset <= SYSCOIN_TX_VERSION_MINT_ASSET)
+		switch (tx.nVersion) {
+		case SYSCOIN_TX_VERSION_ASSET_ACTIVATE:
+			if (theAsset.nAsset <= SYSCOIN_TX_VERSION_MINT)
 			{
 				errorMessage = "SYSCOIN_ASSET_CONSENSUS_ERROR: ERRCODE: 2005 - " + _("asset guid invalid");
 				return error(errorMessage.c_str());
@@ -1226,7 +1257,7 @@ bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs, int
             }  
 			if (theAsset.nPrecision > 8)
 			{
-				errorMessage = "SYSCOIN_ASSET_CONSENSUS_ERROR: ERRCODE: 2013 - " + _("Precision must be between 0 and 8");
+				errorMessage = "SYSCOIN_ASSET_CONSENSUS_ERROR: ERRCODE: 2005 - " + _("Precision must be between 0 and 8");
 				return error(errorMessage.c_str());
 			}
 			if (theAsset.nMaxSupply != -1 && !AssetRange(theAsset.nMaxSupply, theAsset.nPrecision))
@@ -1250,10 +1281,9 @@ bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs, int
             }          
 			break;
 
-		case OP_ASSET_UPDATE:
-			if (theAsset.nBalance < 0)
-			{
-				errorMessage = "SYSCOIN_ASSET_CONSENSUS_ERROR: ERRCODE: 2017 - " + _("Balance must be greator than or equal to 0");
+		case SYSCOIN_TX_VERSION_ASSET_UPDATE:
+			if (theAsset.nBalance < 0){
+				errorMessage = "SYSCOIN_ASSET_CONSENSUS_ERROR: ERRCODE: 2017 - " + _("Balance must be greater than or equal to 0");
 				return error(errorMessage.c_str());
 			}
             if (!theAssetAllocation.assetAllocationTuple.IsNull())
@@ -1272,7 +1302,7 @@ bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs, int
             }           
 			break;
             
-		case OP_ASSET_SEND:
+		case SYSCOIN_TX_VERSION_ASSET_SEND:
 			if (theAssetAllocation.listSendingAllocationAmounts.empty())
 			{
 				errorMessage = "SYSCOIN_ASSET_CONSENSUS_ERROR: ERRCODE: 2020 - " + _("Asset send must send an input or transfer balance");
@@ -1284,23 +1314,22 @@ bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs, int
 				return error(errorMessage.c_str());
 			}
 			break;
-        case OP_ASSET_TRANSFER:
+        case SYSCOIN_TX_VERSION_ASSET_TRANSFER:
             break;
-		default:
-			errorMessage = "SYSCOIN_ASSET_CONSENSUS_ERROR: ERRCODE: 2023 - " + _("Asset transaction has unknown op");
+		    errorMessage = "SYSCOIN_ASSET_CONSENSUS_ERROR: ERRCODE: 2023 - " + _("Asset transaction has unknown op");
 			return error(errorMessage.c_str());
 		}
 	}
 
 	CAsset dbAsset;
-    const uint32_t &nAsset = op == OP_ASSET_SEND ? theAssetAllocation.assetAllocationTuple.nAsset : theAsset.nAsset;
+    const uint32_t &nAsset = tx.nVersion == SYSCOIN_TX_VERSION_ASSET_SEND ? theAssetAllocation.assetAllocationTuple.nAsset : theAsset.nAsset;
     auto result = mapAssets.try_emplace(nAsset, std::move(emptyAsset));
     auto mapAsset = result.first;
     const bool & mapAssetNotFound = result.second; 
 	if (mapAssetNotFound)
 	{
         if(!GetAsset(nAsset, dbAsset)){
-			if (op != OP_ASSET_ACTIVATE) {
+			if (tx.nVersion != SYSCOIN_TX_VERSION_ASSET_ACTIVATE) {
 				errorMessage = "SYSCOIN_ASSET_CONSENSUS_ERROR: ERRCODE: 2024 - " + _("Failed to read from asset DB");
 				return error(errorMessage.c_str());
 			}
@@ -1308,15 +1337,15 @@ bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs, int
                  mapAsset->second = std::move(theAsset); 
 	    }
         else{
-            if(op == OP_ASSET_ACTIVATE){
-                errorMessage = "SYSCOIN_ASSET_CONSENSUS_ERROR: ERRCODE: 2041 - " + _("Asset already exists");
+            if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE){
+                errorMessage =  "SYSCOIN_ASSET_CONSENSUS_ERROR: ERRCODE: 2041 - " + _("Asset already exists");
                 return error(errorMessage.c_str());
             }
             mapAsset->second = std::move(dbAsset); 
         }
     }
     CAsset &storedSenderAssetRef = mapAsset->second;
-	if (op == OP_ASSET_TRANSFER) {
+	if (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_TRANSFER) {
 	
         if (!FindAssetOwnerInTx(inputs, tx, storedSenderAssetRef.witnessAddress))
         {
@@ -1325,7 +1354,7 @@ bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs, int
         }           
 	}
 
-	if (op == OP_ASSET_UPDATE) {
+	if (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_UPDATE) {
 		if (!FindAssetOwnerInTx(inputs, tx, storedSenderAssetRef.witnessAddress))
 		{
 			errorMessage = "SYSCOIN_ASSET_CONSENSUS_ERROR: ERRCODE: 1015 - " + _("Cannot update this asset. Asset owner must sign off on this change");
@@ -1353,7 +1382,7 @@ bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs, int
 		}
 
 	}      
-	if (op == OP_ASSET_SEND) {
+	if (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_SEND) {
 		if (storedSenderAssetRef.witnessAddress != theAssetAllocation.assetAllocationTuple.witnessAddress || !FindAssetOwnerInTx(inputs, tx, storedSenderAssetRef.witnessAddress))
 		{
 			errorMessage = "SYSCOIN_ASSET_CONSENSUS_ERROR: ERRCODE: 1015 - " + _("Cannot send this asset. Asset owner must sign off on this change");
@@ -1409,9 +1438,9 @@ bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs, int
 			}
 		}
         if (!bSanityCheck && !fJustCheck)
-            passetallocationdb->WriteAssetAllocationIndex(op, tx, storedSenderAssetRef, true, nHeight);  
+            passetallocationdb->WriteAssetAllocationIndex(tx, storedSenderAssetRef, true, nHeight);  
 	}
-	else if (op != OP_ASSET_ACTIVATE)
+	else if (tx.nVersion != SYSCOIN_TX_VERSION_ASSET_ACTIVATE)
 	{         
 		if (!theAsset.witnessAddress.IsNull())
 			storedSenderAssetRef.witnessAddress = theAsset.witnessAddress;
@@ -1423,7 +1452,7 @@ bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs, int
 			return error(errorMessage.c_str());
 		}
                  
-		if (!theAsset.vchBurnMethodSignature.empty() && op != OP_ASSET_TRANSFER)
+		if (!theAsset.vchBurnMethodSignature.empty() && tx.nVersion != SYSCOIN_TX_VERSION_ASSET_TRANSFER)
 			storedSenderAssetRef.vchBurnMethodSignature = theAsset.vchBurnMethodSignature;				
 		else if (!(storedSenderAssetRef.nUpdateFlags & ASSET_UPDATE_CONTRACT))
 		{
@@ -1431,7 +1460,7 @@ bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs, int
 			return error(errorMessage.c_str());
 		}
         
-        if (!theAsset.vchContract.empty() && op != OP_ASSET_TRANSFER)
+        if (!theAsset.vchContract.empty() && tx.nVersion != SYSCOIN_TX_VERSION_ASSET_TRANSFER)
             storedSenderAssetRef.vchContract = theAsset.vchContract;             
         else if (!(storedSenderAssetRef.nUpdateFlags & ASSET_UPDATE_CONTRACT))
         {
@@ -1447,7 +1476,7 @@ bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs, int
 
 
 	}
-	if (op == OP_ASSET_ACTIVATE)
+	if (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE)
 	{
         if (!FindAssetOwnerInTx(inputs, tx, storedSenderAssetRef.witnessAddress))
         {
@@ -1462,9 +1491,9 @@ bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs, int
 	storedSenderAssetRef.txHash = txHash;
 	// write asset, if asset send, only write on pow since asset -> asset allocation is not 0-conf compatible
 	if (!bSanityCheck && !fJustCheck) {
-        passetdb->WriteAssetIndex(tx, storedSenderAssetRef, op, nHeight);
-		LogPrint(BCLog::SYS,"CONNECTED ASSET: op=%s symbol=%d hash=%s height=%d fJustCheck=%d\n",
-				assetFromOp(op).c_str(),
+        passetdb->WriteAssetIndex(tx, storedSenderAssetRef, nHeight);
+		LogPrint(BCLog::SYS,"CONNECTED ASSET: tx=%s symbol=%d hash=%s height=%d fJustCheck=%d\n",
+				assetFromTx(tx.nVersion).c_str(),
 				nAsset,
 				txHash.ToString().c_str(),
 				nHeight,
@@ -1512,20 +1541,13 @@ UniValue assetnew(const JSONRPCRequest& request) {
 	string strAddressFrom;
 	string strAddress = vchAddress;
 	const CTxDestination address = DecodeDestination(strAddress);
-	if (IsValidDestination(address)) {
-		strAddressFrom = strAddress;
-	}
+
     UniValue detail = DescribeAddress(address);
     if(find_value(detail.get_obj(), "iswitness").get_bool() == false)
         throw runtime_error("SYSCOIN_ASSET_RPC_ERROR: ERRCODE: 2501 - " + _("Address must be a segwit based address"));
     string witnessProgramHex = find_value(detail.get_obj(), "witness_program").get_str();
     unsigned char witnessVersion = (unsigned char)find_value(detail.get_obj(), "witness_version").get_int();   
-	CScript scriptPubKeyFromOrig;
-	if (!strAddressFrom.empty()) {
-		scriptPubKeyFromOrig = GetScriptForDestination(address);
-	}
-	
-    CScript scriptPubKey;
+
 
 	// calculate net
     // build asset object
@@ -1541,23 +1563,19 @@ UniValue assetnew(const JSONRPCRequest& request) {
 	newAsset.nUpdateFlags = nUpdateFlags;
 	vector<unsigned char> data;
 	newAsset.Serialize(data);
-
-    scriptPubKey << CScript::EncodeOP_N(OP_SYSCOIN_ASSET) << CScript::EncodeOP_N(OP_ASSET_ACTIVATE) << OP_2DROP;
-    scriptPubKey += scriptPubKeyFromOrig;
+    
 
 	// use the script pub key to create the vecsend which sendmoney takes and puts it into vout
 	vector<CRecipient> vecSend;
-	CRecipient recipient;
-	CreateRecipient(scriptPubKey, recipient);
-	vecSend.push_back(recipient);
+
 
 
 	CScript scriptData;
-	scriptData << OP_RETURN << CScript::EncodeOP_N(OP_SYSCOIN_ASSET) << data;
+	scriptData << OP_RETURN << data;
 	CRecipient fee;
 	CreateFeeRecipient(scriptData, fee);
 	vecSend.push_back(fee);
-	UniValue res = syscointxfund_helper(vchWitness, vecSend);
+	UniValue res = syscointxfund_helper(SYSCOIN_TX_VERSION_ASSET_ACTIVATE, vchWitness, vecSend);
 	res.push_back((int)newAsset.nAsset);
 	return res;
 }
@@ -1605,33 +1623,18 @@ UniValue assetupdate(const JSONRPCRequest& request) {
 	int nUpdateFlags = params[5].get_int();
 	string vchWitness;
 	vchWitness = params[6].get_str();
-
-    CScript scriptPubKeyFromOrig;
+    
 	CAsset theAsset;
 
     if (!GetAsset( nAsset, theAsset))
         throw runtime_error("SYSCOIN_ASSET_RPC_ERROR: ERRCODE: 2501 - " + _("Could not find a asset with this key"));
-
-	string strAddressFrom;
-	const string& strAddress = theAsset.witnessAddress.ToString();
-	const CTxDestination &address = DecodeDestination(strAddress);
-	if (IsValidDestination(address)) {
-		strAddressFrom = strAddress;
-	}
+        
 
 	UniValue param4 = params[4];
 	CAmount nBalance = 0;
 	if(param4.get_str() != "0")
 		nBalance = AssetAmountFromValue(param4, theAsset.nPrecision);
 	
-	
-	if (!strAddressFrom.empty()) {
-		scriptPubKeyFromOrig = GetScriptForDestination(address);
-	}
-    
-
-    // create ASSETUPDATE txn keys
-    CScript scriptPubKey;
 
 	if(strPubData != stringFromVch(theAsset.vchPubData))
 		theAsset.vchPubData = vchFromString(strPubData);
@@ -1651,22 +1654,17 @@ UniValue assetupdate(const JSONRPCRequest& request) {
 
 	vector<unsigned char> data;
 	theAsset.Serialize(data);
-
-    scriptPubKey << CScript::EncodeOP_N(OP_SYSCOIN_ASSET) << CScript::EncodeOP_N(OP_ASSET_UPDATE) << OP_2DROP;
-    scriptPubKey += scriptPubKeyFromOrig;
+    
 
 	vector<CRecipient> vecSend;
-	CRecipient recipient;
-	CreateRecipient(scriptPubKey, recipient);
-	vecSend.push_back(recipient);
 
 
 	CScript scriptData;
-	scriptData << OP_RETURN << CScript::EncodeOP_N(OP_SYSCOIN_ASSET) << data;
+	scriptData << OP_RETURN << data;
 	CRecipient fee;
 	CreateFeeRecipient(scriptData, fee);
 	vecSend.push_back(fee);
-	return syscointxfund_helper(vchWitness, vecSend);
+	return syscointxfund_helper(SYSCOIN_TX_VERSION_ASSET_UPDATE, vchWitness, vecSend);
 }
 
 UniValue assettransfer(const JSONRPCRequest& request) {
@@ -1693,27 +1691,17 @@ UniValue assettransfer(const JSONRPCRequest& request) {
     if (!GetAsset( nAsset, theAsset))
         throw runtime_error("SYSCOIN_ASSET_RPC_ERROR: ERRCODE: 2505 - " + _("Could not find a asset with this key"));
 	
-	string strAddressFrom;
-	const string& strAddress = theAsset.witnessAddress.ToString();
-	const CTxDestination addressFrom = DecodeDestination(strAddress);
-	if (IsValidDestination(addressFrom)) {
-		strAddressFrom = strAddress;
-	}
 
 
 	const CTxDestination addressTo = DecodeDestination(vchAddressTo);
-	if (IsValidDestination(addressTo)) {
-		scriptPubKeyOrig = GetScriptForDestination(addressTo);
-	}
+
 
     UniValue detail = DescribeAddress(addressTo);
     if(find_value(detail.get_obj(), "iswitness").get_bool() == false)
         throw runtime_error("SYSCOIN_ASSET_RPC_ERROR: ERRCODE: 2501 - " + _("Address must be a segwit based address"));
     string witnessProgramHex = find_value(detail.get_obj(), "witness_program").get_str();
     unsigned char witnessVersion = (unsigned char)find_value(detail.get_obj(), "witness_version").get_int();   
-	if (!strAddressFrom.empty()) {
-		scriptPubKeyFromOrig = GetScriptForDestination(addressFrom);
-	}
+
     
 	theAsset.ClearAsset();
     CScript scriptPubKey;
@@ -1722,21 +1710,16 @@ UniValue assettransfer(const JSONRPCRequest& request) {
 	vector<unsigned char> data;
 	theAsset.Serialize(data);
 
-    scriptPubKey << CScript::EncodeOP_N(OP_SYSCOIN_ASSET) << CScript::EncodeOP_N(OP_ASSET_TRANSFER) << OP_2DROP;
-	scriptPubKey += scriptPubKeyOrig;
-    // send the asset pay txn
-	vector<CRecipient> vecSend;
-	CRecipient recipient;
-	CreateRecipient(scriptPubKey, recipient);
-	vecSend.push_back(recipient);
 
+	vector<CRecipient> vecSend;
+    
 
 	CScript scriptData;
-	scriptData << OP_RETURN << CScript::EncodeOP_N(OP_SYSCOIN_ASSET) << data;
+	scriptData << OP_RETURN << data;
 	CRecipient fee;
 	CreateFeeRecipient(scriptData, fee);
 	vecSend.push_back(fee);
-	return syscointxfund_helper(vchWitness, vecSend);
+	return syscointxfund_helper(SYSCOIN_TX_VERSION_ASSET_TRANSFER, vchWitness, vecSend);
 }
 UniValue assetsend(const JSONRPCRequest& request) {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
@@ -1762,19 +1745,6 @@ UniValue assetsend(const JSONRPCRequest& request) {
 	if (!GetAsset(nAsset, theAsset))
 		throw runtime_error("SYSCOIN_ASSET_RPC_ERROR: ERRCODE: 2507 - " + _("Could not find a asset with this key"));
 
-	string strAddressFrom;
-	const string& strAddress = theAsset.witnessAddress.ToString();
-	const CTxDestination addressFrom = DecodeDestination(strAddress);
-	if (IsValidDestination(addressFrom)) {
-		strAddressFrom = strAddress;
-	}
-
-
-	CScript scriptPubKeyFromOrig;
-
-	if (!strAddressFrom.empty()) {
-		scriptPubKeyFromOrig = GetScriptForDestination(addressFrom);
-	}
 
 
 	CAssetAllocation theAssetAllocation;
@@ -1814,22 +1784,16 @@ UniValue assetsend(const JSONRPCRequest& request) {
 
     vector<unsigned char> data;
     theAssetAllocation.Serialize(data);
-
-	scriptPubKey << CScript::EncodeOP_N(OP_SYSCOIN_ASSET) << CScript::EncodeOP_N(OP_ASSET_SEND) << OP_2DROP;
-	scriptPubKey += scriptPubKeyFromOrig;
-	// send the asset pay txn
+    
 	vector<CRecipient> vecSend;
-	CRecipient recipient;
-	CreateRecipient(scriptPubKey, recipient);
-	vecSend.push_back(recipient);
 
 	CScript scriptData;
-	scriptData << OP_RETURN << CScript::EncodeOP_N(OP_SYSCOIN_ASSET_ALLOCATION) << data;
+	scriptData << OP_RETURN << data;
 	CRecipient fee;
 	CreateFeeRecipient(scriptData, fee);
 	vecSend.push_back(fee);
 
-	return syscointxfund_helper(vchWitness, vecSend);
+	return syscointxfund_helper(SYSCOIN_TX_VERSION_ASSET_SEND, vchWitness, vecSend);
 }
 
 UniValue assetinfo(const JSONRPCRequest& request) {
@@ -1864,7 +1828,7 @@ bool BuildAssetJson(const CAsset& asset, UniValue& oAsset)
 	oAsset.pushKV("precision", (int)asset.nPrecision);
 	return true;
 }
-bool AssetTxToJSON(const int &op, const CTransaction& tx, UniValue &entry)
+bool AssetTxToJSON(const CTransaction& tx, UniValue &entry)
 {
 	CAsset asset(tx);
 	if(!asset.IsNull())
@@ -1881,63 +1845,63 @@ bool AssetTxToJSON(const int &op, const CTransaction& tx, UniValue &entry)
         nHeight = blockindex->nHeight; 
         	
 
-	entry.pushKV("txtype", assetFromOp(op));
+	entry.pushKV("txtype", assetFromTx(tx.nVersion));
 	entry.pushKV("_id", (int)asset.nAsset);
     entry.pushKV("txid", tx.GetHash().GetHex());
     entry.pushKV("height", nHeight);
     
-	if(op == OP_ASSET_ACTIVATE || (!asset.vchPubData.empty() && dbAsset.vchPubData != asset.vchPubData))
+	if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE || (!asset.vchPubData.empty() && dbAsset.vchPubData != asset.vchPubData))
 		entry.pushKV("publicvalue", stringFromVch(asset.vchPubData));
         
-    if(op == OP_ASSET_ACTIVATE || (!asset.vchContract.empty() && dbAsset.vchContract != asset.vchContract))
+    if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE || (!asset.vchContract.empty() && dbAsset.vchContract != asset.vchContract))
         entry.pushKV("contract", "0x"+HexStr(asset.vchContract));
         
-    if(op == OP_ASSET_ACTIVATE || (!asset.vchBurnMethodSignature.empty() && dbAsset.vchBurnMethodSignature != asset.vchBurnMethodSignature))
+    if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE || (!asset.vchBurnMethodSignature.empty() && dbAsset.vchBurnMethodSignature != asset.vchBurnMethodSignature))
         entry.pushKV("burnsig", HexStr(asset.vchBurnMethodSignature));                  
         
-	if (op == OP_ASSET_ACTIVATE || (!asset.witnessAddress.IsNull() && dbAsset.witnessAddress != asset.witnessAddress))
+	if (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE || (!asset.witnessAddress.IsNull() && dbAsset.witnessAddress != asset.witnessAddress))
 		entry.pushKV("address", asset.witnessAddress.ToString());
 
-	if (op == OP_ASSET_ACTIVATE || asset.nUpdateFlags != dbAsset.nUpdateFlags)
+	if (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE || asset.nUpdateFlags != dbAsset.nUpdateFlags)
 		entry.pushKV("update_flags", asset.nUpdateFlags);
               
-	if (op == OP_ASSET_ACTIVATE || asset.nBalance != dbAsset.nBalance)
+	if (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE || asset.nBalance != dbAsset.nBalance)
 		entry.pushKV("balance", ValueFromAssetAmount(asset.nBalance, dbAsset.nPrecision));
-    if (op == OP_ASSET_ACTIVATE){
+    if (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE){
         entry.pushKV("total_supply", ValueFromAssetAmount(asset.nTotalSupply, dbAsset.nPrecision)); 
         entry.pushKV("precision", asset.nPrecision);  
     }         
      return true;
 }
-bool AssetTxToJSON(const int &op, const CTransaction& tx, const CAsset& dbAsset, const int& nHeight, UniValue &entry)
+bool AssetTxToJSON(const CTransaction& tx, const CAsset& dbAsset, const int& nHeight, UniValue &entry)
 {
     CAsset asset(tx);
     if(asset.IsNull() || dbAsset.IsNull())
         return false;
 
-    entry.pushKV("txtype", assetFromOp(op));
+    entry.pushKV("txtype", assetFromTx(tx.nVersion));
     entry.pushKV("_id", (int)asset.nAsset);
     entry.pushKV("txid", tx.GetHash().GetHex());
     entry.pushKV("height", nHeight);
 
-    if(op == OP_ASSET_ACTIVATE || (!asset.vchPubData.empty() && dbAsset.vchPubData != asset.vchPubData))
+    if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE || (!asset.vchPubData.empty() && dbAsset.vchPubData != asset.vchPubData))
         entry.pushKV("publicvalue", stringFromVch(asset.vchPubData));
         
-    if(op == OP_ASSET_ACTIVATE || (!asset.vchContract.empty() && dbAsset.vchContract != asset.vchContract))
+    if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE|| (!asset.vchContract.empty() && dbAsset.vchContract != asset.vchContract))
         entry.pushKV("contract", "0x"+HexStr(asset.vchContract));
         
-    if(op == OP_ASSET_ACTIVATE || (!asset.vchBurnMethodSignature.empty() && dbAsset.vchBurnMethodSignature != asset.vchBurnMethodSignature))
+    if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE || (!asset.vchBurnMethodSignature.empty() && dbAsset.vchBurnMethodSignature != asset.vchBurnMethodSignature))
         entry.pushKV("burnsig", HexStr(asset.vchBurnMethodSignature));                  
         
-    if (op == OP_ASSET_ACTIVATE || (!asset.witnessAddress.IsNull() && dbAsset.witnessAddress != asset.witnessAddress))
+    if (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE || (!asset.witnessAddress.IsNull() && dbAsset.witnessAddress != asset.witnessAddress))
         entry.pushKV("address", asset.witnessAddress.ToString());
 
-    if (op == OP_ASSET_ACTIVATE || asset.nUpdateFlags != dbAsset.nUpdateFlags)
+    if (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE || asset.nUpdateFlags != dbAsset.nUpdateFlags)
         entry.pushKV("update_flags", asset.nUpdateFlags);
               
-    if (op == OP_ASSET_ACTIVATE || asset.nBalance != dbAsset.nBalance)
+    if (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE || asset.nBalance != dbAsset.nBalance)
         entry.pushKV("balance", ValueFromAssetAmount(asset.nBalance, dbAsset.nPrecision));
-    if (op == OP_ASSET_ACTIVATE){
+    if (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE){
         entry.pushKV("total_supply", ValueFromAssetAmount(asset.nTotalSupply, dbAsset.nPrecision)); 
         entry.pushKV("precision", asset.nPrecision);  
     }  

--- a/src/services/asset.h
+++ b/src/services/asset.h
@@ -55,7 +55,6 @@ bool GetSyscoinBurnData(const CTransaction &tx, CAssetAllocation* theAssetAlloca
 bool GetSyscoinBurnData(const CTransaction &tx, uint32_t& nAssetFromScript, CWitnessAddress& burnWitnessAddress, uint64_t &nAmountFromScript, std::vector<unsigned char> &vchContract, std::vector<unsigned char> &vchEthAddress);
 bool SysTxToJSON(const CTransaction &tx, UniValue &entry);
 bool SysBurnTxToJSON(const CTransaction &tx, UniValue &entry);
-std::string GetSyscoinTransactionDescription(const CTransaction& tx, std::string& responseEnglish, const char &type, std::string& responseGUID);
 bool IsOutpointMature(const COutPoint& outpoint);
 UniValue syscointxfund_helper(const int &nVersion, const std::string &vchWitness, std::vector<CRecipient> &vecSend);
 bool FlushSyscoinDBs();

--- a/src/services/assetallocation.h
+++ b/src/services/assetallocation.h
@@ -182,7 +182,6 @@ public:
 		return !(a == b);
 	}
 	inline void SetNull() { ClearAssetAllocation(); nBalance = 0;}
-	inline bool IsNull() const { return (nBalance == 0); }
 	bool UnserializeFromTx(const CTransaction &tx);
 	bool UnserializeFromData(const std::vector<unsigned char> &vchData);
 	void Serialize(std::vector<unsigned char>& vchData);

--- a/src/services/assetallocation.h
+++ b/src/services/assetallocation.h
@@ -16,14 +16,11 @@ class CCoinsViewCache;
 class CBlock;
 class CAsset;
 class CMintSyscoin;
-bool DecodeAssetAllocationTx(const CTransaction& tx, int& op, std::vector<std::vector<unsigned char> >& vvch);
-bool DecodeAndParseAssetAllocationTx(const CTransaction& tx, int& op, std::vector<std::vector<unsigned char> >& vvch, char& type);
-bool DecodeAssetAllocationScript(const CScript& script, int& op, std::vector<std::vector<unsigned char> > &vvch);
 
 bool AssetMintTxToJson(const CTransaction& tx, UniValue &entry);
 bool AssetMintTxToJson(const CTransaction& tx, const CMintSyscoin& mintsyscoin, const int& nHeight, UniValue &entry);
 
-std::string assetAllocationFromOp(int op);
+std::string assetAllocationFromTx(const int &nVersion);
 
 class CWitnessAddress{
 public:
@@ -199,7 +196,7 @@ public:
         return Read(assetAllocationTuple, assetallocation);
     }
     bool Flush(const AssetAllocationMap &mapAssetAllocations);
-	void WriteAssetAllocationIndex(const int& op, const CTransaction &tx, const CAsset& dbAsset, const bool& confirmed, int nHeight);
+	void WriteAssetAllocationIndex(const CTransaction &tx, const CAsset& dbAsset, const bool& confirmed, int nHeight);
     void WriteMintIndex(const CTransaction& tx, const CMintSyscoin& mintSyscoin, const int &nHeight);
 	bool ScanAssetAllocations(const int count, const int from, const UniValue& oOptions, UniValue& oRes);
 };
@@ -224,13 +221,13 @@ public:
     bool ScanAssetAllocationMempoolBalances(const int count, const int from, const UniValue& oOptions, UniValue& oRes);
 };
 static CAssetAllocation emptyAllocation;
-bool CheckAssetAllocationInputs(const CTransaction &tx, const CCoinsViewCache &inputs, int op, const std::vector<std::vector<unsigned char> > &vvchArgs, bool fJustCheck, int nHeight, AssetAllocationMap &mapAssetAllocations, std::string &errorMessage, bool& bOverflow, bool bSanityCheck = false, bool bMiner = false);
+bool CheckAssetAllocationInputs(const CTransaction &tx, const CCoinsViewCache &inputs, bool fJustCheck, int nHeight, AssetAllocationMap &mapAssetAllocations, std::string &errorMessage, bool& bOverflow, bool bSanityCheck = false, bool bMiner = false);
 bool GetAssetAllocation(const CAssetAllocationTuple& assetAllocationTuple,CAssetAllocation& txPos);
 bool BuildAssetAllocationJson(const CAssetAllocation& assetallocation, const CAsset& asset, UniValue& oName);
 bool ResetAssetAllocation(const std::string &senderStr, const uint256 &txHash, const bool &bMiner=false, const bool &bExpiryOnly=false);
 void ResyncAssetAllocationStates();
-bool AssetAllocationTxToJSON(const int &op, const CTransaction &tx, const CAsset& dbAsset, const int& nHeight, const bool& confirmed, UniValue &entry, CAssetAllocation& assetallocation);
-bool AssetAllocationTxToJSON(const int &op, const CTransaction &tx, UniValue &entry);
+bool AssetAllocationTxToJSON(const CTransaction &tx, const CAsset& dbAsset, const int& nHeight, const bool& confirmed, UniValue &entry, CAssetAllocation& assetallocation);
+bool AssetAllocationTxToJSON(const CTransaction &tx, UniValue &entry);
 void WriteAssetIndexForAllocation(const CAssetAllocation& assetallocation, const uint256& txid, const UniValue& oName);
 void WriteAssetIndexForAllocation(const CMintSyscoin& mintSyscoin, const uint256& txid, const UniValue& oName);
 void WriteAssetAllocationIndexTXID(const CAssetAllocationTuple& allocationTuple, const uint256& txid);

--- a/src/services/graph.cpp
+++ b/src/services/graph.cpp
@@ -6,9 +6,7 @@
 using namespace std;
 extern ArrivalTimesMapImpl arrivalTimesMap;
 bool OrderBasedOnArrivalTime(std::vector<CTransactionRef>& blockVtx) {
-	std::vector<vector<unsigned char> > vvchArgs;
 	std::vector<CTransactionRef> orderedVtx;
-	int op;
 	AssertLockHeld(cs_main);
 	CCoinsViewCache view(pcoinsTip.get());
 	// order the arrival times in ascending order using a map
@@ -18,23 +16,20 @@ bool OrderBasedOnArrivalTime(std::vector<CTransactionRef>& blockVtx) {
 		if (!txRef)
 			continue;
 		const CTransaction &tx = *txRef;
-		if (tx.nVersion == SYSCOIN_TX_VERSION_ASSET)
+		if (IsAssetAllocationTx(tx.nVersion))
 		{
-			if (DecodeAssetAllocationTx(tx, op, vvchArgs))
-			{
-				LOCK(cs_assetallocationarrival);
-				
-				CAssetAllocation assetallocation(tx);
-				ArrivalTimesMap &arrivalTimes = arrivalTimesMap[assetallocation.assetAllocationTuple.ToString()];
+			LOCK(cs_assetallocationarrival);
+			
+			CAssetAllocation assetallocation(tx);
+			ArrivalTimesMap &arrivalTimes = arrivalTimesMap[assetallocation.assetAllocationTuple.ToString()];
 
-				ArrivalTimesMap::iterator it = arrivalTimes.find(tx.GetHash());
-				if (it != arrivalTimes.end())
-					orderedIndexes.insert(make_pair((*it).second, n));
-				// we don't have this in our arrival times list, means it must be rejected via consensus so add it to the end
-				else
-					orderedIndexes.insert(make_pair(INT64_MAX, n));
-				continue;
-			}
+			ArrivalTimesMap::iterator it = arrivalTimes.find(tx.GetHash());
+			if (it != arrivalTimes.end())
+				orderedIndexes.insert(make_pair((*it).second, n));
+			// we don't have this in our arrival times list, means it must be rejected via consensus so add it to the end
+			else
+				orderedIndexes.insert(make_pair(INT64_MAX, n));
+			continue;	
 		}
 		// add normal tx's to orderedvtx, 
 		orderedVtx.emplace_back(txRef);

--- a/src/syscoin-tx.cpp
+++ b/src/syscoin-tx.cpp
@@ -26,7 +26,8 @@
 #include <stdio.h>
 
 #include <boost/algorithm/string.hpp>
-
+// SYSCOIN
+#include <services/asset.h>
 static bool fCreateBlank;
 static std::map<std::string,UniValue> registers;
 static const int CONTINUE_EXECUTION=-1;
@@ -193,7 +194,7 @@ static CAmount ExtractAndValidateValue(const std::string& strValue)
 static void MutateTxVersion(CMutableTransaction& tx, const std::string& cmdVal)
 {
     int64_t newVersion;
-    if (!ParseInt64(cmdVal, &newVersion) || newVersion < 1 || newVersion > CTransaction::MAX_STANDARD_VERSION)
+    if (!ParseInt64(cmdVal, &newVersion) || ((newVersion < 1 || newVersion > CTransaction::MAX_STANDARD_VERSION) && !IsSyscoinTx(newVersion)))
         throw std::runtime_error("Invalid TX version requested: '" + cmdVal + "'");
 
     tx.nVersion = (int) newVersion;
@@ -526,18 +527,6 @@ static bool findSighashFlags(int& flags, const std::string& flagStr)
     }
 
     return false;
-}
-
-static CAmount AmountFromValue(const UniValue& value)
-{
-    if (!value.isNum() && !value.isStr())
-        throw std::runtime_error("Amount is not a number or string");
-    CAmount amount;
-    if (!ParseFixedPoint(value.getValStr(), 8, &amount))
-        throw std::runtime_error("Invalid amount");
-    if (!MoneyRange(amount))
-        throw std::runtime_error("Amount out of range");
-    return amount;
 }
 
 static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)

--- a/src/test/test_syscoin_services.cpp
+++ b/src/test/test_syscoin_services.cpp
@@ -107,7 +107,7 @@ void StopNodes()
 void StartNode(const string &dataDir, bool regTest, const string& extraArgs)
 {
 	boost::filesystem::path fpath = boost::filesystem::system_complete("../syscoind");
-	string nodePath = fpath.string() + string(" -unittest -tpstest -daemon -server -debug=0 -concurrentprocessing=1 -datadir=") + dataDir;
+	string nodePath = fpath.string() + string(" -unittest -tpstest -daemon -server -debug=1 -concurrentprocessing=1 -datadir=") + dataDir;
 	if (regTest)
 		nodePath += string(" -regtest");
 	if (!extraArgs.empty())

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <chainparams.h>
 #include <index/txindex.h>
 #include <script/standard.h>
 #include <test/test_syscoin.h>
@@ -36,6 +37,12 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
     while (!txindex.BlockUntilSyncedToCurrentChain()) {
         BOOST_REQUIRE(time_start + timeout_ms > GetTimeMillis());
         MilliSleep(100);
+    }
+
+    // Check that txindex excludes genesis block transactions.
+    const CBlock& genesis_block = Params().GenesisBlock();
+    for (const auto& txn : genesis_block.vtx) {
+        BOOST_CHECK(!txindex.FindTx(txn->GetHash(), block_hash, tx_disk));
     }
 
     // Check that txindex has all txs that were in the chain before it started.

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -235,6 +235,12 @@ bool LockDirectory(const fs::path& directory, const std::string lockfile_name, b
     return true;
 }
 
+void UnlockDirectory(const fs::path& directory, const std::string& lockfile_name)
+{
+    std::lock_guard<std::mutex> lock(cs_dir_locks);
+    dir_locks.erase((directory / lockfile_name).string());
+}
+
 void ReleaseDirectoryLocks()
 {
     std::lock_guard<std::mutex> ulock(cs_dir_locks);

--- a/src/util.h
+++ b/src/util.h
@@ -120,6 +120,7 @@ int RaiseFileDescriptorLimit(int nMinFD);
 void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length);
 bool RenameOver(fs::path src, fs::path dest);
 bool LockDirectory(const fs::path& directory, const std::string lockfile_name, bool probe_only=false);
+void UnlockDirectory(const fs::path& directory, const std::string& lockfile_name);
 bool DirIsWritable(const fs::path& directory);
 
 /** Release all directory locks. This is used for unit testing only, at runtime

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -774,7 +774,9 @@ bool CheckSyscoinInputs(const bool ibd, const CTransaction& tx, CValidationState
         {
 
             good = true;
-            const CTransaction &tx = *(block.vtx[i]);        
+            const CTransaction &tx = *(block.vtx[i]); 
+            if(tx.IsCoinBase()) 
+                continue;       
             if(fAssetIndex){
                 if(!passetindexdb->WriteBlockHash(tx.GetHash(), block.GetHash())){
                     return state.DoS(0, false, REJECT_INVALID, "Could not write block hash to asset index db");

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -513,32 +513,30 @@ bool DisconnectSyscoinTransaction(const CTransaction& tx, const CBlockIndex* pin
     if(tx.IsCoinBase())
         return true;
 
-    if (tx.nVersion != SYSCOIN_TX_VERSION_ASSET && tx.nVersion != SYSCOIN_TX_VERSION_MINT_ASSET)
+    if (!IsSyscoinTx(tx.nVersion))
         return true;
     if(fAssetIndex)
         vecTXIDs.push_back(tx.GetHash());    
-    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT_ASSET){
+    if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT){
         if(!DisconnectMintAsset(tx, mapAssets, mapAssetAllocations))
             return false;       
     }
     else{
-        std::vector<std::vector<unsigned char> > vvchArgs;
-        int op;
-        if (DecodeAssetAllocationTx(tx, op, vvchArgs))
+        if (IsAssetAllocationTx(tx.nVersion))
         {
             if(!DisconnectAssetAllocation(tx, mapAssetAllocations))
                 return false;       
         }
-        else if (DecodeAssetTx(tx, op, vvchArgs))
+        else if (IsAssetTx(tx.nVersion))
         {
-            if (op == OP_ASSET_SEND) {
+            if (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_SEND) {
                 if(!DisconnectAssetSend(tx, mapAssets, mapAssetAllocations))
                     return false;
-            } else if (op == OP_ASSET_UPDATE) {  
+            } else if (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_UPDATE) {  
                 if(!DisconnectAssetUpdate(tx, mapAssets))
                     return false;
             }
-            else if (op == OP_ASSET_ACTIVATE) {
+            else if (tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ACTIVATE) {
                 if(!DisconnectAssetActivate(tx, mapAssets))
                     return false;
             }     
@@ -558,17 +556,17 @@ bool CheckSyscoinMint(const bool ibd, const CTransaction& tx, CValidationState& 
         errorMessage = "SYSCOIN_ASSET_ALLOCATION_CONSENSUS_ERROR ERRCODE: 1001 - " + _("Cannot unserialize data inside of this transaction relating to an syscoinmint");
         return state.DoS(100, false, REJECT_INVALID, errorMessage);
     }
-    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT_SYSCOIN && !mintSyscoin.assetAllocationTuple.IsNull())
+    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT && !mintSyscoin.assetAllocationTuple.IsNull())
     {
         errorMessage = "SYSCOIN_ASSET_ALLOCATION_CONSENSUS_ERROR ERRCODE: 1001 - " + _("Tried to mint Syscoin but asset information was present");
         return state.DoS(100, false, REJECT_INVALID, errorMessage);
     }  
-    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT_ASSET && mintSyscoin.assetAllocationTuple.IsNull())
+    if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT && mintSyscoin.assetAllocationTuple.IsNull())
     {
         errorMessage = "SYSCOIN_ASSET_ALLOCATION_CONSENSUS_ERROR ERRCODE: 1001 - " + _("Tried to mint asset but asset information was not present");
         return state.DoS(100, false, REJECT_INVALID, errorMessage);
     } 
-    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT_ASSET && !GetAsset(mintSyscoin.assetAllocationTuple.nAsset, dbAsset)) 
+    if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT && !GetAsset(mintSyscoin.assetAllocationTuple.nAsset, dbAsset)) 
     {
         errorMessage = "SYSCOIN_ASSET_ALLOCATION_CONSENSUS_ERROR ERRCODE: 1001 - " + _("Failed to read from asset DB");
         return state.DoS(100, false, REJECT_INVALID, errorMessage);
@@ -627,11 +625,11 @@ bool CheckSyscoinMint(const bool ibd, const CTransaction& tx, CValidationState& 
         return state.DoS(100, false, REJECT_INVALID, errorMessage);
     }                       
     const dev::Address &address160 = rlpValue[3].toHash<dev::Address>(dev::RLP::VeryStrict);
-    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT_SYSCOIN && Params().GetConsensus().vchSYSXContract != address160.asBytes()){
+    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT && Params().GetConsensus().vchSYSXContract != address160.asBytes()){
         errorMessage = "SYSCOIN_ASSET_ALLOCATION_CONSENSUS_ERROR ERRCODE: 1001 - " + _("Receiver not the expected SYSX contract address");
         return state.DoS(100, false, REJECT_INVALID, errorMessage);
     }
-    else if(tx.nVersion == SYSCOIN_TX_VERSION_MINT_ASSET && dbAsset.vchContract != address160.asBytes()){
+    else if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT && dbAsset.vchContract != address160.asBytes()){
         errorMessage = "SYSCOIN_ASSET_ALLOCATION_CONSENSUS_ERROR ERRCODE: 1001 - " + _("Receiver not the expected SYSX contract address");
         return state.DoS(100, false, REJECT_INVALID, errorMessage);
     }
@@ -640,15 +638,15 @@ bool CheckSyscoinMint(const bool ibd, const CTransaction& tx, CValidationState& 
     uint32_t nAsset = 0;
     const std::vector<unsigned char> &rlpBytes = rlpValue[5].data().toBytes();
     CWitnessAddress witnessAddress;
-    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT_SYSCOIN && !parseEthMethodInputData(Params().GetConsensus().vchSYSXBurnMethodSignature, rlpBytes, outputAmount, nAsset, witnessAddress)){
+    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT && !parseEthMethodInputData(Params().GetConsensus().vchSYSXBurnMethodSignature, rlpBytes, outputAmount, nAsset, witnessAddress)){
         errorMessage = "SYSCOIN_ASSET_ALLOCATION_CONSENSUS_ERROR ERRCODE: 1001 - " + _("Could not parse and validate transaction data");
         return state.DoS(100, false, REJECT_INVALID, errorMessage);
     }
-    else if(tx.nVersion == SYSCOIN_TX_VERSION_MINT_ASSET && !parseEthMethodInputData(dbAsset.vchBurnMethodSignature, rlpBytes, outputAmount, nAsset, witnessAddress)){
+    else if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT && !parseEthMethodInputData(dbAsset.vchBurnMethodSignature, rlpBytes, outputAmount, nAsset, witnessAddress)){
         errorMessage = "SYSCOIN_ASSET_ALLOCATION_CONSENSUS_ERROR ERRCODE: 1001 - " + _("Could not parse and validate transaction data");
         return state.DoS(100, false, REJECT_INVALID, errorMessage);
     }
-    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT_SYSCOIN) {
+    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT) {
         int witnessversion;
         std::vector<unsigned char> witnessprogram;
         if (tx.vout[0].scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)){
@@ -663,30 +661,30 @@ bool CheckSyscoinMint(const bool ibd, const CTransaction& tx, CValidationState& 
         } 
        
     }
-    else if(tx.nVersion == SYSCOIN_TX_VERSION_MINT_ASSET)
+    else if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT)
     {
         if(witnessAddress != mintSyscoin.assetAllocationTuple.witnessAddress){
             errorMessage = "SYSCOIN_ASSET_ALLOCATION_CONSENSUS_ERROR ERRCODE: 1001 - " + _("Minting address does not match address passed into burn function");
             return state.DoS(100, false, REJECT_INVALID, errorMessage);
         }
     }    
-    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT_SYSCOIN && nAsset != 0){
+    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT && nAsset != 0){
         errorMessage = "SYSCOIN_ASSET_ALLOCATION_CONSENSUS_ERROR ERRCODE: 1001 - " + _("Cannot mint an asset in a syscoin mint operation");
         return state.DoS(100, false, REJECT_INVALID, errorMessage);
     }
-    else if(tx.nVersion == SYSCOIN_TX_VERSION_MINT_ASSET && nAsset != dbAsset.nAsset){
+    else if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT && nAsset != dbAsset.nAsset){
         errorMessage = "SYSCOIN_ASSET_ALLOCATION_CONSENSUS_ERROR ERRCODE: 1001 - " + _("Invalid asset being minted, does not match asset GUID encoded in transaction data");
         return state.DoS(100, false, REJECT_INVALID, errorMessage);
     }
-    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT_SYSCOIN && outputAmount != tx.vout[0].nValue){
+    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT && outputAmount != tx.vout[0].nValue){
         errorMessage = "SYSCOIN_ASSET_ALLOCATION_CONSENSUS_ERROR ERRCODE: 1001 - " + _("Burn amount must match mint amount");
         return state.DoS(100, false, REJECT_INVALID, errorMessage);
     }
-    else if(tx.nVersion == SYSCOIN_TX_VERSION_MINT_ASSET && outputAmount != mintSyscoin.nValueAsset){
+    else if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT && outputAmount != mintSyscoin.nValueAsset){
         errorMessage = "SYSCOIN_ASSET_ALLOCATION_CONSENSUS_ERROR ERRCODE: 1001 - " + _("Burn amount must match asset mint amount");
         return state.DoS(100, false, REJECT_INVALID, errorMessage);
     }  
-    if(tx.nVersion == SYSCOIN_TX_VERSION_MINT_ASSET){
+    if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT){
         if(outputAmount <= 0){
             errorMessage = "SYSCOIN_ASSET_ALLOCATION_CONSENSUS_ERROR ERRCODE: 1001 - " + _("Burn amount must be positive");
             return state.DoS(100, false, REJECT_INVALID, errorMessage);
@@ -739,36 +737,35 @@ bool CheckSyscoinInputs(const bool ibd, const CTransaction& tx, CValidationState
 {
     AssetAllocationMap mapAssetAllocations;
     AssetMap mapAssets;
-    std::vector<std::vector<unsigned char> > vvchArgs;
-    int op;
+  
     if (nHeight == 0)
         nHeight = chainActive.Height()+1;   
     std::string errorMessage;
     bool good = true;
+    if(!IsSyscoinTx(tx.nVersion))
+        return true;
     bOverflow=false;
     if (block.vtx.empty()) {
         if(tx.IsCoinBase())
             return true;
-        if (tx.nVersion == SYSCOIN_TX_VERSION_ASSET)
+       
+        if (IsAssetAllocationTx(tx.nVersion))
         {
-            if (DecodeAssetAllocationTx(tx, op, vvchArgs))
-            {
-                errorMessage.clear();
-                good = CheckAssetAllocationInputs(tx, inputs, op, vvchArgs, fJustCheck, nHeight, mapAssetAllocations,errorMessage, bOverflow, bSanity);
-            }
-            else if (DecodeAssetTx(tx, op, vvchArgs))
-            {
-                errorMessage.clear();
-                good = CheckAssetInputs(tx, inputs, op, vvchArgs, fJustCheck, nHeight, mapAssets, mapAssetAllocations, errorMessage, bSanity);
-            }
-      
-            if (!good || !errorMessage.empty())
-                return state.DoS(100, false, REJECT_INVALID, errorMessage);
-          
-            return true;
+            errorMessage.clear();
+            good = CheckAssetAllocationInputs(tx, inputs, fJustCheck, nHeight, mapAssetAllocations,errorMessage, bOverflow, bSanity);
         }
-        else if(tx.nVersion == SYSCOIN_TX_VERSION_MINT_SYSCOIN || tx.nVersion == SYSCOIN_TX_VERSION_MINT_ASSET) 
+        else if (IsAssetTx(tx.nVersion))
+        {
+            errorMessage.clear();
+            good = CheckAssetInputs(tx, inputs, fJustCheck, nHeight, mapAssets, mapAssetAllocations, errorMessage, bSanity);
+        }
+        else  if(IsSyscoinMintTx(tx.nVersion)) 
             return CheckSyscoinMint(ibd, tx, state, fJustCheck, nHeight, mapAssets, mapAssetAllocations);
+  
+        if (!good || !errorMessage.empty())
+            return state.DoS(100, false, REJECT_INVALID, errorMessage);
+      
+        return true;
     }
     else if (!block.vtx.empty()) {
     
@@ -784,23 +781,22 @@ bool CheckSyscoinInputs(const bool ibd, const CTransaction& tx, CValidationState
                     return state.DoS(0, false, REJECT_INVALID, "Could not write block hash to asset index db");
                 }
             }                
-            if((tx.nVersion == SYSCOIN_TX_VERSION_MINT_SYSCOIN || tx.nVersion == SYSCOIN_TX_VERSION_MINT_ASSET) && !CheckSyscoinMint(ibd, tx, state, false, nHeight, mapAssets, mapAssetAllocations))
-                return state.DoS(100, error("%s: check syscoin mint", __func__), REJECT_INVALID, FormatStateMessage(state));
-            else if (tx.nVersion != SYSCOIN_TX_VERSION_ASSET)
-                continue;
         
-            if (DecodeAssetAllocationTx(tx, op, vvchArgs))
+            if (IsAssetAllocationTx(tx.nVersion))
             {
                 errorMessage.clear();
                 // fJustCheck inplace of bSanity to preserve global structures from being changed during test calls, fJustCheck is actually passed in as false because we want to check in PoW mode
-                good = CheckAssetAllocationInputs(tx, inputs, op, vvchArgs, false, nHeight, mapAssetAllocations, errorMessage, bOverflow, fJustCheck, bMiner);
+                good = CheckAssetAllocationInputs(tx, inputs, false, nHeight, mapAssetAllocations, errorMessage, bOverflow, fJustCheck, bMiner);
 
             }
-            else if (DecodeAssetTx(tx, op, vvchArgs))
+            else if (IsAssetTx(tx.nVersion))
             {
                 errorMessage.clear();
-                good = CheckAssetInputs(tx, inputs, op, vvchArgs, false, nHeight, mapAssets, mapAssetAllocations, errorMessage, fJustCheck);
-            }                         
+                good = CheckAssetInputs(tx, inputs, false, nHeight, mapAssets, mapAssetAllocations, errorMessage, fJustCheck);
+            } 
+            else  if(IsSyscoinMintTx(tx.nVersion) && !CheckSyscoinMint(ibd, tx, state, false, nHeight, mapAssets, mapAssetAllocations))
+                return state.DoS(100, error("%s: check syscoin mint", __func__), REJECT_INVALID, FormatStateMessage(state));
+                        
             if (!good)
             {
                 if (!errorMessage.empty()) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -742,10 +742,12 @@ bool CheckSyscoinInputs(const bool ibd, const CTransaction& tx, CValidationState
         nHeight = chainActive.Height()+1;   
     std::string errorMessage;
     bool good = true;
-    if(!IsSyscoinTx(tx.nVersion))
-        return true;
+
     bOverflow=false;
     if (block.vtx.empty()) {
+        if(!IsSyscoinTx(tx.nVersion))
+            return true;
+        
         if(tx.IsCoinBase())
             return true;
        
@@ -768,20 +770,18 @@ bool CheckSyscoinInputs(const bool ibd, const CTransaction& tx, CValidationState
         return true;
     }
     else if (!block.vtx.empty()) {
-    
         for (unsigned int i = 0; i < block.vtx.size(); i++)
         {
 
             good = true;
-            const CTransaction &tx = *(block.vtx[i]);
-            if(tx.IsCoinBase())
-                continue;
+            const CTransaction &tx = *(block.vtx[i]);        
             if(fAssetIndex){
                 if(!passetindexdb->WriteBlockHash(tx.GetHash(), block.GetHash())){
                     return state.DoS(0, false, REJECT_INVALID, "Could not write block hash to asset index db");
                 }
             }                
-        
+            if(!IsSyscoinTx(tx.nVersion))
+                continue;      
             if (IsAssetAllocationTx(tx.nVersion))
             {
                 errorMessage.clear();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4585,7 +4585,7 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
     LogPrintf("[0%%]..."); /* Continued */
     for (pindex = chainActive.Tip(); pindex && pindex->pprev; pindex = pindex->pprev) {
         boost::this_thread::interruption_point();
-        int percentageDone = std::max(1, std::min(99, (int)(((double)(chainActive.Height() - pindex->nHeight)) / (double)nCheckDepth * (nCheckLevel >= 4 ? 50 : 100))));
+        const int percentageDone = std::max(1, std::min(99, (int)(((double)(chainActive.Height() - pindex->nHeight)) / (double)nCheckDepth * (nCheckLevel >= 4 ? 50 : 100))));
         if (reportDone < percentageDone/10) {
             // report every 10% step
             LogPrintf("[%d%%]...", percentageDone); /* Continued */
@@ -4643,7 +4643,13 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
     if (nCheckLevel >= 4) {
         while (pindex != chainActive.Tip()) {
             boost::this_thread::interruption_point();
-            uiInterface.ShowProgress(_("Verifying blocks..."), std::max(1, std::min(99, 100 - (int)(((double)(chainActive.Height() - pindex->nHeight)) / (double)nCheckDepth * 50))), false);
+            const int percentageDone = std::max(1, std::min(99, 100 - (int)(((double)(chainActive.Height() - pindex->nHeight)) / (double)nCheckDepth * 50)));
+            if (reportDone < percentageDone/10) {
+                // report every 10% step
+                LogPrintf("[%d%%]...", percentageDone); /* Continued */
+                reportDone = percentageDone/10;
+            }
+            uiInterface.ShowProgress(_("Verifying blocks..."), percentageDone, false);
             pindex = chainActive.Next(pindex);
             CBlock block;
             if (!ReadBlockFromDisk(block, pindex, chainparams.GetConsensus()))

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -80,8 +80,7 @@ bool IsWalletLoaded(const fs::path& wallet_path)
     LOCK(cs_db);
     auto env = g_dbenvs.find(env_directory.string());
     if (env == g_dbenvs.end()) return false;
-    auto db = env->second.m_databases.find(database_filename);
-    return db != env->second.m_databases.end();
+    return env->second.IsDatabaseLoaded(database_filename);
 }
 
 BerkeleyEnvironment* GetWalletEnv(const fs::path& wallet_path, std::string& database_filename)

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -84,6 +84,13 @@ bool IsWalletLoaded(const fs::path& wallet_path)
     return database && database->IsDatabaseLoaded(database_filename);
 }
 
+/**
+ * @param[in] wallet_path Path to wallet directory. Or (for backwards compatibility only) a path to a berkeley btree data file inside a wallet directory.
+ * @param[out] database_filename Filename of berkeley btree data file inside the wallet directory.
+ * @return A shared pointer to the BerkeleyEnvironment object for the wallet directory, never empty because ~BerkeleyEnvironment
+ * erases the weak pointer from the g_dbenvs map.
+ * @post A new BerkeleyEnvironment weak pointer is inserted into g_dbenvs if the directory path key was not already in the map.
+ */
 std::shared_ptr<BerkeleyEnvironment> GetWalletEnv(const fs::path& wallet_path, std::string& database_filename)
 {
     fs::path env_directory;
@@ -218,6 +225,7 @@ bool BerkeleyEnvironment::Open(bool retry)
     return true;
 }
 
+//! Construct an in-memory mock Berkeley environment for testing and as a place-holder for g_dbenvs emplace
 BerkeleyEnvironment::BerkeleyEnvironment()
 {
     Reset();

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -126,11 +126,16 @@ void BerkeleyEnvironment::Close()
         }
     }
 
+    FILE* error_file = nullptr;
+    dbenv->get_errfile(&error_file);
+
     int ret = dbenv->close(0);
     if (ret != 0)
         LogPrintf("BerkeleyEnvironment::Close: Error %d closing database environment: %s\n", ret, DbEnv::strerror(ret));
     if (!fMockDb)
         DbEnv((u_int32_t)0).remove(strPath.c_str(), 0);
+
+    if (error_file) fclose(error_file);
 }
 
 void BerkeleyEnvironment::Reset()

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -724,7 +724,6 @@ void BerkeleyEnvironment::Flush(bool fShutdown)
                 if (!fMockDb) {
                     fs::remove_all(fs::path(strPath) / "database");
                 }
-                g_dbenvs.erase(strPath);
             }
         }
     }
@@ -823,7 +822,11 @@ void BerkeleyDatabase::Flush(bool shutdown)
 {
     if (!IsDummy()) {
         env->Flush(shutdown);
-        if (shutdown) env = nullptr;
+        if (shutdown) {
+            LOCK(cs_db);
+            g_dbenvs.erase(env->Directory().string());
+            env = nullptr;
+        }
     }
 }
 

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -556,6 +556,7 @@ void BerkeleyBatch::Close()
         LOCK(cs_db);
         --env->mapFileUseCount[strFile];
     }
+    env->m_db_in_use.notify_all();
 }
 
 void BerkeleyEnvironment::CloseDb(const std::string& strFile)
@@ -570,6 +571,32 @@ void BerkeleyEnvironment::CloseDb(const std::string& strFile)
             mapDb[strFile] = nullptr;
         }
     }
+}
+
+void BerkeleyEnvironment::ReloadDbEnv()
+{
+    // Make sure that no Db's are in use
+    AssertLockNotHeld(cs_db);
+    std::unique_lock<CCriticalSection> lock(cs_db);
+    m_db_in_use.wait(lock, [this](){
+        for (auto& count : mapFileUseCount) {
+            if (count.second > 0) return false;
+        }
+        return true;
+    });
+
+    std::vector<std::string> filenames;
+    for (auto it : mapDb) {
+        filenames.push_back(it.first);
+    }
+    // Close the individual Db's
+    for (const std::string& filename : filenames) {
+        CloseDb(filename);
+    }
+    // Reset the environment
+    Flush(true); // This will flush and close the environment
+    Reset();
+    Open(true);
 }
 
 bool BerkeleyBatch::Rewrite(BerkeleyDatabase& database, const char* pszSkip)
@@ -797,5 +824,12 @@ void BerkeleyDatabase::Flush(bool shutdown)
     if (!IsDummy()) {
         env->Flush(shutdown);
         if (shutdown) env = nullptr;
+    }
+}
+
+void BerkeleyDatabase::ReloadDbEnv()
+{
+    if (!IsDummy()) {
+        env->ReloadDbEnv();
     }
 }

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -20,6 +20,7 @@
 #include <boost/thread.hpp>
 
 namespace {
+
 //! Make sure database has a unique fileid within the environment. If it
 //! doesn't, throw an error. BDB caches do not work properly when more than one
 //! open database has the same fileid (values written to one database may show
@@ -29,25 +30,19 @@ namespace {
 //! (https://docs.oracle.com/cd/E17275_01/html/programmer_reference/program_copy.html),
 //! so syscoin should never create different databases with the same fileid, but
 //! this error can be triggered if users manually copy database files.
-void CheckUniqueFileid(const BerkeleyEnvironment& env, const std::string& filename, Db& db)
+void CheckUniqueFileid(const BerkeleyEnvironment& env, const std::string& filename, Db& db, WalletDatabaseFileId& fileid)
 {
     if (env.IsMock()) return;
 
-    u_int8_t fileid[DB_FILE_ID_LEN];
-    int ret = db.get_mpf()->get_fileid(fileid);
+    int ret = db.get_mpf()->get_fileid(fileid.value);
     if (ret != 0) {
         throw std::runtime_error(strprintf("BerkeleyBatch: Can't open database %s (get_fileid failed with %d)", filename, ret));
     }
 
-    for (const auto& item : env.mapDb) {
-        u_int8_t item_fileid[DB_FILE_ID_LEN];
-        if (item.second && item.second->get_mpf()->get_fileid(item_fileid) == 0 &&
-            memcmp(fileid, item_fileid, sizeof(fileid)) == 0) {
-            const char* item_filename = nullptr;
-            item.second->get_dbname(&item_filename, nullptr);
+    for (const auto& item : env.m_fileids) {
+        if (fileid == item.second && &fileid != &item.second) {
             throw std::runtime_error(strprintf("BerkeleyBatch: Can't open database %s (duplicates fileid %s from %s)", filename,
-                HexStr(std::begin(item_fileid), std::end(item_fileid)),
-                item_filename ? item_filename : "(unknown database)"));
+                HexStr(std::begin(item.second.value), std::end(item.second.value)), item.first));
         }
     }
 }
@@ -55,6 +50,11 @@ void CheckUniqueFileid(const BerkeleyEnvironment& env, const std::string& filena
 CCriticalSection cs_db;
 std::map<std::string, BerkeleyEnvironment> g_dbenvs GUARDED_BY(cs_db); //!< Map from directory name to open db environment.
 } // namespace
+
+bool WalletDatabaseFileId::operator==(const WalletDatabaseFileId& rhs) const
+{
+    return memcmp(value, &rhs.value, sizeof(value)) == 0;
+}
 
 BerkeleyEnvironment* GetWalletEnv(const fs::path& wallet_path, std::string& database_filename)
 {
@@ -504,7 +504,7 @@ BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bo
             // versions of BDB have an set_lk_exclusive method for this
             // purpose, but the older version we use does not.)
             for (auto& env : g_dbenvs) {
-                CheckUniqueFileid(env.second, strFilename, *pdb_temp);
+                CheckUniqueFileid(env.second, strFilename, *pdb_temp, this->env->m_fileids[strFilename]);
             }
 
             pdb = pdb_temp.release();
@@ -826,6 +826,13 @@ void BerkeleyDatabase::Flush(bool shutdown)
             LOCK(cs_db);
             g_dbenvs.erase(env->Directory().string());
             env = nullptr;
+        } else {
+            // TODO: To avoid g_dbenvs.erase erasing the environment prematurely after the
+            // first database shutdown when multiple databases are open in the same
+            // environment, should replace raw database `env` pointers with shared or weak
+            // pointers, or else separate the database and environment shutdowns so
+            // environments can be shut down after databases.
+            env->m_fileids.erase(strFile);
         }
     }
 }

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -56,9 +56,8 @@ bool WalletDatabaseFileId::operator==(const WalletDatabaseFileId& rhs) const
     return memcmp(value, &rhs.value, sizeof(value)) == 0;
 }
 
-BerkeleyEnvironment* GetWalletEnv(const fs::path& wallet_path, std::string& database_filename)
+static void SplitWalletPath(const fs::path& wallet_path, fs::path& env_directory, std::string& database_filename)
 {
-    fs::path env_directory;
     if (fs::is_regular_file(wallet_path)) {
         // Special case for backwards compatibility: if wallet path points to an
         // existing file, treat it as the path to a BDB data file in a parent
@@ -71,6 +70,24 @@ BerkeleyEnvironment* GetWalletEnv(const fs::path& wallet_path, std::string& data
         env_directory = wallet_path;
         database_filename = "wallet.dat";
     }
+}
+
+bool IsWalletLoaded(const fs::path& wallet_path)
+{
+    fs::path env_directory;
+    std::string database_filename;
+    SplitWalletPath(wallet_path, env_directory, database_filename);
+    LOCK(cs_db);
+    auto env = g_dbenvs.find(env_directory.string());
+    if (env == g_dbenvs.end()) return false;
+    auto db = env->second.m_databases.find(database_filename);
+    return db != env->second.m_databases.end();
+}
+
+BerkeleyEnvironment* GetWalletEnv(const fs::path& wallet_path, std::string& database_filename)
+{
+    fs::path env_directory;
+    SplitWalletPath(wallet_path, env_directory, database_filename);
     LOCK(cs_db);
     // Note: An ununsed temporary BerkeleyEnvironment object may be created inside the
     // emplace function if the key already exists. This is a little inefficient,

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -48,7 +48,7 @@ void CheckUniqueFileid(const BerkeleyEnvironment& env, const std::string& filena
 }
 
 CCriticalSection cs_db;
-std::map<std::string, BerkeleyEnvironment> g_dbenvs GUARDED_BY(cs_db); //!< Map from directory name to open db environment.
+std::map<std::string, std::weak_ptr<BerkeleyEnvironment>> g_dbenvs GUARDED_BY(cs_db); //!< Map from directory name to db environment.
 } // namespace
 
 bool WalletDatabaseFileId::operator==(const WalletDatabaseFileId& rhs) const
@@ -80,19 +80,22 @@ bool IsWalletLoaded(const fs::path& wallet_path)
     LOCK(cs_db);
     auto env = g_dbenvs.find(env_directory.string());
     if (env == g_dbenvs.end()) return false;
-    return env->second.IsDatabaseLoaded(database_filename);
+    auto database = env->second.lock();
+    return database && database->IsDatabaseLoaded(database_filename);
 }
 
-BerkeleyEnvironment* GetWalletEnv(const fs::path& wallet_path, std::string& database_filename)
+std::shared_ptr<BerkeleyEnvironment> GetWalletEnv(const fs::path& wallet_path, std::string& database_filename)
 {
     fs::path env_directory;
     SplitWalletPath(wallet_path, env_directory, database_filename);
     LOCK(cs_db);
-    // Note: An ununsed temporary BerkeleyEnvironment object may be created inside the
-    // emplace function if the key already exists. This is a little inefficient,
-    // but not a big concern since the map will be changed in the future to hold
-    // pointers instead of objects, anyway.
-    return &g_dbenvs.emplace(std::piecewise_construct, std::forward_as_tuple(env_directory.string()), std::forward_as_tuple(env_directory)).first->second;
+    auto inserted = g_dbenvs.emplace(env_directory.string(), std::weak_ptr<BerkeleyEnvironment>());
+    if (inserted.second) {
+        auto env = std::make_shared<BerkeleyEnvironment>(env_directory.string());
+        inserted.first->second = env;
+        return env;
+    }
+    return inserted.first->second.lock();
 }
 
 //
@@ -137,6 +140,7 @@ BerkeleyEnvironment::BerkeleyEnvironment(const fs::path& dir_path) : strPath(dir
 
 BerkeleyEnvironment::~BerkeleyEnvironment()
 {
+    g_dbenvs.erase(strPath);
     Close();
 }
 
@@ -214,10 +218,9 @@ bool BerkeleyEnvironment::Open(bool retry)
     return true;
 }
 
-void BerkeleyEnvironment::MakeMock()
+BerkeleyEnvironment::BerkeleyEnvironment()
 {
-    if (fDbEnvInit)
-        throw std::runtime_error("BerkeleyEnvironment::MakeMock: Already initialized");
+    Reset();
 
     boost::this_thread::interruption_point();
 
@@ -266,7 +269,7 @@ BerkeleyEnvironment::VerifyResult BerkeleyEnvironment::Verify(const std::string&
 bool BerkeleyBatch::Recover(const fs::path& file_path, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue), std::string& newFilename)
 {
     std::string filename;
-    BerkeleyEnvironment* env = GetWalletEnv(file_path, filename);
+    std::shared_ptr<BerkeleyEnvironment> env = GetWalletEnv(file_path, filename);
 
     // Recovery procedure:
     // move wallet file to walletfilename.timestamp.bak
@@ -335,7 +338,7 @@ bool BerkeleyBatch::Recover(const fs::path& file_path, void *callbackDataIn, boo
 bool BerkeleyBatch::VerifyEnvironment(const fs::path& file_path, std::string& errorStr)
 {
     std::string walletFile;
-    BerkeleyEnvironment* env = GetWalletEnv(file_path, walletFile);
+    std::shared_ptr<BerkeleyEnvironment> env = GetWalletEnv(file_path, walletFile);
     fs::path walletDir = env->Directory();
 
     LogPrintf("Using BerkeleyDB version %s\n", DbEnv::version(0, 0, 0));
@@ -359,7 +362,7 @@ bool BerkeleyBatch::VerifyEnvironment(const fs::path& file_path, std::string& er
 bool BerkeleyBatch::VerifyDatabaseFile(const fs::path& file_path, std::string& warningStr, std::string& errorStr, BerkeleyEnvironment::recoverFunc_type recoverFunc)
 {
     std::string walletFile;
-    BerkeleyEnvironment* env = GetWalletEnv(file_path, walletFile);
+    std::shared_ptr<BerkeleyEnvironment> env = GetWalletEnv(file_path, walletFile);
     fs::path walletDir = env->Directory();
 
     if (fs::exists(walletDir / walletFile))
@@ -463,7 +466,7 @@ BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bo
 {
     fReadOnly = (!strchr(pszMode, '+') && !strchr(pszMode, 'w'));
     fFlushOnClose = fFlushOnCloseIn;
-    env = database.env;
+    env = database.env.get();
     if (database.IsDummy()) {
         return;
     }
@@ -520,7 +523,7 @@ BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bo
             // versions of BDB have an set_lk_exclusive method for this
             // purpose, but the older version we use does not.)
             for (auto& env : g_dbenvs) {
-                CheckUniqueFileid(env.second, strFilename, *pdb_temp, this->env->m_fileids[strFilename]);
+                CheckUniqueFileid(*env.second.lock().get(), strFilename, *pdb_temp, this->env->m_fileids[strFilename]);
             }
 
             pdb = pdb_temp.release();
@@ -621,7 +624,7 @@ bool BerkeleyBatch::Rewrite(BerkeleyDatabase& database, const char* pszSkip)
     if (database.IsDummy()) {
         return true;
     }
-    BerkeleyEnvironment *env = database.env;
+    BerkeleyEnvironment *env = database.env.get();
     const std::string& strFile = database.strFile;
     while (true) {
         {
@@ -752,7 +755,7 @@ bool BerkeleyBatch::PeriodicFlush(BerkeleyDatabase& database)
         return true;
     }
     bool ret = false;
-    BerkeleyEnvironment *env = database.env;
+    BerkeleyEnvironment *env = database.env.get();
     const std::string& strFile = database.strFile;
     TRY_LOCK(cs_db, lockDb);
     if (lockDb)

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -136,6 +136,8 @@ void BerkeleyEnvironment::Close()
         DbEnv((u_int32_t)0).remove(strPath.c_str(), 0);
 
     if (error_file) fclose(error_file);
+
+    UnlockDirectory(strPath, ".walletlock");
 }
 
 void BerkeleyEnvironment::Reset()

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -56,6 +56,7 @@ public:
     void MakeMock();
     bool IsMock() const { return fMockDb; }
     bool IsInitialized() const { return fDbEnvInit; }
+    bool IsDatabaseLoaded(const std::string& db_filename) const { return m_databases.find(db_filename) != m_databases.end(); }
     fs::path Directory() const { return strPath; }
 
     /**

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -18,12 +18,18 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <db_cxx.h>
 
 static const unsigned int DEFAULT_WALLET_DBLOGSIZE = 100;
 static const bool DEFAULT_WALLET_PRIVDB = true;
+
+struct WalletDatabaseFileId {
+    u_int8_t value[DB_FILE_ID_LEN];
+    bool operator==(const WalletDatabaseFileId& rhs) const;
+};
 
 class BerkeleyEnvironment
 {
@@ -38,6 +44,7 @@ public:
     std::unique_ptr<DbEnv> dbenv;
     std::map<std::string, int> mapFileUseCount;
     std::map<std::string, Db*> mapDb;
+    std::unordered_map<std::string, WalletDatabaseFileId> m_fileids;
     std::condition_variable_any m_db_in_use;
 
     BerkeleyEnvironment(const fs::path& env_directory);

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -38,6 +38,7 @@ public:
     std::unique_ptr<DbEnv> dbenv;
     std::map<std::string, int> mapFileUseCount;
     std::map<std::string, Db*> mapDb;
+    std::condition_variable_any m_db_in_use;
 
     BerkeleyEnvironment(const fs::path& env_directory);
     ~BerkeleyEnvironment();
@@ -75,6 +76,7 @@ public:
     void CheckpointLSN(const std::string& strFile);
 
     void CloseDb(const std::string& strFile);
+    void ReloadDbEnv();
 
     DbTxn* TxnBegin(int flags = DB_TXN_WRITE_NOSYNC)
     {
@@ -144,6 +146,8 @@ public:
     void Flush(bool shutdown);
 
     void IncrementUpdateCounter();
+
+    void ReloadDbEnv();
 
     std::atomic<unsigned int> nUpdateCounter;
     unsigned int nLastSeen;

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -50,10 +50,10 @@ public:
     std::condition_variable_any m_db_in_use;
 
     BerkeleyEnvironment(const fs::path& env_directory);
+    BerkeleyEnvironment();
     ~BerkeleyEnvironment();
     void Reset();
 
-    void MakeMock();
     bool IsMock() const { return fMockDb; }
     bool IsInitialized() const { return fDbEnvInit; }
     bool IsDatabaseLoaded(const std::string& db_filename) const { return m_databases.find(db_filename) != m_databases.end(); }
@@ -102,7 +102,7 @@ public:
 bool IsWalletLoaded(const fs::path& wallet_path);
 
 /** Get BerkeleyEnvironment and database filename given a wallet path. */
-BerkeleyEnvironment* GetWalletEnv(const fs::path& wallet_path, std::string& database_filename);
+std::shared_ptr<BerkeleyEnvironment> GetWalletEnv(const fs::path& wallet_path, std::string& database_filename);
 
 /** An instance of this class represents one database.
  * For BerkeleyDB this is just a (env, strFile) tuple.
@@ -117,17 +117,11 @@ public:
     }
 
     /** Create DB handle to real database */
-    BerkeleyDatabase(const fs::path& wallet_path, bool mock = false) :
-        nUpdateCounter(0), nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0)
+    BerkeleyDatabase(std::shared_ptr<BerkeleyEnvironment> env, std::string filename) :
+        nUpdateCounter(0), nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0), env(std::move(env)), strFile(std::move(filename))
     {
-        env = GetWalletEnv(wallet_path, strFile);
-        auto inserted = env->m_databases.emplace(strFile, std::ref(*this));
+        auto inserted = this->env->m_databases.emplace(strFile, std::ref(*this));
         assert(inserted.second);
-        if (mock) {
-            env->Close();
-            env->Reset();
-            env->MakeMock();
-        }
     }
 
     ~BerkeleyDatabase() {
@@ -140,7 +134,8 @@ public:
     /** Return object for accessing database at specified path. */
     static std::unique_ptr<BerkeleyDatabase> Create(const fs::path& path)
     {
-        return MakeUnique<BerkeleyDatabase>(path);
+        std::string filename;
+        return MakeUnique<BerkeleyDatabase>(GetWalletEnv(path, filename), std::move(filename));
     }
 
     /** Return object for accessing dummy database with no read/write capabilities. */
@@ -152,7 +147,7 @@ public:
     /** Return object for accessing temporary in-memory database. */
     static std::unique_ptr<BerkeleyDatabase> CreateMock()
     {
-        return MakeUnique<BerkeleyDatabase>("", true /* mock */);
+        return MakeUnique<BerkeleyDatabase>(std::make_shared<BerkeleyEnvironment>(), "");
     }
 
     /** Rewrite the entire database on disk, with the exception of key pszSkip if non-zero
@@ -176,12 +171,21 @@ public:
     unsigned int nLastFlushed;
     int64_t nLastWalletUpdate;
 
+    /**
+     * Pointer to shared database environment.
+     *
+     * Normally there is only one BerkeleyDatabase object per
+     * BerkeleyEnvivonment, but in the special, backwards compatible case where
+     * multiple wallet BDB data files are loaded from the same directory, this
+     * will point to a shared instance that gets freed when the last data file
+     * is closed.
+     */
+    std::shared_ptr<BerkeleyEnvironment> env;
+
     /** Database pointer. This is initialized lazily and reset during flushes, so it can be null. */
     std::unique_ptr<Db> m_db;
 
 private:
-    /** BerkeleyDB specific */
-    BerkeleyEnvironment *env;
     std::string strFile;
 
     /** Return whether this database handle is a dummy for testing.

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -31,6 +31,8 @@ struct WalletDatabaseFileId {
     bool operator==(const WalletDatabaseFileId& rhs) const;
 };
 
+class BerkeleyDatabase;
+
 class BerkeleyEnvironment
 {
 private:
@@ -43,7 +45,7 @@ private:
 public:
     std::unique_ptr<DbEnv> dbenv;
     std::map<std::string, int> mapFileUseCount;
-    std::map<std::string, Db*> mapDb;
+    std::map<std::string, std::reference_wrapper<BerkeleyDatabase>> m_databases;
     std::unordered_map<std::string, WalletDatabaseFileId> m_fileids;
     std::condition_variable_any m_db_in_use;
 
@@ -118,10 +120,19 @@ public:
         nUpdateCounter(0), nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0)
     {
         env = GetWalletEnv(wallet_path, strFile);
+        auto inserted = env->m_databases.emplace(strFile, std::ref(*this));
+        assert(inserted.second);
         if (mock) {
             env->Close();
             env->Reset();
             env->MakeMock();
+        }
+    }
+
+    ~BerkeleyDatabase() {
+        if (env) {
+            size_t erased = env->m_databases.erase(strFile);
+            assert(erased == 1);
         }
     }
 
@@ -163,6 +174,9 @@ public:
     unsigned int nLastSeen;
     unsigned int nLastFlushed;
     int64_t nLastWalletUpdate;
+
+    /** Database pointer. This is initialized lazily and reset during flushes, so it can be null. */
+    std::unique_ptr<Db> m_db;
 
 private:
     /** BerkeleyDB specific */

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -95,6 +95,9 @@ public:
     }
 };
 
+/** Return whether a wallet database is currently loaded. */
+bool IsWalletLoaded(const fs::path& wallet_path);
+
 /** Get BerkeleyEnvironment and database filename given a wallet path. */
 BerkeleyEnvironment* GetWalletEnv(const fs::path& wallet_path, std::string& database_filename);
 

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -203,15 +203,15 @@ bool WalletInit::Verify() const
     std::set<fs::path> wallet_paths;
 
     for (const auto& wallet_file : wallet_files) {
-        fs::path wallet_path = fs::absolute(wallet_file, GetWalletDir());
+        WalletLocation location(wallet_file);
 
-        if (!wallet_paths.insert(wallet_path).second) {
+        if (!wallet_paths.insert(location.GetPath()).second) {
             return InitError(strprintf(_("Error loading wallet %s. Duplicate -wallet filename specified."), wallet_file));
         }
 
         std::string error_string;
         std::string warning_string;
-        bool verify_success = CWallet::Verify(wallet_file, salvage_wallet, error_string, warning_string);
+        bool verify_success = CWallet::Verify(location, salvage_wallet, error_string, warning_string);
         if (!error_string.empty()) InitError(error_string);
         if (!warning_string.empty()) InitWarning(warning_string);
         if (!verify_success) return false;
@@ -228,7 +228,7 @@ bool WalletInit::Open() const
     }
 
     for (const std::string& walletFile : gArgs.GetArgs("-wallet")) {
-        std::shared_ptr<CWallet> pwallet = CWallet::CreateWalletFromFile(walletFile, fs::absolute(walletFile, GetWalletDir()));
+        std::shared_ptr<CWallet> pwallet = CWallet::CreateWalletFromFile(WalletLocation(walletFile));
         if (!pwallet) {
             return false;
         }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3126,26 +3126,26 @@ static UniValue loadwallet(const JSONRPCRequest& request)
             + HelpExampleCli("loadwallet", "\"test.dat\"")
             + HelpExampleRpc("loadwallet", "\"test.dat\"")
         );
-    std::string wallet_file = request.params[0].get_str();
+
+    WalletLocation location(request.params[0].get_str());
     std::string error;
 
-    fs::path wallet_path = fs::absolute(wallet_file, GetWalletDir());
-    if (fs::symlink_status(wallet_path).type() == fs::file_not_found) {
-        throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Wallet " + wallet_file + " not found.");
-    } else if (fs::is_directory(wallet_path)) {
+    if (!location.Exists()) {
+        throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Wallet " + location.GetName() + " not found.");
+    } else if (fs::is_directory(location.GetPath())) {
         // The given filename is a directory. Check that there's a wallet.dat file.
-        fs::path wallet_dat_file = wallet_path / "wallet.dat";
+        fs::path wallet_dat_file = location.GetPath() / "wallet.dat";
         if (fs::symlink_status(wallet_dat_file).type() == fs::file_not_found) {
-            throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Directory " + wallet_file + " does not contain a wallet.dat file.");
+            throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Directory " + location.GetName() + " does not contain a wallet.dat file.");
         }
     }
 
     std::string warning;
-    if (!CWallet::Verify(wallet_file, false, error, warning)) {
+    if (!CWallet::Verify(location, false, error, warning)) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Wallet file verification failed: " + error);
     }
 
-    std::shared_ptr<CWallet> const wallet = CWallet::CreateWalletFromFile(wallet_file, fs::absolute(wallet_file, GetWalletDir()));
+    std::shared_ptr<CWallet> const wallet = CWallet::CreateWalletFromFile(location);
     if (!wallet) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Wallet loading failed.");
     }
@@ -3179,7 +3179,6 @@ static UniValue createwallet(const JSONRPCRequest& request)
             + HelpExampleRpc("createwallet", "\"testwallet\"")
         );
     }
-    std::string wallet_name = request.params[0].get_str();
     std::string error;
     std::string warning;
 
@@ -3188,17 +3187,17 @@ static UniValue createwallet(const JSONRPCRequest& request)
         disable_privatekeys = request.params[1].get_bool();
     }
 
-    fs::path wallet_path = fs::absolute(wallet_name, GetWalletDir());
-    if (fs::symlink_status(wallet_path).type() != fs::file_not_found) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Wallet " + wallet_name + " already exists.");
+    WalletLocation location(request.params[0].get_str());
+    if (location.Exists()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "Wallet " + location.GetName() + " already exists.");
     }
 
     // Wallet::Verify will check if we're trying to create a wallet with a duplication name.
-    if (!CWallet::Verify(wallet_name, false, error, warning)) {
+    if (!CWallet::Verify(location, false, error, warning)) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Wallet file verification failed: " + error);
     }
 
-    std::shared_ptr<CWallet> const wallet = CWallet::CreateWalletFromFile(wallet_name, fs::absolute(wallet_name, GetWalletDir()), (disable_privatekeys ? (uint64_t)WALLET_FLAG_DISABLE_PRIVATE_KEYS : 0));
+    std::shared_ptr<CWallet> const wallet = CWallet::CreateWalletFromFile(location, (disable_privatekeys ? (uint64_t)WALLET_FLAG_DISABLE_PRIVATE_KEYS : 0));
     if (!wallet) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Wallet creation failed.");
     }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2754,7 +2754,6 @@ static UniValue encryptwallet(const JSONRPCRequest& request)
             "will require the passphrase to be set prior the making these calls.\n"
             "Use the walletpassphrase call for this, and then walletlock call.\n"
             "If the wallet is already encrypted, use the walletpassphrasechange call.\n"
-            "Note that this will shutdown the server.\n"
             "\nArguments:\n"
             "1. \"passphrase\"    (string) The pass phrase to encrypt the wallet with. It must be at least 1 character, but should be long.\n"
             "\nExamples:\n"
@@ -2791,12 +2790,8 @@ static UniValue encryptwallet(const JSONRPCRequest& request)
     if (!pwallet->EncryptWallet(strWalletPass)) {
         throw JSONRPCError(RPC_WALLET_ENCRYPTION_FAILED, "Error: Failed to encrypt the wallet.");
     }
-
-    // BDB seems to have a bad habit of writing old data into
-    // slack space in .dat files; that is bad if the old data is
-    // unencrypted private keys. So:
-    StartShutdown();
-    return "wallet encrypted; Syscoin server stopping, restart to run with encrypted wallet. The keypool has been flushed and a new HD seed was generated (if you are using HD). You need to make a new backup.";
+    
+    return "wallet encrypted; The keypool has been flushed and a new HD seed was generated (if you are using HD). You need to make a new backup.";
 }
 
 static UniValue lockunspent(const JSONRPCRequest& request)

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -28,7 +28,7 @@ std::vector<std::unique_ptr<CWalletTx>> wtxn;
 typedef std::set<CInputCoin> CoinSet;
 
 static std::vector<COutput> vCoins;
-static CWallet testWallet("dummy", WalletDatabase::CreateDummy());
+static CWallet testWallet(WalletLocation(), WalletDatabase::CreateDummy());
 static CAmount balance = 0;
 
 CoinEligibilityFilter filter_standard(1, 6, 0);

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <memory>
+
+#include <boost/test/unit_test.hpp>
+
+#include <fs.h>
+#include <test/test_bitcoin.h>
+#include <wallet/db.h>
+
+
+BOOST_FIXTURE_TEST_SUITE(db_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(getwalletenv_file)
+{
+    std::string test_name = "test_name.dat";
+    fs::path datadir = SetDataDir("tempdir");
+    fs::path file_path = datadir / test_name;
+    std::ofstream f(file_path.BOOST_FILESYSTEM_C_STR);
+    f.close();
+
+    std::string filename;
+    std::shared_ptr<BerkeleyEnvironment> env = GetWalletEnv(file_path, filename);
+    BOOST_CHECK(filename == test_name);
+    BOOST_CHECK(env->Directory() == datadir);
+}
+
+BOOST_AUTO_TEST_CASE(getwalletenv_directory)
+{
+    std::string expected_name = "wallet.dat";
+    fs::path datadir = SetDataDir("tempdir");
+
+    std::string filename;
+    std::shared_ptr<BerkeleyEnvironment> env = GetWalletEnv(datadir, filename);
+    BOOST_CHECK(filename == expected_name);
+    BOOST_CHECK(env->Directory() == datadir);
+}
+
+BOOST_AUTO_TEST_CASE(getwalletenv_g_dbenvs_multiple)
+{
+    fs::path datadir = SetDataDir("tempdir");
+    fs::path datadir_2 = SetDataDir("tempdir_2");
+    std::string filename;
+
+    std::shared_ptr<BerkeleyEnvironment> env_1 = GetWalletEnv(datadir, filename);
+    std::shared_ptr<BerkeleyEnvironment> env_2 = GetWalletEnv(datadir, filename);
+    std::shared_ptr<BerkeleyEnvironment> env_3 = GetWalletEnv(datadir_2, filename);
+
+    BOOST_CHECK(env_1 == env_2);
+    BOOST_CHECK(env_2 != env_3);
+}
+
+BOOST_AUTO_TEST_CASE(getwalletenv_g_dbenvs_free_instance)
+{
+    fs::path datadir = SetDataDir("tempdir");
+    fs::path datadir_2 = SetDataDir("tempdir_2");
+    std::string filename;
+
+    std::shared_ptr <BerkeleyEnvironment> env_1_a = GetWalletEnv(datadir, filename);
+    std::shared_ptr <BerkeleyEnvironment> env_2_a = GetWalletEnv(datadir_2, filename);
+    env_1_a.reset();
+
+    std::shared_ptr<BerkeleyEnvironment> env_1_b = GetWalletEnv(datadir, filename);
+    std::shared_ptr<BerkeleyEnvironment> env_2_b = GetWalletEnv(datadir_2, filename);
+
+    BOOST_CHECK(env_1_a != env_1_b);
+    BOOST_CHECK(env_2_a == env_2_b);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/db_tests.cpp
+++ b/src/wallet/test/db_tests.cpp
@@ -7,7 +7,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <fs.h>
-#include <test/test_bitcoin.h>
+#include <test/test_syscoin.h>
 #include <wallet/db.h>
 
 

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -6,9 +6,10 @@
 
 #include <rpc/server.h>
 #include <wallet/db.h>
+#include <wallet/rpcwallet.h>
 
 WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
-    TestingSetup(chainName), m_wallet("mock", WalletDatabase::CreateMock())
+    TestingSetup(chainName), m_wallet(WalletLocation(), WalletDatabase::CreateMock())
 {
     bool fFirstRun;
     m_wallet.LoadWallet(fFirstRun);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -47,7 +47,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
     // Verify ScanForWalletTransactions picks up transactions in both the old
     // and new block files.
     {
-        CWallet wallet("dummy", WalletDatabase::CreateDummy());
+        CWallet wallet(WalletLocation(), WalletDatabase::CreateDummy());
         AddKey(wallet, coinbaseKey);
         WalletRescanReserver reserver(&wallet);
         reserver.reserve();
@@ -63,7 +63,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
     // Verify ScanForWalletTransactions only picks transactions in the new block
     // file.
     {
-        CWallet wallet("dummy", WalletDatabase::CreateDummy());
+        CWallet wallet(WalletLocation(), WalletDatabase::CreateDummy());
         AddKey(wallet, coinbaseKey);
         WalletRescanReserver reserver(&wallet);
         reserver.reserve();
@@ -76,7 +76,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
     // before the missing block, and success for a key whose creation time is
     // after.
     {
-        std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>("dummy", WalletDatabase::CreateDummy());
+        std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(WalletLocation(), WalletDatabase::CreateDummy());
         AddWallet(wallet);
         UniValue keys;
         keys.setArray();
@@ -137,7 +137,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 
     // Import key into wallet and call dumpwallet to create backup file.
     {
-        std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>("dummy", WalletDatabase::CreateDummy());
+        std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(WalletLocation(), WalletDatabase::CreateDummy());
         LOCK(wallet->cs_wallet);
         wallet->mapKeyMetadata[coinbaseKey.GetPubKey().GetID()].nCreateTime = KEY_TIME;
         wallet->AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey());
@@ -153,7 +153,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
     // Call importwallet RPC and verify all blocks with timestamps >= BLOCK_TIME
     // were scanned, and no prior blocks were scanned.
     {
-        std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>("dummy", WalletDatabase::CreateDummy());
+        std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(WalletLocation(), WalletDatabase::CreateDummy());
 
         JSONRPCRequest request;
         request.params.setArray();
@@ -183,7 +183,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 // debit functions.
 BOOST_FIXTURE_TEST_CASE(coin_mark_dirty_immature_credit, TestChain100Setup)
 {
-    CWallet wallet("dummy", WalletDatabase::CreateDummy());
+    CWallet wallet(WalletLocation(), WalletDatabase::CreateDummy());
     CWalletTx wtx(&wallet, m_coinbase_txns.back());
     LOCK2(cs_main, wallet.cs_wallet);
     wtx.hashBlock = chainActive.Tip()->GetBlockHash();
@@ -277,7 +277,7 @@ public:
     ListCoinsTestingSetup()
     {
         CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
-        wallet = MakeUnique<CWallet>("mock", WalletDatabase::CreateMock());
+        wallet = MakeUnique<CWallet>(WalletLocation(), WalletDatabase::CreateMock());
         bool firstRun;
         wallet->LoadWallet(firstRun);
         AddKey(*wallet, coinbaseKey);
@@ -375,7 +375,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoins, ListCoinsTestingSetup)
 
 BOOST_FIXTURE_TEST_CASE(wallet_disableprivkeys, TestChain100Setup)
 {
-    std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>("dummy", WalletDatabase::CreateDummy());
+    std::shared_ptr<CWallet> wallet = std::make_shared<CWallet>(WalletLocation(), WalletDatabase::CreateDummy());
     wallet->SetWalletFlag(WALLET_FLAG_DISABLE_PRIVATE_KEYS);
     BOOST_CHECK(!wallet->TopUpKeyPool(1000));
     CPubKey pubkey;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -27,7 +27,6 @@
 #include <txmempool.h>
 #include <utilmoneystr.h>
 #include <wallet/fees.h>
-#include <wallet/walletutil.h>
 
 #include <algorithm>
 #include <assert.h>
@@ -4169,7 +4168,7 @@ void CWallet::MarkPreSplitKeys()
     }
 }
 
-bool CWallet::Verify(std::string wallet_file, bool salvage_wallet, std::string& error_string, std::string& warning_string)
+bool CWallet::Verify(const WalletLocation& location, bool salvage_wallet, std::string& error_string, std::string& warning_string)
 {
     // Do some checking on wallet path. It should be either a:
     //
@@ -4178,23 +4177,23 @@ bool CWallet::Verify(std::string wallet_file, bool salvage_wallet, std::string& 
     // 3. Path to a symlink to a directory.
     // 4. For backwards compatibility, the name of a data file in -walletdir.
     LOCK(cs_wallets);
-    fs::path wallet_path = fs::absolute(wallet_file, GetWalletDir());
+    const fs::path& wallet_path = location.GetPath();
     fs::file_type path_type = fs::symlink_status(wallet_path).type();
     if (!(path_type == fs::file_not_found || path_type == fs::directory_file ||
           (path_type == fs::symlink_file && fs::is_directory(wallet_path)) ||
-          (path_type == fs::regular_file && fs::path(wallet_file).filename() == wallet_file))) {
+          (path_type == fs::regular_file && fs::path(location.GetName()).filename() == location.GetName()))) {
         error_string = strprintf(
               "Invalid -wallet path '%s'. -wallet path should point to a directory where wallet.dat and "
               "database/log.?????????? files can be stored, a location where such a directory could be created, "
               "or (for backwards compatibility) the name of an existing data file in -walletdir (%s)",
-              wallet_file, GetWalletDir());
+              location.GetName(), GetWalletDir());
         return false;
     }
 
     // Make sure that the wallet path doesn't clash with an existing wallet path
     for (auto wallet : GetWallets()) {
-        if (fs::absolute(wallet->GetName(), GetWalletDir()) == wallet_path) {
-            error_string = strprintf("Error loading wallet %s. Duplicate -wallet filename specified.", wallet_file);
+        if (wallet->GetLocation().GetPath() == wallet_path) {
+            error_string = strprintf("Error loading wallet %s. Duplicate -wallet filename specified.", location.GetName());
             return false;
         }
     }
@@ -4204,13 +4203,13 @@ bool CWallet::Verify(std::string wallet_file, bool salvage_wallet, std::string& 
             return false;
         }
     } catch (const fs::filesystem_error& e) {
-        error_string = strprintf("Error loading wallet %s. %s", wallet_file, e.what());
+        error_string = strprintf("Error loading wallet %s. %s", location.GetName(), e.what());
         return false;
     }
 
     if (salvage_wallet) {
         // Recover readable keypairs:
-        CWallet dummyWallet("dummy", WalletDatabase::CreateDummy());
+        CWallet dummyWallet(WalletLocation(), WalletDatabase::CreateDummy());
         std::string backup_filename;
         if (!WalletBatch::Recover(wallet_path, (void *)&dummyWallet, WalletBatch::RecoverKeysOnlyFilter, backup_filename)) {
             return false;
@@ -4220,9 +4219,9 @@ bool CWallet::Verify(std::string wallet_file, bool salvage_wallet, std::string& 
     return WalletBatch::VerifyDatabaseFile(wallet_path, warning_string, error_string);
 }
 
-std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, const fs::path& path, uint64_t wallet_creation_flags)
+std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const WalletLocation& location, uint64_t wallet_creation_flags)
 {
-    const std::string& walletFile = name;
+    const std::string& walletFile = location.GetName();
 
     // needed to restore wallet transaction meta data after -zapwallettxes
     std::vector<CWalletTx> vWtx;
@@ -4230,7 +4229,7 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
     if (gArgs.GetBoolArg("-zapwallettxes", false)) {
         uiInterface.InitMessage(_("Zapping all transactions from wallet..."));
 
-        std::unique_ptr<CWallet> tempWallet = MakeUnique<CWallet>(name, WalletDatabase::Create(path));
+        std::unique_ptr<CWallet> tempWallet = MakeUnique<CWallet>(location, WalletDatabase::Create(location.GetPath()));
         DBErrors nZapWalletRet = tempWallet->ZapWalletTx(vWtx);
         if (nZapWalletRet != DBErrors::LOAD_OK) {
             InitError(strprintf(_("Error loading %s: Wallet corrupted"), walletFile));
@@ -4244,7 +4243,7 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
     bool fFirstRun = true;
     // TODO: Can't use std::make_shared because we need a custom deleter but
     // should be possible to use std::allocate_shared.
-    std::shared_ptr<CWallet> walletInstance(new CWallet(name, WalletDatabase::Create(path)), ReleaseWallet);
+    std::shared_ptr<CWallet> walletInstance(new CWallet(location, WalletDatabase::Create(location.GetPath())), ReleaseWallet);
     DBErrors nLoadWalletRet = walletInstance->LoadWallet(fFirstRun);
     if (nLoadWalletRet != DBErrors::LOAD_OK)
     {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -831,6 +831,11 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
         // bits of the unencrypted private key in slack space in the database file.
         database->Rewrite();
 
+        // BDB seems to have a bad habit of writing old data into
+        // slack space in .dat files; that is bad if the old data is
+        // unencrypted private keys. So:
+        database->ReloadDbEnv();
+
     }
     NotifyStatusChanged(this);
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4196,6 +4196,9 @@ bool CWallet::Verify(const WalletLocation& location, bool salvage_wallet, std::s
         return false;
     }
 
+    // Keep same database environment instance across Verify/Recover calls below.
+    std::unique_ptr<WalletDatabase> database = WalletDatabase::Create(wallet_path);
+
     try {
         if (!WalletBatch::VerifyEnvironment(wallet_path, error_string)) {
             return false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4191,11 +4191,9 @@ bool CWallet::Verify(const WalletLocation& location, bool salvage_wallet, std::s
     }
 
     // Make sure that the wallet path doesn't clash with an existing wallet path
-    for (auto wallet : GetWallets()) {
-        if (wallet->GetLocation().GetPath() == wallet_path) {
-            error_string = strprintf("Error loading wallet %s. Duplicate -wallet filename specified.", location.GetName());
-            return false;
-        }
+    if (IsWalletLoaded(wallet_path)) {
+        error_string = strprintf("Error loading wallet %s. Duplicate -wallet filename specified.", location.GetName());
+        return false;
     }
 
     try {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -21,7 +21,7 @@
 #include <wallet/crypter.h>
 #include <wallet/coinselection.h>
 #include <wallet/walletdb.h>
-#include <wallet/rpcwallet.h>
+#include <wallet/walletutil.h>
 
 #include <algorithm>
 #include <atomic>
@@ -727,12 +727,8 @@ private:
      */
     bool AddWatchOnly(const CScript& dest) override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    /**
-     * Wallet filename from wallet=<path> command line or config option.
-     * Used in debug logs and to send RPCs to the right wallet instance when
-     * more than one wallet is loaded.
-     */
-    std::string m_name;
+    /** Wallet location which includes wallet name (see WalletLocation). */
+    WalletLocation m_location;
 
     /** Internal database handle. */
     std::unique_ptr<WalletDatabase> database;
@@ -772,9 +768,11 @@ public:
     bool SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet,
                     const CCoinControl& coin_control, CoinSelectionParams& coin_selection_params, bool& bnb_used) const;
 
+    const WalletLocation& GetLocation() const { return m_location; }
+
     /** Get a name for this wallet for logging/debugging purposes.
      */
-    const std::string& GetName() const { return m_name; }
+    const std::string& GetName() const { return m_location.GetName(); }
 
     void LoadKeyPool(int64_t nIndex, const CKeyPool &keypool) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void MarkPreSplitKeys();
@@ -790,7 +788,7 @@ public:
     unsigned int nMasterKeyMaxID = 0;
 
     /** Construct wallet with specified name and database implementation. */
-    CWallet(std::string name, std::unique_ptr<WalletDatabase> database) : m_name(std::move(name)), database(std::move(database))
+    CWallet(const WalletLocation& location, std::unique_ptr<WalletDatabase> database) : m_location(location), database(std::move(database))
     {
     }
 
@@ -1125,10 +1123,10 @@ public:
     bool MarkReplaced(const uint256& originalHash, const uint256& newHash);
 
     //! Verify wallet naming and perform salvage on the wallet if required
-    static bool Verify(std::string wallet_file, bool salvage_wallet, std::string& error_string, std::string& warning_string);
+    static bool Verify(const WalletLocation& location, bool salvage_wallet, std::string& error_string, std::string& warning_string);
 
     /* Initializes the wallet, returns a new CWallet instance or a null pointer in case of an error */
-    static std::shared_ptr<CWallet> CreateWalletFromFile(const std::string& name, const fs::path& path, uint64_t wallet_creation_flags = 0);
+    static std::shared_ptr<CWallet> CreateWalletFromFile(const WalletLocation& location, uint64_t wallet_creation_flags = 0);
 
     /**
      * Wallet post-init setup

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -25,3 +25,14 @@ fs::path GetWalletDir()
 
     return path;
 }
+
+WalletLocation::WalletLocation(const std::string& name)
+    : m_name(name)
+    , m_path(fs::absolute(name, GetWalletDir()))
+{
+}
+
+bool WalletLocation::Exists() const
+{
+    return fs::symlink_status(m_path).type() != fs::file_not_found;
+}

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -11,4 +11,25 @@
 //! Get the path of the wallet directory.
 fs::path GetWalletDir();
 
+//! The WalletLocation class provides wallet information.
+class WalletLocation final
+{
+    std::string m_name;
+    fs::path m_path;
+
+public:
+    explicit WalletLocation() {}
+    explicit WalletLocation(const std::string& name);
+
+    //! Get wallet name.
+    const std::string& GetName() const { return m_name; }
+
+    //! Get wallet absolute path.
+    const fs::path& GetPath() const { return m_path; }
+
+    //! Return whether the wallet exists.
+    bool Exists() const;
+};
+
 #endif // SYSCOIN_WALLET_WALLETUTIL_H
+

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -478,10 +478,8 @@ class RawTransactionsTest(SyscoinTestFramework):
 
         ############################################################
         # locked wallet test
-        self.stop_node(0)
-        self.nodes[1].node_encrypt_wallet("test")
-        self.stop_node(2)
-        self.stop_node(3)
+        self.nodes[1].encryptwallet("test")
+        self.stop_nodes()
 
         self.start_nodes()
         # This test is not meant to test fee estimation and we'd like

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -304,15 +304,7 @@ class TestNode():
                 else:
                     assert_msg = "syscoind should have exited with expected error " + expected_msg
                 self._raise_assertion_error(assert_msg)
-
-    def node_encrypt_wallet(self, passphrase):
-        """"Encrypts the wallet.
-
-        This causes syscoind to shutdown, so this method takes
-        care of cleaning up resources."""
-        self.encryptwallet(passphrase)
-        self.wait_until_stopped()
-
+                
     def add_p2p_connection(self, p2p_conn, *, wait_for_verack=True, **kwargs):
         """Add a p2p connection to the node.
 

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -41,8 +41,7 @@ class BumpFeeTest(SyscoinTestFramework):
 
     def run_test(self):
         # Encrypt wallet for test_locked_wallet_fails test
-        self.nodes[1].node_encrypt_wallet(WALLET_PASSPHRASE)
-        self.start_node(1)
+        self.nodes[1].encryptwallet(WALLET_PASSPHRASE)
         self.nodes[1].walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
 
         connect_nodes_bi(self.nodes, 0, 1)

--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -128,8 +128,7 @@ class WalletDumpTest(SyscoinTestFramework):
         assert_equal(witness_addr_ret, witness_addr)  # p2sh-p2wsh address added to the first key
 
         #encrypt wallet, restart, unlock and dump
-        self.nodes[0].node_encrypt_wallet('test')
-        self.start_node(0)
+        self.nodes[0].encryptwallet('test')
         self.nodes[0].walletpassphrase('test', 10)
         # Should be a no-op:
         self.nodes[0].keypoolrefill()

--- a/test/functional/wallet_encryption.py
+++ b/test/functional/wallet_encryption.py
@@ -33,8 +33,7 @@ class WalletEncryptionTest(SyscoinTestFramework):
         assert_equal(len(privkey), 52)
 
         # Encrypt the wallet
-        self.nodes[0].node_encrypt_wallet(passphrase)
-        self.start_node(0)
+        self.nodes[0].encryptwallet(passphrase)
 
         # Test that the wallet is encrypted
         assert_raises_rpc_error(-13, "Please enter the wallet passphrase with walletpassphrase first", self.nodes[0].dumpprivkey, address)

--- a/test/functional/wallet_keypool.py
+++ b/test/functional/wallet_keypool.py
@@ -28,9 +28,7 @@ class KeyPoolTest(SyscoinTestFramework):
         assert(addr_before_encrypting_data['hdseedid'] == wallet_info_old['hdseedid'])
 
         # Encrypt wallet and wait to terminate
-        nodes[0].node_encrypt_wallet('test')
-        # Restart node 0
-        self.start_node(0)
+        nodes[0].encryptwallet('test')
         # Keep creating keys
         addr = nodes[0].getnewaddress()
         addr_data = nodes[0].getaddressinfo(addr)

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -220,6 +220,10 @@ class MultiWalletTest(SyscoinTestFramework):
         # Fail to load if one wallet is a copy of another
         assert_raises_rpc_error(-1, "BerkeleyBatch: Can't open database w8_copy (duplicates fileid", self.nodes[0].loadwallet, 'w8_copy')
 
+        # Fail to load if one wallet is a copy of another, test this twice to make sure that we don't re-introduce #14304
+        assert_raises_rpc_error(-1, "BerkeleyBatch: Can't open database w8_copy (duplicates fileid", self.nodes[0].loadwallet, 'w8_copy')
+
+
         # Fail to load if wallet file is a symlink
         assert_raises_rpc_error(-4, "Wallet file verification failed: Invalid -wallet path 'w8_symlink'", self.nodes[0].loadwallet, 'w8_symlink')
 

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -217,6 +217,9 @@ class MultiWalletTest(SyscoinTestFramework):
         # Fail to load duplicate wallets
         assert_raises_rpc_error(-4, 'Wallet file verification failed: Error loading wallet w1. Duplicate -wallet filename specified.', self.nodes[0].loadwallet, wallet_names[0])
 
+        # Fail to load duplicate wallets by different ways (directory and filepath)
+        assert_raises_rpc_error(-4, "Wallet file verification failed: Error loading wallet wallet.dat. Duplicate -wallet filename specified.", self.nodes[0].loadwallet, 'wallet.dat')
+
         # Fail to load if one wallet is a copy of another
         assert_raises_rpc_error(-1, "BerkeleyBatch: Can't open database w8_copy (duplicates fileid", self.nodes[0].loadwallet, 'w8_copy')
 

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -311,6 +311,14 @@ class MultiWalletTest(SyscoinTestFramework):
             self.nodes[0].loadwallet(wallet_name)
             assert_equal(rpc.getaddressinfo(addr)['ismine'], True)
 
+        # Test .walletlock file is closed
+        self.start_node(1)
+        wallet = os.path.join(self.options.tmpdir, 'my_wallet')
+        self.nodes[0].createwallet(wallet)
+        assert_raises_rpc_error(-4, "Error initializing wallet database environment", self.nodes[1].loadwallet, wallet)
+        self.nodes[0].unloadwallet(wallet)
+        self.nodes[1].loadwallet(wallet)
+
 
 if __name__ == '__main__':
     MultiWalletTest().main()


### PR DESCRIPTION
remove custom outputs and use tx versioning to understand syscoin txs. This removes an output for every syscoin tx so its more efficient and also more compatible with bitcoin related integrations like electrum which parses transactions to sign, because no custom outputs it wont need a handler to parse syscoin transactions.

Also refactored burning of sys/assets. For assets do not use cassetallocation serialized into opreturn but put the data needed to validate the burn in opreturn manually and recreate cassetallocation when the transaction is deserialized.