### PR TITLE
2 features: dbl spend eth detection + syscoinmint json output in deco…

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -254,7 +254,7 @@ public:
         consensus.nAuxpowChainId = 0x1000;
         consensus.fStrictChainId = false;
         consensus.nLegacyBlocksBefore = 1;
-        consensus.vchSYSXContract = ParseHex("deaa65c2162a141bc768ef624c6b7d1342f629fb");
+        consensus.vchSYSXContract = ParseHex("f7af70929df0d4beda3abb4c056169daae4b39d7");
         consensus.vchSYSXBurnMethodSignature = ParseHex("285c5bc6");
         pchMessageStart[0] = 0xce;
         pchMessageStart[1] = 0xe2;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -326,6 +326,7 @@ void Shutdown(InitInterfaces& interfaces)
     passetallocationdb.reset();
     passetallocationmempooldb.reset();
     pethereumtxrootsdb.reset();
+    pethereumtxmintdb.reset();
     passetindexdb.reset();
     pblockindexdb.reset();
 	plockedoutpointsdb.reset();
@@ -1634,6 +1635,7 @@ bool AppInitMain(InitInterfaces& interfaces)
                 passetallocationdb.reset();
                 passetallocationmempooldb.reset();
                 pethereumtxrootsdb.reset();
+                pethereumtxmintdb.reset();
                 passetindexdb.reset();
                 pblockindexdb.reset();
 				plockedoutpointsdb.reset();
@@ -1651,6 +1653,7 @@ bool AppInitMain(InitInterfaces& interfaces)
                     passetallocationmempooldb->ReadAssetAllocationMempoolArrivalTimes(arrivalTimesMap);
                 }                
                 pethereumtxrootsdb.reset(new CEthereumTxRootsDB(nCoinDBCache*16, false, fReset));
+                pethereumtxmintdb.reset(new CEthereumMintedTxDB(nCoinDBCache, false, fReset));
                 pblockindexdb.reset(new CBlockIndexDB(nCoinDBCache, false, fReset));
                 fAssetIndex = gArgs.GetBoolArg("-assetindex", false);
                 if(fAssetIndex)

--- a/src/services/asset.cpp
+++ b/src/services/asset.cpp
@@ -2314,7 +2314,7 @@ UniValue syscoinsetethheaders(const JSONRPCRequest& request) {
         const UniValue &tupleArray = headerArray[i].get_array();
         if(tupleArray.size() != 3)
             throw runtime_error("SYSCOIN_ASSET_RPC_ERROR: ERRCODE: 2512 - " + _("Invalid size in a blocknumber/txroots input, should be size of 3"));
-        uint32_t nHeight = (uint32_t)tupleArray[0].get_int();
+        const uint32_t &nHeight = (uint32_t)tupleArray[0].get_int();
         string txRoot = tupleArray[1].get_str();
         boost::erase_all(txRoot, "0x");  // strip 0x
         const vector<unsigned char> &vchTxRoot = ParseHex(txRoot);

--- a/src/services/asset.h
+++ b/src/services/asset.h
@@ -203,21 +203,6 @@ public:
     bool UnserializeFromTx(const CTransaction &tx);
     void Serialize(std::vector<unsigned char>& vchData);
 };
-typedef std::unordered_map<uint32_t, std::pair<std::vector<unsigned char>, std::vector<unsigned char> > > EthereumTxRootMap;
-class CEthereumTxRootsDB : public CDBWrapper {
-public:
-    CEthereumTxRootsDB(size_t nCacheSize, bool fMemory, bool fWipe) : CDBWrapper(GetDataDir() / "ethereumtxroots", nCacheSize, fMemory, fWipe) {
-       Init();
-    } 
-    bool ReadTxRoots(const uint32_t& nHeight, std::pair<std::vector<unsigned char>, std::vector<unsigned char> >& vchTxRoots) {
-        return Read(nHeight, vchTxRoots);
-    } 
-    void AuditTxRootDB(std::vector<std::pair<uint32_t, uint32_t> > &vecMissingBlockRanges);
-    bool Init();
-    bool PruneTxRoots(const uint32_t &fNewGethSyncHeight);
-    bool FlushErase(const std::vector<uint32_t> &vecHeightKeys);
-    bool FlushWrite(const EthereumTxRootMap &mapTxRoots);
-};
 typedef std::unordered_map<int, CAsset > AssetMap;
 class CAssetDB : public CDBWrapper {
 public:
@@ -357,6 +342,5 @@ void WriteAssetIndexTXID(const uint32_t& nAsset, const uint256& txid);
 extern std::unique_ptr<CAssetDB> passetdb;
 extern std::unique_ptr<CAssetAllocationDB> passetallocationdb;
 extern std::unique_ptr<CAssetAllocationMempoolDB> passetallocationmempooldb;
-extern std::unique_ptr<CEthereumTxRootsDB> pethereumtxrootsdb;
 extern std::unique_ptr<CAssetIndexDB> passetindexdb;
 #endif // SYSCOIN_SERVICES_ASSET_H

--- a/src/services/assetallocation.cpp
+++ b/src/services/assetallocation.cpp
@@ -1209,8 +1209,6 @@ bool AssetMintTxToJson(const CTransaction& tx, UniValue &entry){
         if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT){
             entry.pushKV("asset_guid", (int)mintsyscoin.assetAllocationTuple.nAsset);
             entry.pushKV("sender", mintsyscoin.assetAllocationTuple.witnessAddress.ToString());
-        }
-        if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT){
             UniValue oAssetAllocationReceiversArray(UniValue::VARR);
             CAsset dbAsset;
             GetAsset(mintsyscoin.assetAllocationTuple.nAsset, dbAsset);
@@ -1255,8 +1253,6 @@ bool AssetMintTxToJson(const CTransaction& tx, const CMintSyscoin& mintsyscoin, 
         if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT){
             entry.pushKV("asset_guid", (int)mintsyscoin.assetAllocationTuple.nAsset);
             entry.pushKV("sender", mintsyscoin.assetAllocationTuple.witnessAddress.ToString());
-        }
-        if(tx.nVersion == SYSCOIN_TX_VERSION_ASSET_ALLOCATION_MINT){
             UniValue oAssetAllocationReceiversArray(UniValue::VARR);
             CAsset dbAsset;
             GetAsset(mintsyscoin.assetAllocationTuple.nAsset, dbAsset);

--- a/src/services/assetallocation.cpp
+++ b/src/services/assetallocation.cpp
@@ -452,6 +452,7 @@ UniValue assetallocationmint(const JSONRPCRequest& request) {
                     {"merklerootpath_hex", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The merkle path to walk through the tree to recreate the merkle hash for both transaction and receipt root."},
                     {"receipt_hex", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "Transaction Receipt Hex."},
                     {"receiptroot_hex", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The transaction receipt merkle root that commits this receipt to the block header."},
+                    {"receiptmerkleproof_hex", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The list of parent nodes of the Merkle Patricia Tree for SPV proof of transaction receipt merkle root."},
                     {"witness", RPCArg::Type::STR, "\"\"", "Witness address that will sign for web-of-trust notarization of this transaction."}
                 },
                 RPCResult{

--- a/src/services/assetconsensus.h
+++ b/src/services/assetconsensus.h
@@ -65,7 +65,7 @@ bool DisconnectAssetUpdate(const CTransaction &tx, AssetMap &mapAssets);
 bool DisconnectAssetAllocation(const CTransaction &tx, AssetAllocationMap &mapAssetAllocations);
 bool DisconnectMintAsset(const CTransaction &tx, AssetAllocationMap &mapAssetAllocations, EthereumMintTxVec &vecMintKeys);
 bool DisconnectMint(const CTransaction &tx, EthereumMintTxVec &vecMintKeys);
-bool CheckSyscoinMint(const bool ibd, const CTransaction& tx, std::string& errorMessage, const bool &fJustCheck, const bool& bSanity, const bool& bMiner, const int& nHeight, const uint256& blockhash, AssetMap& mapAssets, AssetAllocationMap &mapAssetAllocations, EthereumMintTxVec &vecMintKeys);
+bool CheckSyscoinMint(const bool ibd, const CTransaction& tx, std::string& errorMessage, const bool &fJustCheck, const bool& bSanity, const bool& bMiner, const int& nHeight, const uint256& blockhash, AssetMap& mapAssets, AssetAllocationMap &mapAssetAllocations, EthereumMintTxVec &vecMintKeys, bool &bTxRootError);
 bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs, bool fJustCheck, int nHeight, const uint256& blockhash, AssetMap &mapAssets, AssetAllocationMap &mapAssetAllocations, std::string &errorMessage, const bool &bSanityCheck=false, const bool &bMiner=false);
 static std::vector<uint256> DEFAULT_VECTOR;
 bool CheckSyscoinInputs(const bool ibd, const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fJustCheck, bool &bOverflow, int nHeight, const CBlock& block, const bool &bSanity = false, const bool &bMiner = false, std::vector<uint256>& txsToRemove=DEFAULT_VECTOR);

--- a/src/services/assetconsensus.h
+++ b/src/services/assetconsensus.h
@@ -28,15 +28,44 @@ public:
 	bool FlushWrite(const std::vector<COutPoint> &lockedOutpoints);
 	bool FlushErase(const std::vector<COutPoint> &lockedOutpoints);
 };
+typedef std::unordered_map<uint32_t, std::pair<std::vector<unsigned char>, std::vector<unsigned char> > > EthereumTxRootMap;
+class CEthereumTxRootsDB : public CDBWrapper {
+public:
+    CEthereumTxRootsDB(size_t nCacheSize, bool fMemory, bool fWipe) : CDBWrapper(GetDataDir() / "ethereumtxroots", nCacheSize, fMemory, fWipe) {
+       Init();
+    } 
+    bool ReadTxRoots(const uint32_t& nHeight, std::pair<std::vector<unsigned char>, std::vector<unsigned char> >& vchTxRoots) {
+        return Read(nHeight, vchTxRoots);
+    } 
+    void AuditTxRootDB(std::vector<std::pair<uint32_t, uint32_t> > &vecMissingBlockRanges);
+    bool Init();
+    bool PruneTxRoots(const uint32_t &fNewGethSyncHeight);
+    bool FlushErase(const std::vector<uint32_t> &vecHeightKeys);
+    bool FlushWrite(const EthereumTxRootMap &mapTxRoots);
+};
+typedef std::vector<std::pair<uint64_t, uint32_t> > EthereumMintTxVec;
+class CEthereumMintedTxDB : public CDBWrapper {
+public:
+    CEthereumMintedTxDB(size_t nCacheSize, bool fMemory, bool fWipe) : CDBWrapper(GetDataDir() / "ethereumminttx", nCacheSize, fMemory, fWipe) {
+    } 
+    bool ExistsKey(const std::pair<uint64_t, uint32_t> &ethKey) {
+        return Exists(ethKey);
+    } 
+    bool FlushErase(const EthereumMintTxVec &vecMintKeys);
+    bool FlushWrite(const EthereumMintTxVec &vecMintKeys);
+};
 extern std::unique_ptr<CBlockIndexDB> pblockindexdb;
 extern std::unique_ptr<CLockedOutpointsDB> plockedoutpointsdb;
-bool DisconnectSyscoinTransaction(const CTransaction& tx, const CBlockIndex* pindex, CCoinsViewCache& view, AssetMap &mapAssets, AssetAllocationMap &mapAssetAllocations);
+extern std::unique_ptr<CEthereumTxRootsDB> pethereumtxrootsdb;
+extern std::unique_ptr<CEthereumMintedTxDB> pethereumtxmintdb;
+bool DisconnectSyscoinTransaction(const CTransaction& tx, const CBlockIndex* pindex, CCoinsViewCache& view, AssetMap &mapAssets, AssetAllocationMap &mapAssetAllocations, EthereumMintTxVec &vecMintKeys);
 bool DisconnectAssetActivate(const CTransaction &tx, AssetMap &mapAssets);
 bool DisconnectAssetSend(const CTransaction &tx, AssetMap &mapAssets, AssetAllocationMap &mapAssetAllocations);
 bool DisconnectAssetUpdate(const CTransaction &tx, AssetMap &mapAssets);
 bool DisconnectAssetAllocation(const CTransaction &tx, AssetAllocationMap &mapAssetAllocations);
-bool DisconnectMintAsset(const CTransaction &tx, AssetAllocationMap &mapAssetAllocations);
-bool CheckSyscoinMint(const bool ibd, const CTransaction& tx, std::string& errorMessage, const bool &fJustCheck, const bool& bSanity, const bool& bMiner, const int& nHeight, const uint256& blockhash, AssetMap& mapAssets, AssetAllocationMap &mapAssetAllocations);
+bool DisconnectMintAsset(const CTransaction &tx, AssetAllocationMap &mapAssetAllocations, EthereumMintTxVec &vecMintKeys);
+bool DisconnectMint(const CTransaction &tx, EthereumMintTxVec &vecMintKeys);
+bool CheckSyscoinMint(const bool ibd, const CTransaction& tx, std::string& errorMessage, const bool &fJustCheck, const bool& bSanity, const bool& bMiner, const int& nHeight, const uint256& blockhash, AssetMap& mapAssets, AssetAllocationMap &mapAssetAllocations, EthereumMintTxVec &vecMintKeys);
 bool CheckAssetInputs(const CTransaction &tx, const CCoinsViewCache &inputs, bool fJustCheck, int nHeight, const uint256& blockhash, AssetMap &mapAssets, AssetAllocationMap &mapAssetAllocations, std::string &errorMessage, const bool &bSanityCheck=false, const bool &bMiner=false);
 static std::vector<uint256> DEFAULT_VECTOR;
 bool CheckSyscoinInputs(const bool ibd, const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fJustCheck, bool &bOverflow, int nHeight, const CBlock& block, const bool &bSanity = false, const bool &bMiner = false, std::vector<uint256>& txsToRemove=DEFAULT_VECTOR);

--- a/src/test/syscoin_asset_tests.cpp
+++ b/src/test/syscoin_asset_tests.cpp
@@ -135,6 +135,7 @@ BOOST_AUTO_TEST_CASE(generate_asset_audittxroot1)
 }
 BOOST_AUTO_TEST_CASE(generate_asset_throughput)
 {
+
     int64_t start = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
     UniValue r;
     printf("Running generate_asset_throughput...\n");
@@ -417,11 +418,20 @@ BOOST_AUTO_TEST_CASE(generate_syscoinmint)
     std::string spv_receipt_root = "d2f2401b91a8625f24508ced119fde56012d5f523ee07f17b769f23f1c817c0c";
     std::string spv_receipt_parent_nodes = "f90458f851a02134434d523bf63424751820616d62f6ade388009724c1d1f2c892969eb6df4680808080808080a0e58215be848c1293dd381210359d84485553000a82b67410406d183b42adbbdd8080808080808080f901f180a0386f6bdc34e1469a424a4cfac85c62baeffb30f63643b1ea0195dee62527b6efa0c0567cc263d6e94ac00616245a7765dea1d2fbac700f5cca7d738b3df4e6d559a0cccf1990f8e5b36ed8f73a9b5790256cdbe19be4c2e08a8ed184afbf892c3ea3a069fcc61b1885ad084d9a821786f301b5f7110920dc985dbbcfdd22b72148effaa0f448a231ee9d335bffa17f89bda80f93a95b4c40a58edfad30444bb2bbc8328fa085a8314e91e4ea8484edb05ac95cb7a79b9d2b4968911cff68964896a5071cc8a0054c4901dc735415ac95d3641d398b79b191a2ecff84ae86990dae2179a9413ba0e551274c969b8f11966a1192660884c95200273b8be27b4701834f5186da8f35a0abc4c5c9a8a9da18d6973fdd899e3b045491ccaf122d0d2f462fe456005999eba0ccc33f018212af392c211272d5a5f2f5c6e2c7c88cf68b96f9edbb516794e12ca08d840ffeb5042d40372843799b2b9c8f97acf3f883d228cecb5f3de44a5af926a0cd366e7dc3e453a2624c3dfb63ee7880596239460e2de5c4785ed326d889e710a00064dbbbf5e446fc1f71d2afa27867e87c557cbbf98344b48a355ee397671004a02ea034d281cced4241777416600ab751589ad4641f0634ad74392b77aee2708da0d91aff6cb90254a646b46b4cfa91928da80009059b5677977974650fb794919580f9020e20b9020af9020701830f55e4b9010000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000080000000000000000000000000000000000000000000000000000000000000000800000000000000000000001000010000f8fdf8fb945f6e74ba20bf26161612eac8f7e8b3b6c9baaaddf842a0496f2146a902cabfc1b17d4cd1de13001dc9a8e792c8f89ecb7eb3c941bf8344a0000000000000000000000000bd244ffc1e6c64a6732f2b5b123d1e34d43ec341b8a00000000000000000000000000000000000000000000000000000000011e1a30000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000001500ddeb722584e9a6ffe2cf02468abca0ddc32341de0000000000000000000000";
     std::string spv_receipt_value = "f9020701830f55e4b9010000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000080000000000000000000000000000000000000000000000000000000000000000800000000000000000000001000010000f8fdf8fb945f6e74ba20bf26161612eac8f7e8b3b6c9baaaddf842a0496f2146a902cabfc1b17d4cd1de13001dc9a8e792c8f89ecb7eb3c941bf8344a0000000000000000000000000bd244ffc1e6c64a6732f2b5b123d1e34d43ec341b8a00000000000000000000000000000000000000000000000000000000011e1a30000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060000000000000000000000000000000000000000000000000000000000000001500ddeb722584e9a6ffe2cf02468abca0ddc32341de0000000000000000000000";
-    std::string spv_receipt_path = "0e";
     
     int height = 4189030;
     string newaddress = GetNewFundedAddress("node1");
-    SyscoinMint("node1", newaddress, "3", height, spv_tx_value, spv_tx_root, spv_tx_parent_nodes, spv_tx_path, spv_receipt_value, spv_receipt_root, spv_receipt_parent_nodes, spv_receipt_path);
+    string amount = "3";
+    
+    SyscoinMint("node1", newaddress, amount, height, spv_tx_value, spv_tx_root, spv_tx_parent_nodes, spv_tx_path, spv_receipt_value, spv_receipt_root, spv_receipt_parent_nodes);
+    
+    // try to mint again
+    BOOST_CHECK_NO_THROW(r = CallRPC("node1", "syscoinmint " + newaddress + " " + amount + " " + boost::lexical_cast<string>(height) + " " + spv_tx_value + " a0" + spv_tx_root + " " + spv_tx_parent_nodes + " " + spv_tx_path + " " + spv_receipt_value + " a0" + spv_receipt_root + " " + spv_receipt_parent_nodes +  " ''"));
+    BOOST_CHECK_NO_THROW(r = CallRPC("node1", "signrawtransactionwithwallet " + find_value(r.get_obj(), "hex").get_str()));
+    string hex_str = find_value(r.get_obj(), "hex").get_str();
+    // should fail: already minted with that block+txindex tuple
+    BOOST_CHECK_NO_THROW(r = CallRPC("node1", "sendrawtransaction " + hex_str, true, false)); 
+    BOOST_CHECK(r.write().size() < 32);
 }
 BOOST_AUTO_TEST_CASE(generate_burn_syscoin)
 {
@@ -461,8 +471,8 @@ BOOST_AUTO_TEST_CASE(generate_burn_syscoin_asset)
 
     BOOST_CHECK_NO_THROW(r = CallRPC("node1", "signrawtransactionwithwallet " + find_value(r.get_obj(), "hex").get_str()));
     string hexStr = find_value(r.get_obj(), "hex").get_str();
-    BOOST_CHECK_THROW(r = CallRPC("node1", "sendrawtransaction " + hexStr), runtime_error);
-
+    BOOST_CHECK_NO_THROW(r = CallRPC("node1", "sendrawtransaction " + hexStr, true, false));
+    BOOST_CHECK(r.write().size() < 32);
     // this one is ok
     BurnAssetAllocation("node1", assetguid, useraddress, "0.5");
     
@@ -519,8 +529,8 @@ BOOST_AUTO_TEST_CASE(generate_burn_syscoin_asset_multiple)
 
     BOOST_CHECK_NO_THROW(r = CallRPC("node1", "signrawtransactionwithwallet " + find_value(r.get_obj(), "hex").get_str()));
     string hexStr = find_value(r.get_obj(), "hex").get_str();
-    BOOST_CHECK_THROW(r = CallRPC("node1", "sendrawtransaction " + hexStr), runtime_error);
-    
+    BOOST_CHECK_NO_THROW(r = CallRPC("node1", "sendrawtransaction " + hexStr, true, false));
+    BOOST_CHECK(r.write().size() < 32);
 
     // this will stop the chain if both burns were allowed in the chain, the miner must throw away one of the burns to avoid his block from being flagged as invalid
     GenerateBlocks(5, "node1");
@@ -611,7 +621,9 @@ BOOST_AUTO_TEST_CASE(generate_burn_syscoin_asset_zdag1)
 
     BOOST_CHECK_NO_THROW(r = CallRPC("node1", "signrawtransactionwithwallet " + find_value(r.get_obj(), "hex").get_str()));
     string hexStr = find_value(r.get_obj(), "hex").get_str();
-    BOOST_CHECK_THROW(r = CallRPC("node1", "sendrawtransaction " + hexStr), runtime_error);
+    BOOST_CHECK_NO_THROW(r = CallRPC("node1", "sendrawtransaction " + hexStr, true, false));
+    BOOST_CHECK(r.write().size() < 32);
+    
     MilliSleep(1000);
 
     AssetAllocationTransfer(true, "node1", assetguid, useraddress1, "\"[{\\\"address\\\":\\\"" + useraddress3 + "\\\",\\\"amount\\\":0.2}]\"");
@@ -682,7 +694,8 @@ BOOST_AUTO_TEST_CASE(generate_burn_syscoin_asset_zdag2)
 
     BOOST_CHECK_NO_THROW(r = CallRPC("node1", "signrawtransactionwithwallet " + find_value(r.get_obj(), "hex").get_str()));
     string hexStr = find_value(r.get_obj(), "hex").get_str();
-    BOOST_CHECK_THROW(r = CallRPC("node1", "sendrawtransaction " + hexStr), runtime_error);
+    BOOST_CHECK_NO_THROW(r = CallRPC("node1", "sendrawtransaction " + hexStr, true, false));
+    BOOST_CHECK(r.write().size() < 32);
 
     AssetAllocationTransfer(true, "node1", assetguid, useraddress2, "\"[{\\\"address\\\":\\\"" + useraddress3 + "\\\",\\\"amount\\\":0.2}]\"");
     MilliSleep(1000);
@@ -729,7 +742,8 @@ BOOST_AUTO_TEST_CASE(generate_burn_syscoin_asset_zdag3)
 
     BOOST_CHECK_NO_THROW(r = CallRPC("node1", "signrawtransactionwithwallet " + find_value(r.get_obj(), "hex").get_str()));
     string hexStr = find_value(r.get_obj(), "hex").get_str();
-    BOOST_CHECK_THROW(r = CallRPC("node1", "sendrawtransaction " + hexStr ), runtime_error); 
+    BOOST_CHECK_NO_THROW(r = CallRPC("node1", "sendrawtransaction " + hexStr, true, false));
+    BOOST_CHECK(r.write().size() < 32);
     
     
     AssetAllocationTransfer(true, "node1", assetguid, useraddress1, "\"[{\\\"address\\\":\\\"" + useraddress2 + "\\\",\\\"amount\\\":0.1}]\"");
@@ -895,8 +909,9 @@ BOOST_AUTO_TEST_CASE(generate_bad_assetmaxsupply_address)
 	BOOST_CHECK_NO_THROW(r = CallRPC("node1", "assetnew " + newaddress + " " + gooddata + " '' 3 2000 1000 31 ''"));
 
     BOOST_CHECK_NO_THROW(r = CallRPC("node1", "signrawtransactionwithwallet " + find_value(r.get_obj(), "hex").get_str()));
-    string hex = find_value(r.get_obj(), "hex").get_str();
-    BOOST_CHECK_THROW(r = CallRPC("node1", "sendrawtransaction " + hex ), runtime_error); 
+    string hexStr = find_value(r.get_obj(), "hex").get_str();
+    BOOST_CHECK_NO_THROW(r = CallRPC("node1", "sendrawtransaction " + hexStr, true, false));
+    BOOST_CHECK(r.write().size() < 32);
     
 }
 
@@ -911,8 +926,9 @@ BOOST_AUTO_TEST_CASE(generate_assetupdate_address)
 	BOOST_CHECK_NO_THROW(r = CallRPC("node2", "assetupdate " + guid + " " + newaddress + " '' 1 31 ''"));
 
 	BOOST_CHECK_NO_THROW(r = CallRPC("node2", "signrawtransactionwithwallet " + find_value(r.get_obj(), "hex").get_str()));
-    string hex_str = find_value(r.get_obj(), "hex").get_str();
-    BOOST_CHECK_THROW(r = CallRPC("node1", "sendrawtransaction " + hex_str ), runtime_error);
+    string hexStr = find_value(r.get_obj(), "hex").get_str();
+    BOOST_CHECK_NO_THROW(r = CallRPC("node1", "sendrawtransaction " + hexStr, true, false));
+    BOOST_CHECK(r.write().size() < 32);
     
 	AssetUpdate("node1", guid, "pub1");
 	// shouldn't update data, just uses prev data because it hasn't changed
@@ -929,8 +945,9 @@ BOOST_AUTO_TEST_CASE(generate_assetupdate_address)
 	BOOST_CHECK_NO_THROW(r = CallRPC("node1", "assetupdate " + guid + " " + newaddress + " '' 5 " + boost::lexical_cast<string>(updateflags) + " ''"));
 
     BOOST_CHECK_NO_THROW(r = CallRPC("node1", "signrawtransactionwithwallet " + find_value(r.get_obj(), "hex").get_str()));
-    string hex = find_value(r.get_obj(), "hex").get_str();
-    BOOST_CHECK_THROW(r = CallRPC("node1", "sendrawtransaction " + hex ), runtime_error);
+    hexStr = find_value(r.get_obj(), "hex").get_str();
+    BOOST_CHECK_NO_THROW(r = CallRPC("node1", "sendrawtransaction " + hexStr, true, false));
+    BOOST_CHECK(r.write().size() < 32);
         
 
 	AssetUpdate("node1", guid1, "pub12", "1", boost::lexical_cast<string>(updateflags));
@@ -938,8 +955,9 @@ BOOST_AUTO_TEST_CASE(generate_assetupdate_address)
 	BOOST_CHECK_NO_THROW(r = CallRPC("node1", "assetupdate " + guid1 + " " + newaddress + " '' 1 " + boost::lexical_cast<string>(updateflags) + " ''"));
 
     BOOST_CHECK_NO_THROW(r = CallRPC("node1", "signrawtransactionwithwallet " + find_value(r.get_obj(), "hex").get_str()));
-    hex = find_value(r.get_obj(), "hex").get_str();
-    BOOST_CHECK_THROW(r = CallRPC("node1", "sendrawtransaction " + hex ), runtime_error);  
+    hexStr = find_value(r.get_obj(), "hex").get_str();
+    BOOST_CHECK_NO_THROW(r = CallRPC("node1", "sendrawtransaction " + hexStr, true, false));
+    BOOST_CHECK(r.write().size() < 32);
 
 }
 BOOST_AUTO_TEST_CASE(generate_assetupdate_precision_address)
@@ -966,8 +984,9 @@ BOOST_AUTO_TEST_CASE(generate_assetupdate_precision_address)
 		// can't go above max balance (10^18) / (10^i) for i decimal places
 		BOOST_CHECK_NO_THROW(r = CallRPC("node1", "assetupdate " + guid + " pub '' 1 31 ''"));
         BOOST_CHECK_NO_THROW(r = CallRPC("node1", "signrawtransactionwithwallet " + find_value(r.get_obj(), "hex").get_str()));
-        string hex = find_value(r.get_obj(), "hex").get_str();
-        BOOST_CHECK_THROW(r = CallRPC("node1", "sendrawtransaction " + hex ), runtime_error);
+        string hexStr = find_value(r.get_obj(), "hex").get_str();
+        BOOST_CHECK_NO_THROW(r = CallRPC("node1", "sendrawtransaction " + hexStr, true, false));
+        BOOST_CHECK(r.write().size() < 32);
 
 
 		// "assetnew [address] [public value] [contract] [precision=8] [supply] [max_supply] [update_flags] [witness]\n"
@@ -1030,8 +1049,9 @@ BOOST_AUTO_TEST_CASE(generate_assetsend_address)
 	BOOST_CHECK_NO_THROW(r = CallRPC("node1", "assetupdate " + guid + " " + newaddress + " '' 1 31 ''"));
 
     BOOST_CHECK_NO_THROW(r = CallRPC("node1", "signrawtransactionwithwallet " + find_value(r.get_obj(), "hex").get_str()));
-    string hex = find_value(r.get_obj(), "hex").get_str();
-    BOOST_CHECK_THROW(r = CallRPC("node1", "sendrawtransaction " + hex ), runtime_error);
+    string hexStr = find_value(r.get_obj(), "hex").get_str();
+    BOOST_CHECK_NO_THROW(r = CallRPC("node1", "sendrawtransaction " + hexStr, true, false));
+    BOOST_CHECK(r.write().size() < 32);
 
 }
 BOOST_AUTO_TEST_CASE(generate_assettransfer_address)
@@ -1059,8 +1079,9 @@ BOOST_AUTO_TEST_CASE(generate_assettransfer_address)
 	BOOST_CHECK_NO_THROW(r = CallRPC("node1", "assettransfer " + guid1 + " " + newaddres3 + " ''"));
 
     BOOST_CHECK_NO_THROW(r = CallRPC("node1", "signrawtransactionwithwallet " + find_value(r.get_obj(), "hex").get_str()));
-    string hex = find_value(r.get_obj(), "hex").get_str();
-    BOOST_CHECK_THROW(r = CallRPC("node1", "sendrawtransaction " + hex ), runtime_error);    
+    string hexStr = find_value(r.get_obj(), "hex").get_str();
+    BOOST_CHECK_NO_THROW(r = CallRPC("node1", "sendrawtransaction " + hexStr, true, false));
+    BOOST_CHECK(r.write().size() < 32);  
     GenerateBlocks(5, "node1");
     BOOST_CHECK_NO_THROW(r = CallRPC("node1", "assetinfo " + guid1));
     BOOST_CHECK(find_value(r.get_obj(), "address").get_str() == newaddres2);

--- a/src/test/test_syscoin_services.cpp
+++ b/src/test/test_syscoin_services.cpp
@@ -601,7 +601,7 @@ void GetOtherNodes(const string& node, string& otherNode1, string& otherNode2)
 	}
 
 }
-string SyscoinMint(const string& node, const string& address, const string& amount, int height, const string& tx_hex, const string& txroot_hex, const string& txmerkleproof_hex, const string& txmerkleroofpath_hex, const string& receipt_hex, const string& receiptroot_hex, const string& receiptmerkleproof_hex, const string& receiptmerkleroofpath_hex, const string& witness)
+string SyscoinMint(const string& node, const string& address, const string& amount, int height, const string& tx_hex, const string& txroot_hex, const string& txmerkleproof_hex, const string& txmerkleroofpath_hex, const string& receipt_hex, const string& receiptroot_hex, const string& receiptmerkleproof_hex, const string& witness)
 {
     string otherNode1, otherNode2;
     GetOtherNodes(node, otherNode1, otherNode2);
@@ -627,8 +627,8 @@ string SyscoinMint(const string& node, const string& address, const string& amou
         BOOST_CHECK_NO_THROW(r = CallRPC(otherNode2, "syscoinsetethheaders " + headerStr));
         BOOST_CHECK_NO_THROW(r = CallRPC(otherNode2, "syscoinsetethstatus synced " + boost::lexical_cast<string>(heightPlus240)));
     }   
-    // "syscoinmint [addressto] [amount] [blocknumber] [tx_hex] [txroot_hex] [txmerkleproof_hex] [txmerkleroofpath_hex] [receipt_hex] [receiptroot_hex] [receiptmerkleproof_hex] [receiptmerkleroofpath_hex [witness]\n"
-    BOOST_CHECK_NO_THROW(r = CallRPC(node, "syscoinmint " + address + " " + amount + " " + boost::lexical_cast<string>(height) + " " + tx_hex + " a0" + txroot_hex + " " + txmerkleproof_hex + " " + txmerkleroofpath_hex + " " + receipt_hex + " a0" + receiptroot_hex + " " + receiptmerkleproof_hex + " " + receiptmerkleroofpath_hex +  " " + witness));
+    // "syscoinmint [addressto] [amount] [blocknumber] [tx_hex] [txroot_hex] [txmerkleproof_hex] [txmerkleroofpath_hex] [receipt_hex] [receiptroot_hex] [receiptmerkleproof_hex] [witness]\n"
+    BOOST_CHECK_NO_THROW(r = CallRPC(node, "syscoinmint " + address + " " + amount + " " + boost::lexical_cast<string>(height) + " " + tx_hex + " a0" + txroot_hex + " " + txmerkleproof_hex + " " + txmerkleroofpath_hex + " " + receipt_hex + " a0" + receiptroot_hex + " " + receiptmerkleproof_hex +  " " + witness));
     
     BOOST_CHECK_NO_THROW(r = CallRPC(node, "signrawtransactionwithwallet " + find_value(r.get_obj(), "hex").get_str()));
     string hex_str = find_value(r.get_obj(), "hex").get_str();

--- a/src/test/test_syscoin_services.cpp
+++ b/src/test/test_syscoin_services.cpp
@@ -601,7 +601,7 @@ void GetOtherNodes(const string& node, string& otherNode1, string& otherNode2)
 	}
 
 }
-string SyscoinMint(const string& node, const string& address, const string& amount, int height, const string& tx_hex, const string& txroot_hex, const string& txmerkleproof_hex, const string& txmerkleroofpath_hex, const string& receipt_hex, const string& receiptroot_hex, const string& receiptmerkleproof_hex, const string& witness)
+string SyscoinMint(const string& node, const string& address, const string& amount, int height, const string& tx_hex, const string& txroot_hex, const string& txmerkleproof_hex, const string& txmerkleproofpath_hex, const string& receipt_hex, const string& receiptroot_hex, const string& receiptmerkleproof_hex, const string& witness)
 {
     string otherNode1, otherNode2;
     GetOtherNodes(node, otherNode1, otherNode2);
@@ -628,7 +628,7 @@ string SyscoinMint(const string& node, const string& address, const string& amou
         BOOST_CHECK_NO_THROW(r = CallRPC(otherNode2, "syscoinsetethstatus synced " + boost::lexical_cast<string>(heightPlus240)));
     }   
     // "syscoinmint [addressto] [amount] [blocknumber] [tx_hex] [txroot_hex] [txmerkleproof_hex] [txmerkleroofpath_hex] [receipt_hex] [receiptroot_hex] [receiptmerkleproof_hex] [witness]\n"
-    BOOST_CHECK_NO_THROW(r = CallRPC(node, "syscoinmint " + address + " " + amount + " " + boost::lexical_cast<string>(height) + " " + tx_hex + " a0" + txroot_hex + " " + txmerkleproof_hex + " " + txmerkleroofpath_hex + " " + receipt_hex + " a0" + receiptroot_hex + " " + receiptmerkleproof_hex +  " " + witness));
+    BOOST_CHECK_NO_THROW(r = CallRPC(node, "syscoinmint " + address + " " + amount + " " + boost::lexical_cast<string>(height) + " " + tx_hex + " a0" + txroot_hex + " " + txmerkleproof_hex + " " + txmerkleproofpath_hex + " " + receipt_hex + " a0" + receiptroot_hex + " " + receiptmerkleproof_hex +  " " + witness));
     
     BOOST_CHECK_NO_THROW(r = CallRPC(node, "signrawtransactionwithwallet " + find_value(r.get_obj(), "hex").get_str()));
     string hex_str = find_value(r.get_obj(), "hex").get_str();

--- a/src/test/test_syscoin_services.h
+++ b/src/test/test_syscoin_services.h
@@ -28,7 +28,7 @@ string CallExternal(string &cmd);
 void SetSysMocktime(const int64_t& expiryTime);
 void SleepFor(const int& seconds, bool actualSleep=false);
 void GetOtherNodes(const string& node, string& otherNode1, string& otherNode2);
-string SyscoinMint(const string& node, const string& address, const string& amount, int height, const string& txroot_hex, const string& tx_hex, const string& txmerkleproof_hex, const string& txmerkleroofpath_hex, const string& receipt_hex, const string& receiptroot_hex, const string& receiptmerkleproof_hex, const string& witness="''");
+string SyscoinMint(const string& node, const string& address, const string& amount, int height, const string& txroot_hex, const string& tx_hex, const string& txmerkleproof_hex, const string& txmerkleproofpath_hex, const string& receipt_hex, const string& receiptroot_hex, const string& receiptmerkleproof_hex, const string& witness="''");
 string AssetNew(const string& node, const string& address, const string& pubdata = "''", const string& contract="''", const string& precision="8", const string& supply = "1", const string& maxsupply = "10", const string& updateflags = "31", const string& witness = "''");
 void AssetUpdate(const string& node, const string& guid, const string& pubdata = "''", const string& supply = "''",  const string& updateflags = "31", const string& witness = "''");
 void AssetTransfer(const string& node, const string &tonode, const string& gid, const string& toaddress, const string& witness = "''");

--- a/src/test/test_syscoin_services.h
+++ b/src/test/test_syscoin_services.h
@@ -28,7 +28,7 @@ string CallExternal(string &cmd);
 void SetSysMocktime(const int64_t& expiryTime);
 void SleepFor(const int& seconds, bool actualSleep=false);
 void GetOtherNodes(const string& node, string& otherNode1, string& otherNode2);
-string SyscoinMint(const string& node, const string& address, const string& amount, int height, const string& txroot_hex, const string& tx_hex, const string& txmerkleproof_hex, const string& txmerkleroofpath_hex, const string& receipt_hex, const string& receiptroot_hex, const string& receiptmerkleproof_hex, const string& receiptmerkleroofpath_hex, const string& witness="''");
+string SyscoinMint(const string& node, const string& address, const string& amount, int height, const string& txroot_hex, const string& tx_hex, const string& txmerkleproof_hex, const string& txmerkleroofpath_hex, const string& receipt_hex, const string& receiptroot_hex, const string& receiptmerkleproof_hex, const string& witness="''");
 string AssetNew(const string& node, const string& address, const string& pubdata = "''", const string& contract="''", const string& precision="8", const string& supply = "1", const string& maxsupply = "10", const string& updateflags = "31", const string& witness = "''");
 void AssetUpdate(const string& node, const string& guid, const string& pubdata = "''", const string& supply = "''",  const string& updateflags = "31", const string& witness = "''");
 void AssetTransfer(const string& node, const string &tonode, const string& gid, const string& toaddress, const string& witness = "''");

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1876,6 +1876,7 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
     }
     AssetMap mapAssets;
     AssetAllocationMap mapAssetAllocations;
+    EthereumMintTxVec vecMintKeys;
     std::vector<uint256> vecTXIDs;
 	std::vector<COutPoint> vecOutpoints;
     std::vector<uint256> vecBlocks;
@@ -1930,11 +1931,11 @@ DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockI
             // At this point, all of txundo.vprevout should have been moved out.
         }
         // SYSCOIN
-        if(!DisconnectSyscoinTransaction(tx, pindex, view, mapAssets, mapAssetAllocations))
+        if(!DisconnectSyscoinTransaction(tx, pindex, view, mapAssets, mapAssetAllocations, vecMintKeys))
             fClean = false;
     } 
     // SYSCOIN 
-    if(!passetallocationdb->Flush(mapAssetAllocations) || !passetdb->Flush(mapAssets) || !passetindexdb->FlushErase(vecTXIDs) || !pblockindexdb->FlushErase(vecTXIDs) || !plockedoutpointsdb->FlushErase(vecOutpoints)){
+    if(!passetallocationdb->Flush(mapAssetAllocations) || !passetdb->Flush(mapAssets) || !passetindexdb->FlushErase(vecTXIDs) || !pblockindexdb->FlushErase(vecTXIDs) || !plockedoutpointsdb->FlushErase(vecOutpoints) || !pethereumtxmintdb->FlushErase(vecMintKeys)){
        error("DisconnectBlock(): Error flushing to asset dbs on disconnect");
        return DISCONNECT_FAILED;
     }  

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4464,9 +4464,9 @@ static const CRPCCommand commands[] =
    /* SYSCOIN rpc functions*/
     { "syscoin",            "convertaddress",                   &convertaddress,                {"address"} },
     { "syscoin",            "syscoinburn",                      &syscoinburn,                   {"funding_address","amount","ethereum_destination_address"} },
-    { "syscoin",            "syscoinmint",                      &syscoinmint,                   {"address","amount","blocknumber","tx_hex","txroot_hex","txmerkleproof_hex","txmerkleroofpath_hex","witness"} }, 
+    { "syscoin",            "syscoinmint",                      &syscoinmint,                   {"address","amount","blocknumber","tx_hex","txroot_hex","txmerkleproof_hex","txmerkleproofpath_hex","witness"} }, 
     { "syscoin",            "assetallocationburn",              &assetallocationburn,           {"asset_guid","address","amount","ethereum_destination_address"} }, 
-    { "syscoin",            "assetallocationmint",              &assetallocationmint,           {"asset_guid","address","amount","blocknumber","tx_hex","txroot_hex","txmerkleproof_hex","txmerkleroofpath_hex","witness"} },     
+    { "syscoin",            "assetallocationmint",              &assetallocationmint,           {"asset_guid","address","amount","blocknumber","tx_hex","txroot_hex","txmerkleproof_hex","txmerkleproofpath_hex","witness"} },     
     { "syscoin",            "syscointxfund",                    &syscointxfund,                 {"hexstring","address","output_index"}},
     { "syscoin",            "syscoindecoderawtransaction",      &syscoindecoderawtransaction,   {}},
   


### PR DESCRIPTION
…deraw

1) We weren't checking to see if ethereum transactions were actually already used to mint. So we create a db to keep track of eth blocknumber/tx index tuple as key and ensure its not already spent. We also need to manage reorgs on the syscoin side and remove these keys from db on syscoin reorg. We have blocknumber as part of the tx mintsyscoin object and blocknumber retrieves the txroot that is checked from the txrootdb, and the txroot is commited to by the block header which is verified by consensus. The path value is an RLP encoded transaction index so we can decode it and get it as a uint32 (not sure what correct format is for the path but i assume uint32 is safe to convert to, seems to pass the test).
2) syscoinmint tx's were not showing json in the "systx" field in decoderawtransaction, just add to the path inside of the mintassettx and detect the type inside.