### PR TITLE
sendfrom + fix on wallet spending on allocation addresses

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -173,6 +173,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "syscoinmint", 1, "amount" },
     { "syscoinmint", 2, "blocknumber" },
     { "syscoinburn", 1, "amount" },
+    { "sendfrom", 2, "amount" },
     { "syscointxfund", 2, "output_index" },
     { "assetallocationlock", 0, "asset_guid" },
     { "assetallocationlock", 3, "output_index" },

--- a/src/services/assetallocation.h
+++ b/src/services/assetallocation.h
@@ -140,6 +140,9 @@ public:
     bool ReadAssetsByAddress(const CWitnessAddress &address, std::vector<uint32_t> &assetGuids){
         return Read(address, assetGuids);
     }
+    bool ExistsAssetsByAddress(const CWitnessAddress &address){
+        return Exists(address);
+    }	
     bool Flush(const AssetAllocationMap &mapAssetAllocations);
 	void WriteAssetAllocationIndex(const CTransaction &tx, const CAsset& dbAsset, const int &nHeight, const uint256& blockhash);
     void WriteMintIndex(const CTransaction& tx, const CMintSyscoin& mintSyscoin, const int &nHeight, const uint256& blockhash);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2407,9 +2407,9 @@ void CWallet::AvailableCoins(interfaces::Chain::Lock& locked_chain, std::vector<
             int witnessversion = 0;
             std::vector<unsigned char> witnessprogram;
             // if asset index and coincontrol is not enabled or not selecting this output and this is a witness program, check to ensure the address doesn't belong to an asset
-            if (fAssetIndex && passetdb != nullptr && (!coinControl || !coinControl->HasSelected() || !coinControl->IsSelected(COutPoint(entry.first, i)) && wtx.tx->vout[i].scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram))){
+            if (fAssetIndex && passetdb != nullptr && passetallocationdb != nullptr && (!coinControl || !coinControl->HasSelected() || !coinControl->IsSelected(COutPoint(entry.first, i))) && wtx.tx->vout[i].scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)){
                 CWitnessAddress witnessAddress(witnessversion, witnessprogram);
-                if(passetdb->ExistsAssetsByAddress(witnessAddress)){
+                if(passetdb->ExistsAssetsByAddress(witnessAddress) || passetallocationdb->ExistsAssetsByAddress(witnessAddress)){
                     WalletLogPrintf("Ignoring fund addr connected to asset(s): %s\n", witnessAddress.ToString());
                     continue;
                 }


### PR DESCRIPTION
wasn't checking for asset allocation addresses associated to assets also wrote unit test around the wallet auto selection algo and asset addresses.

sendfrom helper rpc for spending sys from a source funding address, uses syscointxfund internally and returns an unsigned hex.