### PR TITLE
fix masternode list-conf bug

### DIFF
--- a/src/rpc/masternode.cpp
+++ b/src/rpc/masternode.cpp
@@ -314,6 +314,7 @@ UniValue masternode(const JSONRPCRequest& request)
     if (strCommand == "list-conf")
     {
         UniValue resultObj(UniValue::VOBJ);
+        UniValue masternodesObj(UniValue::VARR);
 
         for (const auto& mne : masternodeConfig.getEntries()) {
             uint32_t outputIndex;
@@ -333,8 +334,9 @@ UniValue masternode(const JSONRPCRequest& request)
             mnObj.pushKV("txHash", mne.getTxHash());
             mnObj.pushKV("outputIndex", mne.getOutputIndex());
             mnObj.pushKV("status", strStatus);
-            resultObj.pushKV("masternode", mnObj);
+            masternodesObj.push_back(mnObj);
         }
+        resultObj.pushKV("masternode", masternodesObj);
 
         return resultObj;
     }


### PR DESCRIPTION
masternode list-conf only show last entry in masternode.conf.

This pull request attempt to fix this by changing "masternode" to an array:
```
{
  "masternode": [
    {
      "name": "mn0",
...
    },
    {
      "name": "mn1",
...
    }
  ]
}
```

Since no document about list-conf's result structure, other method is also acceptable. I just point out this issue and feel free to change my code or merge other's pull request.