### PR TITLE
Fixed issue #395 and assetnew input checks

### DIFF
--- a/src/services/rpc/assetrpc.cpp
+++ b/src/services/rpc/assetrpc.cpp
@@ -114,13 +114,13 @@ CAmount AssetAmountFromValue(UniValue& value, int precision)
         throw JSONRPCError(RPC_TYPE_ERROR, "Precision must be between 0 and 8");
     if (!value.isNum() && !value.isStr())
         throw JSONRPCError(RPC_TYPE_ERROR, "Amount is not a number or string");
-    if (value.isStr() && value.get_str() == "-1") {
+    if ((value.isNum() && value.get_real() == double(-1)) || (value.isStr() && value.get_str() == "-1")) {
         value.setInt((int64_t)(MAX_ASSET / ((int)pow(10, precision))));
     }
     CAmount amount;
     if (!ParseFixedPoint(value.getValStr(), precision, &amount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");
-    if (amount > 0 && !AssetRange(amount))
+    if (amount < 0 || !AssetRange(amount))
         throw JSONRPCError(RPC_TYPE_ERROR, "Amount out of range");
     return amount;
 }

--- a/src/services/rpc/wallet/assetwalletrpc.cpp
+++ b/src/services/rpc/wallet/assetwalletrpc.cpp
@@ -448,6 +448,8 @@ UniValue assetnew(const JSONRPCRequest& request) {
          boost::erase_all(strContract, "0x");  // strip 0x in hex str if exist
 
     uint32_t precision = params[4].get_uint();
+    if(precision < 0 || precision > 8)
+        throw JSONRPCError(RPC_TYPE_ERROR, "Precision must be between 0 and 8");
     string vchWitness;
     UniValue param4 = params[5];
     UniValue param5 = params[6];


### PR DESCRIPTION
This following command is currently accepted, albeit not signable / sendable
```
assetnew "tsys1qg24rsevayhz9myjxu2ypcythynsqughpcjh7qw" "TEST" "" "" 108 -50000 "-100" 31 '{}' ""
```
3 Issues are located:
1.  Precision check is in `AssetAmountFromValue` and throws an error if out-of-bound, but `assetnew` catches the error and just sets the value to 0.  The fix is to do a precision check just after reading the precision param value.

2.  Total supply and max supply are allowed to be negative.  The check in AssetAmountFromValue allowed negative number to fall through.  This can be fixed by changing the check 
```
-    if (amount > 0 && !AssetRange(amount))
+    if (amount < 0 || !AssetRange(amount))
```

3.  As mentioned in `help assetnew`.  A total supply or max supply of `-1` should set those values to the maximum value possible post precision calculation.   This is not currently happening as reported in #395 .  It appears that the string check for -1 is insufficient so a number check for -1 is added