### PR TITLE
Split deterministic asset guid start height and erc20 start height

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -146,6 +146,7 @@ public:
         consensus.vchTokenFreezeMethod = ParseHex("aabab1db49e504b5156edf3f99042aeecb9607a08f392589571cd49743aaba8d");
         consensus.nBridgeStartBlock = 348000;
         consensus.nDeterministicAssetStartBlock = 448000;
+        consensus.nERC20StartBlock = 448000;
         /**
          * The message start string is designed to be unlikely to occur in normal data.
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -271,7 +272,8 @@ public:
         consensus.vchSYSXERC20Manager = ParseHex("443d9a14fb6ba2A45465bEC3767186f404Ccea25");
         consensus.vchTokenFreezeMethod = ParseHex("aabab1db49e504b5156edf3f99042aeecb9607a08f392589571cd49743aaba8d");
         consensus.nBridgeStartBlock = 1000;
-        consensus.nDeterministicAssetStartBlock = 80000;
+        consensus.nDeterministicAssetStartBlock = 125000;
+        consensus.nERC20StartBlock = 80000;
         pchMessageStart[0] = 0xce;
         pchMessageStart[1] = 0xe2;
         pchMessageStart[2] = 0xca;
@@ -390,6 +392,7 @@ public:
         consensus.vchTokenFreezeMethod = ParseHex("aabab1db49e504b5156edf3f99042aeecb9607a08f392589571cd49743aaba8d");
         consensus.nBridgeStartBlock = 100;
         consensus.nDeterministicAssetStartBlock = 100;
+        consensus.nERC20StartBlock = 100;
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;
         pchMessageStart[2] = 0xb5;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -55,6 +55,7 @@ struct Params {
     double nSeniorityLevel2;
     int nBridgeStartBlock;
     int nDeterministicAssetStartBlock;
+    int nERC20StartBlock
         
     int nSuperblockStartBlock;
     int nSuperblockCycle; // in blocks

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -55,7 +55,7 @@ struct Params {
     double nSeniorityLevel2;
     int nBridgeStartBlock;
     int nDeterministicAssetStartBlock;
-    int nERC20StartBlock
+    int nERC20StartBlock;
         
     int nSuperblockStartBlock;
     int nSuperblockCycle; // in blocks

--- a/src/services/assetconsensus.cpp
+++ b/src/services/assetconsensus.cpp
@@ -129,7 +129,7 @@ bool CheckSyscoinMint(const bool &ibd, const CTransaction& tx, const uint256& tx
     }
     const size_t &itemCount = rlpReceiptLogsValue.itemCount();
     // just sanity checks for bounds
-    if(nHeight >= Params().GetConsensus().nDeterministicAssetStartBlock) {
+    if(nHeight >= Params().GetConsensus().nERC20StartBlock) {
         if (itemCount < 1 || itemCount > 10){
             return FormatSyscoinErrorMessage(state, "mint-invalid-receipt-logs-count", bSanityCheck);
         }


### PR DESCRIPTION
This allows the 2 height to be separated as needed on the current testnet