### PR TITLE
Combine superblock 23 and superblock 24 budget

### DIFF
--- a/src/governance/governanceclasses.cpp
+++ b/src/governance/governanceclasses.cpp
@@ -542,10 +542,11 @@ CAmount CSuperblock::GetPaymentsLimit(int nBlockHeight)
                         nPaymentsLimit =  272260.39 *COIN;
                         break;
             case 23:
-                        nPaymentsLimit =  231421.33 *COIN;
+                        nPaymentsLimit =  0;
                         break;
             case 24:
-                        nPaymentsLimit =  196708.13 *COIN;
+                        /* Syscoin 4.2 Upgrade - combine superblock 23 and 24 */
+                        nPaymentsLimit =  (231421.33 + 196708.13) *COIN;
                         break;
             case 25:
                         nPaymentsLimit =  151767.00 *COIN;


### PR DESCRIPTION
Due to the upgrade height (block 1004200) being between the voting deadline (block 1003080) and superblock 23 block height (block 1007400), this commit will omit superblock 23 and combine the budget in superblock 24 for a total of 428129.46 