### PR TITLE
switch to own fork of libsodium-cmake

### DIFF
--- a/depends/packages/bls-dash.mk
+++ b/depends/packages/bls-dash.mk
@@ -8,6 +8,13 @@ $(package)_sha256_hash=65a6f5385861e6c5f52bc67518b9468f65b3f826dc9a30cf6e30860e6
 $(package)_dependencies=gmp cmake
 $(package)_darwin_triplet=x86_64-apple-darwin19
 
+$(package)_sodium_version=97b0f4eff964f4ddaf0d0dd2bc5735df7cbd0c85
+$(package)_sodium_download_path=https://github.com/syscoin/libsodium-cmake/archive
+$(package)_sodium_download_file=$($(package)_sodium_version).tar.gz
+$(package)_sodium_file_name=sodium-$($(package)_sodium_download_file)
+$(package)_sodium_build_subdir=sodium
+$(package)_sodium_sha256_hash=151d927c8e49dd290b92572f86642d624d0bc0ebbeb3d83866f35b05f43118a7
+
 $(package)_relic_version=aecdcae7956f542fbee2392c1f0feb0a8ac41dc5
 $(package)_relic_download_path=https://github.com/relic-toolkit/relic/archive
 $(package)_relic_download_file=$($(package)_relic_version).tar.gz
@@ -15,19 +22,23 @@ $(package)_relic_file_name=relic-$($(package)_relic_download_file)
 $(package)_relic_build_subdir=relic
 $(package)_relic_sha256_hash=f2de6ebdc9def7077f56c83c8b06f4da5bacc36b709514bd550a92a149e9fa1d
 
-$(package)_extra_sources=$($(package)_relic_file_name)
+$(package)_extra_sources  = $($(package)_sodium_file_name)
+$(package)_extra_sources += $($(package)_relic_file_name)
 
 define $(package)_fetch_cmds
 $(call fetch_file,$(package),$($(package)_download_path),$($(package)_download_file),$($(package)_file_name),$($(package)_sha256_hash)) && \
+$(call fetch_file,$(package),$($(package)_sodium_download_path),$($(package)_sodium_download_file),$($(package)_sodium_file_name),$($(package)_sodium_sha256_hash)) && \
 $(call fetch_file,$(package),$($(package)_relic_download_path),$($(package)_relic_download_file),$($(package)_relic_file_name),$($(package)_relic_sha256_hash))
 endef
 
 define $(package)_extract_cmds
   mkdir -p $($(package)_extract_dir) && \
   echo "$($(package)_sha256_hash)  $($(package)_source)" > $($(package)_extract_dir)/.$($(package)_file_name).hash && \
+  echo "$($(package)_sodium_sha256_hash)  $($(package)_source_dir)/$($(package)_sodium_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   echo "$($(package)_relic_sha256_hash)  $($(package)_source_dir)/$($(package)_relic_file_name)" >> $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   $(build_SHA256SUM) -c $($(package)_extract_dir)/.$($(package)_file_name).hash && \
   tar --strip-components=1 -xf $($(package)_source) -C . && \
+  cp $($(package)_source_dir)/$($(package)_sodium_file_name) . && \
   cp $($(package)_source_dir)/$($(package)_relic_file_name) .
 endef
 
@@ -54,6 +65,8 @@ define $(package)_set_vars
 endef
 
 define $(package)_preprocess_cmds
+  sed -i.old "s|GIT_REPOSITORY https://github.com/AmineKhaldi/libsodium-cmake.git|URL \"../../sodium-$($(package)_sodium_version).tar.gz\"|" CMakeLists.txt && \
+  sed -i.old "s|GIT_TAG f73a3fe1afdc4e37ac5fe0ddd401bf521f6bba65|GIT_TAG \"\"|" CMakeLists.txt && \
   sed -i.old "s|GIT_REPOSITORY https://github.com/Chia-Network/relic.git|URL \"../../relic-$($(package)_relic_version).tar.gz\"|" CMakeLists.txt && \
   sed -i.old "s|RELIC_GIT_TAG \".*\"|RELIC_GIT_TAG \"\"|" CMakeLists.txt
 endef


### PR DESCRIPTION
Libsodium-cmake used git submodule and cloning, which caused problems when building with guix;
in our own fork we replaced the submodule with the file tree of the included repo and download the git archive file.