### PR TITLE
Fixed RPC Internal errors in helps

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -299,9 +299,29 @@ static RPCHelpMan getchainlocks()
             RPCResult{
                 RPCResult::Type::OBJ, "", "",
                 {
-                    {RPCResult::Type::ANY, "recent_chainlock", "Most recent chainlock share"},
-                    {RPCResult::Type::ANY, "active_chainlock", "Most active chainlock"},
-                    
+                    {RPCResult::Type::OBJ, "recent_chainlock", "Most recent chainlock information", 
+                    {
+                        {RPCResult::Type::STR_HEX, "blockhash", "Block Hash"},
+                        {RPCResult::Type::NUM, "height", "Block Height"},
+                        {RPCResult::Type::STR_HEX, "signature", "Signature"},
+                        {RPCResult::Type::BOOL, "known_block", "Block Known"}
+                    }},
+                    {RPCResult::Type::OBJ, "active_chainlock", "Active chainlock information",
+                    {
+                        {RPCResult::Type::STR_HEX, "blockhash", "Block Hash"},
+                        {RPCResult::Type::NUM, "height", "Block Height"},
+                        {RPCResult::Type::NUM, "signers", "Signer"},
+                        {RPCResult::Type::STR_HEX, "signature", "Signature"},
+                        {RPCResult::Type::ARR, "shares", "",
+                        {
+                            {RPCResult::Type::OBJ, "shares", "Shares information",
+                            {
+                                {RPCResult::Type::STR_HEX, "quorumHash", "Quorum Hash"},
+                                {RPCResult::Type::NUM, "signers", "Signers"},
+                                {RPCResult::Type::STR_HEX, "signature", "Signature"}
+                            }}
+                        }}
+                    }}
                 }},
             RPCExamples{
                 HelpExampleCli("getchainlocks", "")

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -120,13 +120,13 @@ static std::vector<RPCResult> DecodeTxDoc(const std::string& txid_field_doc)
                 }},
             }},
         }},
-        {RPCResult::Type::ANY, "sysx", /*optional=*/true, ""},
-        {RPCResult::Type::ANY, "proRegTx", /*optional=*/true, ""},
-        {RPCResult::Type::ANY, "proUpServTx", /*optional=*/true, ""},
-        {RPCResult::Type::ANY, "proUpRegTx", /*optional=*/true, ""},
-        {RPCResult::Type::ANY, "proUpRevTx", /*optional=*/true, ""},
-        {RPCResult::Type::ANY, "cbTx", /*optional=*/true, ""},
-        {RPCResult::Type::ANY, "qcTx", /*optional=*/true, ""},
+        {RPCResult::Type::STR_HEX, "sysx", /*optional=*/true, ""},
+        {RPCResult::Type::STR_HEX, "proRegTx", /*optional=*/true, ""},
+        {RPCResult::Type::STR_HEX, "proUpServTx", /*optional=*/true, ""},
+        {RPCResult::Type::STR_HEX, "proUpRegTx", /*optional=*/true, ""},
+        {RPCResult::Type::STR_HEX, "proUpRevTx", /*optional=*/true, ""},
+        {RPCResult::Type::STR_HEX, "cbTx", /*optional=*/true, ""},
+        {RPCResult::Type::STR_HEX, "qcTx", /*optional=*/true, ""},
     };
 }
 


### PR DESCRIPTION
Six RPC commands (getchainlocks, decoderawtransaction, getrawtransaction, listtransactions, gettransaction, listsinceblock) were showing the following error messages when using `syscoin-cli help [command]`

```
syscoin-cli help getrawtransaction
Internal bug detected: "Unreachable code reached (non-fatal)"
rpc/util.cpp:832 (ToSections)
Please report this issue here: https://github.com/syscoin/syscoin/issues

```

And shows up as the following when calling `syscoin-cli help`
```
Internal bug detected: "Unreachable code reached (non-fatal)"
```

