### PR TITLE
Implement getutxostats RPC method for total unique funded addresses.

### DIFF
--- a/src/kernel/coinstats.cpp
+++ b/src/kernel/coinstats.cpp
@@ -142,6 +142,9 @@ static bool ComputeUTXOStats(CCoinsView* view, CCoinsStats& stats, T hash_obj, c
             prevkey = key.hash;
             outputs[key.n] = std::move(coin);
             stats.coins_count++;
+
+            // Add the scriptPubKey to the set of unique scriptPubKeys
+            stats.uniqueScriptPubKeys.insert(coin.out.scriptPubKey);
         } else {
             return error("%s: unable to read value", __func__);
         }

--- a/src/kernel/coinstats.h
+++ b/src/kernel/coinstats.h
@@ -39,6 +39,9 @@ struct CCoinsStats {
     //! The total amount, or nullopt if an overflow occurred calculating it
     std::optional<CAmount> total_amount{0};
 
+    //! The set of unique scriptPubKeys in the UTXO set. Used to estimate the number of addresses holding coins.
+    std::set<CScript> uniqueScriptPubKeys;
+
     //! The number of coins contained.
     uint64_t coins_count{0};
 

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -5,6 +5,8 @@
 #ifndef SYSCOIN_RPC_BLOCKCHAIN_H
 #define SYSCOIN_RPC_BLOCKCHAIN_H
 
+#include <kernel/coinstats.h>
+
 #include <consensus/amount.h>
 #include <core_io.h>
 #include <streams.h>

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -16,6 +16,7 @@ Test the following RPCs:
     - getblock
     - getblockhash
     - getbestblockhash
+    - getutxostats
     - verifychain
 
 Tests correspond to code in rpc/blockchain.cpp.
@@ -86,6 +87,7 @@ class BlockchainTest(SyscoinTestFramework):
         self._test_getblockheader()
         self._test_getdifficulty()
         self._test_getnetworkhashps()
+        self._test_getutxostats()
         self._test_stopatheight()
         self._test_waitforblockheight()
         self._test_getblock()
@@ -595,6 +597,24 @@ class BlockchainTest(SyscoinTestFramework):
         assert 'previousblockhash' not in node.getblock(node.getblockhash(0))
         assert 'nextblockhash' not in node.getblock(node.getbestblockhash())
 
+    def _test_getutxostats(self):
+        self.log.info("Test getutxostats")
+        node = self.nodes[0]
+
+        # Call getutxostats with default arguments
+        res = node.getutxostats()
+
+        # Check that the result includes the expected keys
+        expected_keys = ['height', 'transactions', 'txouts', 'bogosize', 'total_amount', 'total_addresses']
+        assert_equal(sorted(res.keys()), sorted(expected_keys))
+
+        # Check that the values are of the correct types
+        assert isinstance(res['height'], int)
+        assert isinstance(res['transactions'], int)
+        assert isinstance(res['txouts'], int)
+        assert isinstance(res['bogosize'], int)
+        assert isinstance(res['total_amount'], Decimal)
+        assert isinstance(res['total_addresses'], int)
 
 if __name__ == '__main__':
     BlockchainTest().main()


### PR DESCRIPTION
- Implemented a new RPC method, getutxostats(), to compute UTXO statistics including the count of total unique funded addresses (scriptPubKeys) in the UTXO set.
- This enhancement provides the ability to determine the total number of unique addresses that currently hold some amount of SYS.
- Implemented _test_getutxostats() function in rpc_blockchain.py to validate the new getutxostats() RPC method and the total_addresses field.