### PR TITLE
nevm: avoid managed geth startup and shutdown stalls

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -348,6 +348,10 @@ void Shutdown(NodeContext& node)
     // Drop transactions we were still watching, and record fee estimations.
     if (node.fee_estimator) node.fee_estimator->Flush();
 
+    if (node.chainman) {
+        node.chainman->ActiveChainstate().StopGethNode();
+    }
+
     // FlushStateToDisk generates a ChainStateFlushed callback, which we should avoid missing
     if (node.chainman) {
         const auto phase1_flush_start = std::chrono::steady_clock::now();
@@ -398,7 +402,6 @@ void Shutdown(NodeContext& node)
             LogPrint(BCLog::SYS, "Shutdown: phase 2 ForceFlushStateToDisk + ResetCoinsViews start\n");
             // SYSCOIN
             node.chainman->ActiveChainstate().StopBTCHeaderNode();
-            node.chainman->ActiveChainstate().StopGethNode();
             for (Chainstate* chainstate : node.chainman->GetAll()) {
                 if (chainstate->CanFlushToDisk()) {
                     chainstate->ForceFlushStateToDisk();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -47,7 +47,6 @@
 #include <script/script.h>
 #include <script/sigcache.h>
 #include <signet.h>
-#include <shutdown.h>
 #include <tinyformat.h>
 #include <txdb.h>
 #include <txmempool.h>
@@ -1976,7 +1975,7 @@ bool ChainstateManager::IsInitialBlockDownload() const
         notify_nevm_startnetwork = fNEVMConnection && !fRegTest;
     }
 
-    if (notify_nevm_startnetwork && !ShutdownRequested()) {
+    if (notify_nevm_startnetwork && !m_interrupt) {
         bool bResponse = false;
         GetMainSignals().NotifyNEVMComms("startnetwork", bResponse);
     }
@@ -2312,7 +2311,7 @@ bool Chainstate::ConnectNEVMCommitment(BlockValidationState& state, NEVMTxRootMa
     std::string stateStr;
     const bool bypass_external_notify = ShouldBypassExternalNEVMNotifyCalls(m_chainman, nHeight);
     if(fNEVMConnection && !bypass_external_notify) {
-        if (ShutdownRequested()) {
+        if (m_chainman.m_interrupt) {
             return state.Error("shutdown");
         }
         GetMainSignals().NotifyNEVMBlockConnect(nevmBlockHeader, block, stateStr, fJustCheck? uint256(): nBlockHash, NEVMDataVecOut, nHeight, bSkipValidation, btcPrevHashForNEVM, diff);
@@ -2370,7 +2369,7 @@ bool DisconnectNEVMCommitment(ChainstateManager& chainman, BlockValidationState&
         return false; // state filled by GetNEVMData
     }
     if(fNEVMConnection && !ShouldBypassExternalNEVMNotifyCalls(chainman, nHeight)) {
-        if (ShutdownRequested()) {
+        if (chainman.m_interrupt) {
             return state.Error("shutdown");
         }
         std::string stateStr;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -47,6 +47,7 @@
 #include <script/script.h>
 #include <script/sigcache.h>
 #include <signet.h>
+#include <shutdown.h>
 #include <tinyformat.h>
 #include <txdb.h>
 #include <txmempool.h>
@@ -1975,7 +1976,7 @@ bool ChainstateManager::IsInitialBlockDownload() const
         notify_nevm_startnetwork = fNEVMConnection && !fRegTest;
     }
 
-    if (notify_nevm_startnetwork) {
+    if (notify_nevm_startnetwork && !ShutdownRequested()) {
         bool bResponse = false;
         GetMainSignals().NotifyNEVMComms("startnetwork", bResponse);
     }
@@ -2310,7 +2311,7 @@ bool Chainstate::ConnectNEVMCommitment(BlockValidationState& state, NEVMTxRootMa
     }
     std::string stateStr;
     const bool bypass_external_notify = ShouldBypassExternalNEVMNotifyCalls(m_chainman, nHeight);
-    if(fNEVMConnection && !bypass_external_notify) {
+    if(fNEVMConnection && !bypass_external_notify && !ShutdownRequested()) {
         GetMainSignals().NotifyNEVMBlockConnect(nevmBlockHeader, block, stateStr, fJustCheck? uint256(): nBlockHash, NEVMDataVecOut, nHeight, bSkipValidation, btcPrevHashForNEVM, diff);
         if(!stateStr.empty()) {
             state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, stateStr);
@@ -2365,7 +2366,7 @@ bool DisconnectNEVMCommitment(ChainstateManager& chainman, BlockValidationState&
     if(!GetNEVMData(state, block, evmBlock)) {
         return false; // state filled by GetNEVMData
     }
-    if(fNEVMConnection && !ShouldBypassExternalNEVMNotifyCalls(chainman, nHeight)) {
+    if(fNEVMConnection && !ShouldBypassExternalNEVMNotifyCalls(chainman, nHeight) && !ShutdownRequested()) {
         std::string stateStr;
         GetMainSignals().NotifyNEVMBlockDisconnect(stateStr, nBlockHash, diff);
         if(!stateStr.empty()) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2311,7 +2311,10 @@ bool Chainstate::ConnectNEVMCommitment(BlockValidationState& state, NEVMTxRootMa
     }
     std::string stateStr;
     const bool bypass_external_notify = ShouldBypassExternalNEVMNotifyCalls(m_chainman, nHeight);
-    if(fNEVMConnection && !bypass_external_notify && !ShutdownRequested()) {
+    if(fNEVMConnection && !bypass_external_notify) {
+        if (ShutdownRequested()) {
+            return state.Error("shutdown");
+        }
         GetMainSignals().NotifyNEVMBlockConnect(nevmBlockHeader, block, stateStr, fJustCheck? uint256(): nBlockHash, NEVMDataVecOut, nHeight, bSkipValidation, btcPrevHashForNEVM, diff);
         if(!stateStr.empty()) {
             state.Invalid(BlockValidationResult::BLOCK_INVALID_HEADER, stateStr);
@@ -2366,7 +2369,10 @@ bool DisconnectNEVMCommitment(ChainstateManager& chainman, BlockValidationState&
     if(!GetNEVMData(state, block, evmBlock)) {
         return false; // state filled by GetNEVMData
     }
-    if(fNEVMConnection && !ShouldBypassExternalNEVMNotifyCalls(chainman, nHeight) && !ShutdownRequested()) {
+    if(fNEVMConnection && !ShouldBypassExternalNEVMNotifyCalls(chainman, nHeight)) {
+        if (ShutdownRequested()) {
+            return state.Error("shutdown");
+        }
         std::string stateStr;
         GetMainSignals().NotifyNEVMBlockDisconnect(stateStr, nBlockHash, diff);
         if(!stateStr.empty()) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -119,6 +119,12 @@ NEVMMintTxSet setMintTxsMempool;
 std::unordered_map<COutPoint, std::pair<CTransactionRef, CTransactionRef>, SaltedOutpointHasher> mapAssetAllocationConflicts;
 std::map<uint256, int64_t> mapRejectedBlocks GUARDED_BY(cs_main);
 
+static bool IsManagedGethStarted()
+{
+    LOCK(cs_geth);
+    return gethpid > 0;
+}
+
 using kernel::CCoinsStats;
 using kernel::CoinStatsHashType;
 using kernel::ComputeUTXOStats;
@@ -1943,28 +1949,36 @@ bool ChainstateManager::IsInitialBlockDownload() const
     if (m_cached_finished_ibd.load(std::memory_order_relaxed))
         return false;
 
-    LOCK(cs_main);
-    if (m_cached_finished_ibd.load(std::memory_order_relaxed))
-        return false;
-    if (m_blockman.LoadingBlocks()) {
-        return true;
+    bool notify_nevm_startnetwork{false};
+    {
+        LOCK(cs_main);
+        if (m_cached_finished_ibd.load(std::memory_order_relaxed))
+            return false;
+        if (m_blockman.LoadingBlocks()) {
+            return true;
+        }
+        CChain& chain{ActiveChain()};
+        if (chain.Tip() == nullptr) {
+            return true;
+        }
+        if (chain.Tip()->nChainWork < MinimumChainWork()) {
+            return true;
+        }
+        if (chain.Tip()->Time() < Now<NodeSeconds>() - m_options.max_tip_age) {
+            return true;
+        }
+        if (fNEVMConnection && !fRegTest && !IsManagedGethStarted()) {
+            return true;
+        }
+        LogPrintf("Leaving InitialBlockDownload (latching to false)\n");
+        m_cached_finished_ibd.store(true, std::memory_order_relaxed);
+        notify_nevm_startnetwork = fNEVMConnection && !fRegTest;
     }
-    CChain& chain{ActiveChain()};
-    if (chain.Tip() == nullptr) {
-        return true;
-    }
-    if (chain.Tip()->nChainWork < MinimumChainWork()) {
-        return true;
-    }
-    if (chain.Tip()->Time() < Now<NodeSeconds>() - m_options.max_tip_age) {
-        return true;
-    }
-    LogPrintf("Leaving InitialBlockDownload (latching to false)\n");
-    if(fNEVMConnection && !fRegTest) {
+
+    if (notify_nevm_startnetwork) {
         bool bResponse = false;
         GetMainSignals().NotifyNEVMComms("startnetwork", bResponse);
     }
-    m_cached_finished_ibd.store(true, std::memory_order_relaxed);
     return false;
 }
 

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -16,6 +16,7 @@
 #include <primitives/transaction.h>
 #include <rpc/server.h>
 #include <serialize.h>
+#include <shutdown.h>
 #include <streams.h>
 #include <sync.h>
 #include <uint256.h>
@@ -319,6 +320,9 @@ bool CZMQAbstractPublishNotifier::NotifyNEVMCommsCommon(const std::string &commM
 {
     LOCK(cs_nevm);
     bResponse = false;
+    if (ShutdownRequested() && commMessage != "disconnect") {
+        return false;
+    }
     if(psocketsub) {
         int timeout = 150000;
         int rc = zmq_setsockopt(psocketsub, ZMQ_RCVTIMEO, &timeout, sizeof(timeout));
@@ -364,6 +368,10 @@ bool CZMQPublishNEVMBlockConnectNotifier::NotifyNEVMBlockConnect(const CNEVMHead
 {
     LOCK(cs_nevm);
     state = "";
+    if (ShutdownRequested()) {
+        state = "shutdown";
+        return false;
+    }
     if(bFirstTime) {
         bFirstTime = false;
         bool bResponse = false;
@@ -417,6 +425,10 @@ bool CZMQPublishNEVMBlockConnectNotifier::NotifyNEVMBlockConnect(const CNEVMHead
 bool CZMQPublishNEVMBlockDisconnectNotifier::NotifyNEVMBlockDisconnect(std::string &state, const uint256& nSYSBlockHash, const CDeterministicMNListNEVMAddressDiff &diff)
 {
     LOCK(cs_nevm);
+    if (ShutdownRequested()) {
+        state = "shutdown";
+        return false;
+    }
     if(bFirstTime) {
         bFirstTime = false;
         bool bResponse = false;
@@ -468,6 +480,10 @@ bool CZMQPublishNEVMBlockDisconnectNotifier::NotifyNEVMBlockDisconnect(std::stri
 bool CZMQPublishNEVMBlockInfoNotifier::NotifyGetNEVMBlockInfo(uint64_t &nHeight, std::string &state)
 {
     LOCK(cs_nevm);
+    if (ShutdownRequested()) {
+        state = "shutdown";
+        return false;
+    }
     if(bFirstTime) {
         bFirstTime = false;
         bool bResponse = false;
@@ -507,6 +523,10 @@ bool CZMQPublishNEVMBlockInfoNotifier::NotifyGetNEVMBlockInfo(uint64_t &nHeight,
 bool CZMQPublishNEVMBlockNotifier::NotifyGetNEVMBlock(CNEVMBlock &evmBlock, std::string &state)
 {
     LOCK(cs_nevm);
+    if (ShutdownRequested()) {
+        state = "shutdown";
+        return false;
+    }
     if(bFirstTime) {
         bFirstTime = false;
         bool bResponse = false;

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -369,7 +369,6 @@ bool CZMQPublishNEVMBlockConnectNotifier::NotifyNEVMBlockConnect(const CNEVMHead
     LOCK(cs_nevm);
     state = "";
     if (ShutdownRequested()) {
-        state = "shutdown";
         return false;
     }
     if(bFirstTime) {
@@ -426,7 +425,6 @@ bool CZMQPublishNEVMBlockDisconnectNotifier::NotifyNEVMBlockDisconnect(std::stri
 {
     LOCK(cs_nevm);
     if (ShutdownRequested()) {
-        state = "shutdown";
         return false;
     }
     if(bFirstTime) {

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -16,7 +16,6 @@
 #include <primitives/transaction.h>
 #include <rpc/server.h>
 #include <serialize.h>
-#include <shutdown.h>
 #include <streams.h>
 #include <sync.h>
 #include <uint256.h>
@@ -320,9 +319,6 @@ bool CZMQAbstractPublishNotifier::NotifyNEVMCommsCommon(const std::string &commM
 {
     LOCK(cs_nevm);
     bResponse = false;
-    if (ShutdownRequested() && commMessage != "disconnect") {
-        return false;
-    }
     if(psocketsub) {
         int timeout = 150000;
         int rc = zmq_setsockopt(psocketsub, ZMQ_RCVTIMEO, &timeout, sizeof(timeout));
@@ -368,9 +364,6 @@ bool CZMQPublishNEVMBlockConnectNotifier::NotifyNEVMBlockConnect(const CNEVMHead
 {
     LOCK(cs_nevm);
     state = "";
-    if (ShutdownRequested()) {
-        return false;
-    }
     if(bFirstTime) {
         bFirstTime = false;
         bool bResponse = false;
@@ -424,9 +417,6 @@ bool CZMQPublishNEVMBlockConnectNotifier::NotifyNEVMBlockConnect(const CNEVMHead
 bool CZMQPublishNEVMBlockDisconnectNotifier::NotifyNEVMBlockDisconnect(std::string &state, const uint256& nSYSBlockHash, const CDeterministicMNListNEVMAddressDiff &diff)
 {
     LOCK(cs_nevm);
-    if (ShutdownRequested()) {
-        return false;
-    }
     if(bFirstTime) {
         bFirstTime = false;
         bool bResponse = false;
@@ -478,10 +468,6 @@ bool CZMQPublishNEVMBlockDisconnectNotifier::NotifyNEVMBlockDisconnect(std::stri
 bool CZMQPublishNEVMBlockInfoNotifier::NotifyGetNEVMBlockInfo(uint64_t &nHeight, std::string &state)
 {
     LOCK(cs_nevm);
-    if (ShutdownRequested()) {
-        state = "shutdown";
-        return false;
-    }
     if(bFirstTime) {
         bFirstTime = false;
         bool bResponse = false;
@@ -521,10 +507,6 @@ bool CZMQPublishNEVMBlockInfoNotifier::NotifyGetNEVMBlockInfo(uint64_t &nHeight,
 bool CZMQPublishNEVMBlockNotifier::NotifyGetNEVMBlock(CNEVMBlock &evmBlock, std::string &state)
 {
     LOCK(cs_nevm);
-    if (ShutdownRequested()) {
-        state = "shutdown";
-        return false;
-    }
     if(bFirstTime) {
         bFirstTime = false;
         bool bResponse = false;


### PR DESCRIPTION
## Summary
- Prevent `IsInitialBlockDownload()` from latching false and sending NEVM `startnetwork` before managed sysgeth has started.
- Move managed sysgeth shutdown earlier so it receives `disconnect` before later flush/reset work.
- Skip blocking NEVM ZMQ round-trips once shutdown is requested, while still allowing the explicit `disconnect` command.

## Test plan
- Manually reproduced and verified on testnet server with `./syscoind --testnet -server=1 -daemon=1` plus HTTP/WS `-gethcommandline` args.
- Confirmed restart no longer stalls at `Leaving InitialBlockDownload (latching to false)` before sysgeth startup.
- Confirmed Cursor lints report no errors for touched files.
- Codex review reported no PR-blocking issues after the final patch.


Made with [Cursor](https://cursor.com)