### PR TITLE
Harden ChainLock publication and signing

### DIFF
--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -223,30 +223,12 @@ CQuorumPtr CQuorumManager::BuildQuorumFromCommitment(
 
     quorum->Init(std::move(qc), pQuorumBaseBlockIndex, minedBlockHash, members);
 
-    bool hasValidVvec = false;
-    if (WITH_LOCK(cs_db, return quorum->ReadContributions(evoDb_vvec, evoDb_sk))) {
-        hasValidVvec = true;
-    } else {
+    if (!WITH_LOCK(cs_db, return quorum->ReadContributions(evoDb_vvec, evoDb_sk))) {
         if (BuildQuorumContributions(quorum->qc, quorum)) {
             WITH_LOCK(cs_db, quorum->WriteContributions(evoDb_vvec, evoDb_sk));
-            hasValidVvec = true;
         } else {
             LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- quorum.ReadContributions and BuildQuorumContributions for quorumHash[%s] failed\n", __func__, quorum->qc->quorumHash.ToString());
         }
-    }
-
-    if (hasValidVvec) {
-        // pre-populate caches in the background
-        // recovering public key shares is quite expensive and would result in serious lags for the first few signing
-        // sessions if the shares would be calculated on-demand
-        StartCachePopulatorThread(quorum);
-    }
-    {
-        LOCK(cs_quorums);
-        if(vecQuorumsCache.size() >= QUORUM_CACHE_SIZE) {
-            vecQuorumsCache.erase(vecQuorumsCache.begin());
-        }
-        vecQuorumsCache.emplace_back(quorum);
     }
 
     return quorum;
@@ -389,8 +371,48 @@ CQuorumCPtr CQuorumManager::GetQuorum(const CBlockIndex* pQuorumBaseBlockIndex)
                 }),
             vecQuorumsCache.end());
     }
-    return BuildQuorumFromCommitment(
+    CQuorumPtr quorum = BuildQuorumFromCommitment(
         pQuorumBaseBlockIndex, std::move(qc), minedBlockHash);
+    if (quorum == nullptr) {
+        return nullptr;
+    }
+
+    {
+        LOCK(quorumBlockProcessor->m_commitment_evoDb.cs);
+        uint256 currentMinedBlockHash;
+        CFinalCommitmentPtr currentQc =
+            quorumBlockProcessor->GetMinedCommitment(
+                quorumHash, currentMinedBlockHash);
+        if (currentQc == nullptr ||
+            currentMinedBlockHash != minedBlockHash ||
+            ::SerializeHash(*currentQc) != ::SerializeHash(*quorum->qc)) {
+            return nullptr;
+        }
+
+        LOCK(cs_quorums);
+        auto it = FindQuorum(quorumHash, minedBlockHash);
+        if (it != vecQuorumsCache.end()) {
+            return *it;
+        }
+        vecQuorumsCache.erase(
+            std::remove_if(
+                vecQuorumsCache.begin(),
+                vecQuorumsCache.end(),
+                [&](const CQuorumCPtr& cachedQuorum) {
+                    return cachedQuorum->m_quorum_base_block_index
+                               ->GetBlockHash() == quorumHash;
+                }),
+            vecQuorumsCache.end());
+        if (vecQuorumsCache.size() >= QUORUM_CACHE_SIZE) {
+            vecQuorumsCache.erase(vecQuorumsCache.begin());
+        }
+        vecQuorumsCache.emplace_back(quorum);
+    }
+
+    // Recovering public key shares is expensive, so populate them only after
+    // the exact commitment snapshot has been published to the cache.
+    StartCachePopulatorThread(quorum);
+    return quorum;
 }
 
 void CQuorumManager::StartCachePopulatorThread(const CQuorumCPtr pQuorum) const

--- a/src/llmq/quorums.cpp
+++ b/src/llmq/quorums.cpp
@@ -30,10 +30,10 @@ uint256 BuildSignHash(const uint256& quorumHash, const uint256& id, const uint25
 
 CQuorumManager* quorumManager;
 
-static uint256 MakeQuorumKey(const CQuorum& q)
+uint256 CQuorumManager::MakeQuorumKey(const CQuorum& q)
 {
     CHashWriter hw(SER_NETWORK, 0);
-    hw << q.qc->quorumHash;
+    hw << ::SerializeHash(*q.qc);
     for (const auto& dmn : q.members) {
         hw << dmn->proTxHash;
     }
@@ -116,7 +116,7 @@ int CQuorum::GetMemberIndex(const uint256& proTxHash) const
 
 void CQuorum::WriteContributions(std::unique_ptr<CEvoDB<uint256, std::vector<CBLSPublicKey>, StaticSaltedHasher>>& evoDb_vvec, std::unique_ptr<CEvoDB<uint256, CBLSSecretKey, StaticSaltedHasher>>& evoDb_sk)
 {
-    uint256 dbKey = MakeQuorumKey(*this);
+    uint256 dbKey = CQuorumManager::MakeQuorumKey(*this);
     LOCK(cs_vvec_shShare);
     if (HasVerificationVectorInternal()) {
         evoDb_vvec->WriteCache(dbKey, *quorumVvec);
@@ -128,7 +128,7 @@ void CQuorum::WriteContributions(std::unique_ptr<CEvoDB<uint256, std::vector<CBL
 
 bool CQuorum::ReadContributions(std::unique_ptr<CEvoDB<uint256, std::vector<CBLSPublicKey>, StaticSaltedHasher>>& evoDb_vvec, std::unique_ptr<CEvoDB<uint256, CBLSSecretKey, StaticSaltedHasher>>& evoDb_sk)
 {
-    uint256 dbKey = MakeQuorumKey(*this);
+    uint256 dbKey = CQuorumManager::MakeQuorumKey(*this);
     std::vector<CBLSPublicKey> qv;
     if (evoDb_vvec->ReadCache(dbKey, qv)) {
         WITH_LOCK(cs_vvec_shShare, quorumVvec = std::make_shared<std::vector<CBLSPublicKey>>(std::move(qv)));
@@ -208,17 +208,14 @@ void CQuorumManager::EnsureQuorumConnections(const CBlockIndex* pindexNew)
     }
 }
 
-CQuorumPtr CQuorumManager::BuildQuorumFromCommitment(const CBlockIndex* pQuorumBaseBlockIndex)
+CQuorumPtr CQuorumManager::BuildQuorumFromCommitment(
+    const CBlockIndex* pQuorumBaseBlockIndex,
+    CFinalCommitmentPtr qc,
+    const uint256& minedBlockHash)
 {
     assert(pQuorumBaseBlockIndex);
 
-    const uint256& quorumHash{pQuorumBaseBlockIndex->GetBlockHash()};
-    uint256 minedBlockHash;
-    CFinalCommitmentPtr qc = quorumBlockProcessor->GetMinedCommitment(quorumHash, minedBlockHash);
-    if (qc == nullptr) {
-        LogPrint(BCLog::LLMQ, "CQuorumManager::%s -- No mined commitment for nHeight[%d] quorumHash[%s]\n", __func__, pQuorumBaseBlockIndex->nHeight, pQuorumBaseBlockIndex->GetBlockHash().ToString());
-        return nullptr;
-    }
+    assert(qc != nullptr);
     assert(qc->quorumHash == pQuorumBaseBlockIndex->GetBlockHash());
 
     auto quorum = std::make_shared<CQuorum>(blsWorker);
@@ -295,6 +292,24 @@ std::vector<CQuorumCPtr> CQuorumManager::ScanQuorums(size_t nCountRequested)
     return ScanQuorums(pindex, nCountRequested);
 }
 
+bool CQuorumManager::IsQuorumMinedOnChain(
+    const CQuorum& quorum,
+    const CBlockIndex* pindexStart)
+{
+    if (pindexStart == nullptr || quorum.m_quorum_base_block_index == nullptr) {
+        return false;
+    }
+    for (const CBlockIndex* pindex = pindexStart;
+         pindex != nullptr &&
+         pindex->nHeight > quorum.m_quorum_base_block_index->nHeight;
+         pindex = pindex->pprev) {
+        if (pindex->GetBlockHash() == quorum.minedBlockHash) {
+            return true;
+        }
+    }
+    return false;
+}
+
 std::vector<CQuorumCPtr> CQuorumManager::ScanQuorums(const CBlockIndex* pindexStart, size_t nCountRequested)
 {
     if (pindexStart == nullptr || nCountRequested == 0) {
@@ -315,7 +330,7 @@ std::vector<CQuorumCPtr> CQuorumManager::ScanQuorums(const CBlockIndex* pindexSt
     // Iterate through blocks using dkgInterval to gather the required number of quorums
     while (vecResultQuorums.size() < nCountRequested && pIndex != nullptr) {
         CQuorumCPtr quorum = GetQuorum(pIndex);
-        if (quorum != nullptr) {
+        if (quorum != nullptr && IsQuorumMinedOnChain(*quorum, pindexStart)) {
             vecResultQuorums.emplace_back(quorum);
         }
         // Move to the previous block at the interval of nDKGInterval
@@ -337,10 +352,14 @@ CQuorumCPtr CQuorumManager::GetQuorum(const uint256& quorumHash)
     return GetQuorum(pQuorumBaseBlockIndex);
 }
 
-std::vector<CQuorumCPtr>::iterator CQuorumManager::FindQuorumByHash(const uint256& blockHash) {
+std::vector<CQuorumCPtr>::iterator CQuorumManager::FindQuorum(
+    const uint256& quorumHash,
+    const uint256& minedBlockHash)
+{
     AssertLockHeld(cs_quorums);
-    return std::find_if(vecQuorumsCache.begin(), vecQuorumsCache.end(), [&blockHash](const CQuorumCPtr& quorum) {
-        return quorum->m_quorum_base_block_index->GetBlockHash() == blockHash;
+    return std::find_if(vecQuorumsCache.begin(), vecQuorumsCache.end(), [&](const CQuorumCPtr& quorum) {
+        return quorum->m_quorum_base_block_index->GetBlockHash() == quorumHash &&
+               quorum->minedBlockHash == minedBlockHash;
     });
 }
 
@@ -348,21 +367,30 @@ CQuorumCPtr CQuorumManager::GetQuorum(const CBlockIndex* pQuorumBaseBlockIndex)
 {
     assert(pQuorumBaseBlockIndex);
 
-    auto quorumHash = pQuorumBaseBlockIndex->GetBlockHash();
-
-    // we must check this before we look into the cache. Reorgs might have happened which would mean we might have
-    // cached quorums which are not in the active chain anymore
-    if (!HasQuorum(quorumHash)) {
+    const uint256 quorumHash = pQuorumBaseBlockIndex->GetBlockHash();
+    uint256 minedBlockHash;
+    CFinalCommitmentPtr qc =
+        quorumBlockProcessor->GetMinedCommitment(quorumHash, minedBlockHash);
+    if (qc == nullptr) {
         return nullptr;
     }
     {
         LOCK(cs_quorums);
-        auto it = FindQuorumByHash(quorumHash);
+        auto it = FindQuorum(quorumHash, minedBlockHash);
         if (it != vecQuorumsCache.end()) {
             return *it;
         }
+        vecQuorumsCache.erase(
+            std::remove_if(
+                vecQuorumsCache.begin(),
+                vecQuorumsCache.end(),
+                [&](const CQuorumCPtr& quorum) {
+                    return quorum->m_quorum_base_block_index->GetBlockHash() == quorumHash;
+                }),
+            vecQuorumsCache.end());
     }
-    return BuildQuorumFromCommitment(pQuorumBaseBlockIndex);
+    return BuildQuorumFromCommitment(
+        pQuorumBaseBlockIndex, std::move(qc), minedBlockHash);
 }
 
 void CQuorumManager::StartCachePopulatorThread(const CQuorumCPtr pQuorum) const

--- a/src/llmq/quorums.h
+++ b/src/llmq/quorums.h
@@ -22,7 +22,10 @@ class CDeterministicMN;
 class ChainstateManager;
 using CDeterministicMNCPtr = std::shared_ptr<const CDeterministicMN>;
 
-
+namespace llmq_tests
+{
+class CQuorumManagerTestAccess;
+}
 namespace llmq
 {
 enum class VerifyRecSigStatus
@@ -136,16 +139,28 @@ public:
     std::vector<CQuorumCPtr> ScanQuorums(const CBlockIndex* pindexStart, size_t nCountRequested) EXCLUSIVE_LOCKS_REQUIRED(!cs_quorums, !cs_db);
     bool FlushCacheToDisk(bool bForceFlush, bool fSync = true);
 private:
+    static uint256 MakeQuorumKey(const CQuorum& quorum);
+    static bool IsQuorumMinedOnChain(
+        const CQuorum& quorum,
+        const CBlockIndex* pindexStart);
     bool DoMaintenance(bool bForceFlush, bool fSync = true);
-    std::vector<CQuorumCPtr>::iterator FindQuorumByHash(const uint256& blockHash) EXCLUSIVE_LOCKS_REQUIRED(cs_quorums);
+    std::vector<CQuorumCPtr>::iterator FindQuorum(
+        const uint256& quorumHash,
+        const uint256& minedBlockHash) EXCLUSIVE_LOCKS_REQUIRED(cs_quorums);
     // all private methods here are cs_main-free
     void EnsureQuorumConnections(const CBlockIndex *pindexNew) EXCLUSIVE_LOCKS_REQUIRED(!cs_quorums, !cs_db);
 
-    CQuorumPtr BuildQuorumFromCommitment(const CBlockIndex* pQuorumBaseBlockIndex) EXCLUSIVE_LOCKS_REQUIRED(!cs_quorums, !cs_db);
+    CQuorumPtr BuildQuorumFromCommitment(
+        const CBlockIndex* pQuorumBaseBlockIndex,
+        CFinalCommitmentPtr qc,
+        const uint256& minedBlockHash) EXCLUSIVE_LOCKS_REQUIRED(!cs_quorums, !cs_db);
     bool BuildQuorumContributions(const CFinalCommitmentPtr& fqc, const std::shared_ptr<CQuorum>& quorum) const EXCLUSIVE_LOCKS_REQUIRED(!cs_db, !cs_quorums);
 
     CQuorumCPtr GetQuorum(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(!cs_quorums, !cs_db);
     void StartCachePopulatorThread(const CQuorumCPtr pQuorum) const;
+
+    friend class CQuorum;
+    friend class llmq_tests::CQuorumManagerTestAccess;
 };
 
 // when selecting a quorum for signing and verification, we use CQuorumManager::SelectQuorum with this offset as

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -288,14 +288,33 @@ bool CChainLocksHandler::IsCandidateStillAdmissible(
 
 const CBlockIndex* CChainLocksHandler::SelectAlternativeSigningTarget(
     int32_t height,
-    const uint256& current_hash,
+    const CBlockIndex* current_index,
     const CChainLockSig& previous_share,
-    const CBlockIndex* previous_share_index)
+    const CBlockIndex* previous_share_index,
+    int32_t dkg_interval)
 {
-    if (previous_share.blockHash == current_hash ||
+    if (current_index == nullptr ||
+        current_index->nHeight != height ||
+        previous_share.nHeight != height ||
+        previous_share.blockHash == current_index->GetBlockHash() ||
         previous_share_index == nullptr ||
         previous_share_index->nHeight != height ||
-        previous_share_index->GetBlockHash() != previous_share.blockHash) {
+        previous_share_index->GetBlockHash() != previous_share.blockHash ||
+        dkg_interval <= 0) {
+        return nullptr;
+    }
+
+    // ScanQuorums derives the active quorum vector by walking DKG-boundary
+    // ancestors. Only join an alternative when both targets therefore produce
+    // the same quorum set and ordering.
+    const int32_t quorum_base_height = height - (height % dkg_interval);
+    const CBlockIndex* current_quorum_base =
+        current_index->GetAncestor(quorum_base_height);
+    const CBlockIndex* alternative_quorum_base =
+        previous_share_index->GetAncestor(quorum_base_height);
+    if (current_quorum_base == nullptr ||
+        alternative_quorum_base == nullptr ||
+        current_quorum_base->GetBlockHash() != alternative_quorum_base->GetBlockHash()) {
         return nullptr;
     }
     return previous_share_index;
@@ -1051,7 +1070,7 @@ void CChainLocksHandler::TrySignChainTip()
                 LOCK(cs_main);
                 auto shareBlockIndex = chainman.m_blockman.LookupBlockIndex(it2->second->blockHash);
                 const CBlockIndex* alternativeTarget = SelectAlternativeSigningTarget(
-                    nHeight, targetHash, *it2->second, shareBlockIndex);
+                    nHeight, pindex, *it2->second, shareBlockIndex, llmqParams.dkgInterval);
                 if (alternativeTarget != nullptr) {
                     // previous quorum signed an alternative chain tip, sign it too instead
                     LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- previous quorum (%d, %s) signed an alternative chaintip (%s != %s) at height %d, join it\n",

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -255,6 +255,52 @@ bool CChainLocksHandler::TryUpdateBestChainLock(const CBlockIndex* pindex)
     return false;
 }
 
+bool CChainLocksHandler::IsCandidateStillAdmissible(
+    const CChain& active_chain,
+    const CChainLockSig& best_chainlock,
+    const CChainLockSig& candidate,
+    const CBlockIndex* candidate_index)
+{
+    if (candidate_index == nullptr ||
+        candidate_index->nHeight != candidate.nHeight ||
+        candidate_index->GetBlockHash() != candidate.blockHash) {
+        return false;
+    }
+    if (!best_chainlock.IsNull()) {
+        if (candidate.nHeight <= best_chainlock.nHeight) {
+            return false;
+        }
+        const CBlockIndex* winner_ancestor =
+            candidate_index->GetAncestor(best_chainlock.nHeight);
+        if (winner_ancestor == nullptr ||
+            winner_ancestor->GetBlockHash() != best_chainlock.blockHash) {
+            return false;
+        }
+    }
+    if (candidate.nHeight < SIGN_HEIGHT_OFFSET) {
+        return true;
+    }
+
+    const int32_t anchor_height = candidate.nHeight - SIGN_HEIGHT_OFFSET;
+    return active_chain[anchor_height] != nullptr &&
+           candidate_index->GetAncestor(anchor_height) == active_chain[anchor_height];
+}
+
+const CBlockIndex* CChainLocksHandler::SelectAlternativeSigningTarget(
+    int32_t height,
+    const uint256& current_hash,
+    const CChainLockSig& previous_share,
+    const CBlockIndex* previous_share_index)
+{
+    if (previous_share.blockHash == current_hash ||
+        previous_share_index == nullptr ||
+        previous_share_index->nHeight != height ||
+        previous_share_index->GetBlockHash() != previous_share.blockHash) {
+        return nullptr;
+    }
+    return previous_share_index;
+}
+
 
 bool CChainLocksHandler::VerifyChainLockShare(const CChainLockSig& clsig, const CBlockIndex* pindexScan, const uint256& idIn, std::pair<int, CQuorumCPtr>& ret, const uint256& hash, bool* retSigVerifyAttempted)
 {
@@ -645,6 +691,16 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
         CInv clsigAggInv;
         {
             LOCK2(cs_main, cs);
+            // BLS verification runs without cs_main. Revalidate the mutable
+            // chain anchor and winner slot at the publication point so the
+            // first valid aggregate remains the unique ChainLock.
+            if (!IsCandidateStillAdmissible(
+                    chainman.ActiveChain(), bestChainLockWithKnownBlock, clsig, pindexScan)) {
+                if (from != -1) {
+                    peerman.ForgetTxHash(from, hash);
+                }
+                return state.Invalid(BlockValidationResult::BLOCK_CHAINLOCK, "stale-clsig-after-verify");
+            }
             clsig.signers[ret.first] = true;
             if (std::count(clsig.signers.begin(), clsig.signers.end(), true) > 1) {
                 // this should never happen
@@ -708,7 +764,16 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
             return state.Invalid(BlockValidationResult::BLOCK_CHAINLOCK, "clsig-invalid-sig");
         }
             {
-                LOCK(cs);
+                LOCK2(cs_main, cs);
+                // Serialize publication with chain activation and competing
+                // verified aggregates. Enforcement never revokes this winner.
+                if (!IsCandidateStillAdmissible(
+                        chainman.ActiveChain(), bestChainLockWithKnownBlock, clsig, pindexScan)) {
+                    if (from != -1) {
+                        peerman.ForgetTxHash(from, hash);
+                    }
+                    return state.Invalid(BlockValidationResult::BLOCK_CHAINLOCK, "stale-clsig-after-verify");
+                }
                 bestChainLockCandidates[clsig.nHeight] = std::make_shared<const CChainLockSig>(clsig);
                 mostRecentChainLockShare = clsig;
                 TryUpdateBestChainLock(pindexScan);
@@ -880,8 +945,8 @@ void CChainLocksHandler::TrySignChainTip()
         }
     }
 
-    const uint256 msgHash = pindex->GetBlockHash();
     const int32_t nHeight = pindex->nHeight;
+    uint256 targetHash = pindex->GetBlockHash();
 
     // DIP8 defines a process called "Signing attempts" which should run before the CLSIG is finalized
     // To simplify the initial implementation, we skip this process and directly try to create a CLSIG
@@ -906,7 +971,7 @@ void CChainLocksHandler::TrySignChainTip()
             LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler:: -- not enabled\n");
             return;
         }
-        if (signingState.IsAlreadySigned(nHeight, msgHash)) {
+        if (signingState.IsAlreadySigned(nHeight, targetHash)) {
             // already signed this one
             LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler:: -- already signed\n");
             return;
@@ -919,7 +984,7 @@ void CChainLocksHandler::TrySignChainTip()
             return;
         }
 
-        if (InternalHasConflictingChainLock(nHeight, msgHash)) {
+        if (InternalHasConflictingChainLock(nHeight, targetHash)) {
             // don't sign if another conflicting CLSIG is already present. EnforceBestChainLock will later enforce
             // the correct chain.
             LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler:: -- conflicting internal chainlock\n");
@@ -929,7 +994,7 @@ void CChainLocksHandler::TrySignChainTip()
 
     }
 
-    LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- trying to sign %s, height=%d\n", __func__, msgHash.ToString(), nHeight);
+    LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- trying to sign %s, height=%d\n", __func__, targetHash.ToString(), nHeight);
     const auto& consensus = Params().GetConsensus();
     const auto& llmqParams = consensus.llmqTypeChainLocks;
     const auto& signingActiveQuorumCount = llmqParams.signingActiveQuorumCount;
@@ -944,7 +1009,6 @@ void CChainLocksHandler::TrySignChainTip()
         }
     }
     bool fMemberOfSomeQuorum{false};
-    const auto heightHashKP = std::make_pair(nHeight, msgHash);
     signingState.BumpAttempt();
     auto proTxHash = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash);
     for (size_t i = 0; i < quorums_scanned.size(); ++i) {
@@ -983,18 +1047,21 @@ void CChainLocksHandler::TrySignChainTip()
                 // else
                 // waiting for previous quorum(s) to sign anything for too long already,
                 // just sign whatever we think is a good tip
-            } else if (it2->second->blockHash != msgHash) {
+            } else if (it2->second->blockHash != targetHash) {
                 LOCK(cs_main);
                 auto shareBlockIndex = chainman.m_blockman.LookupBlockIndex(it2->second->blockHash);
-                if (shareBlockIndex != nullptr && shareBlockIndex->nHeight == nHeight) {
+                const CBlockIndex* alternativeTarget = SelectAlternativeSigningTarget(
+                    nHeight, targetHash, *it2->second, shareBlockIndex);
+                if (alternativeTarget != nullptr) {
                     // previous quorum signed an alternative chain tip, sign it too instead
                     LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- previous quorum (%d, %s) signed an alternative chaintip (%s != %s) at height %d, join it\n",
-                            __func__, nQuorumIndexPrev, quorums_scanned[nQuorumIndexPrev]->qc->quorumHash.ToString(), it2->second->blockHash.ToString(), msgHash.ToString(), nHeight);
-                    pindex = shareBlockIndex;
+                            __func__, nQuorumIndexPrev, quorums_scanned[nQuorumIndexPrev]->qc->quorumHash.ToString(), it2->second->blockHash.ToString(), targetHash.ToString(), nHeight);
+                    pindex = alternativeTarget;
+                    targetHash = alternativeTarget->GetBlockHash();
                 } else if (signingState.GetAttempt() <= (int)i) {
                     // previous quorum signed some different hash we have no idea about, bail out for now
                     LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- previous quorum (%d, %s) signed an unknown or an invalid blockHash (%s != %s) at height %d\n",
-                            __func__, nQuorumIndexPrev, quorums_scanned[nQuorumIndexPrev]->qc->quorumHash.ToString(), it2->second->blockHash.ToString(), msgHash.ToString(), nHeight);
+                            __func__, nQuorumIndexPrev, quorums_scanned[nQuorumIndexPrev]->qc->quorumHash.ToString(), it2->second->blockHash.ToString(), targetHash.ToString(), nHeight);
                     return;
                 }
                 // else
@@ -1003,21 +1070,30 @@ void CChainLocksHandler::TrySignChainTip()
             }
         }
         LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- use quorum (%d, %s) and try to sign %s at height %d\n",
-                __func__, nQuorumIndex, quorum->qc->quorumHash.ToString(), msgHash.ToString(), nHeight);
+                __func__, nQuorumIndex, quorum->qc->quorumHash.ToString(), targetHash.ToString(), nHeight);
         uint256 requestId = ::SerializeHash(std::make_tuple(CLSIG_REQUESTID_PREFIX, nHeight, quorum->qc->quorumHash));
         {
-            LOCK(cs);
-            if (bestChainLockWithKnownBlock.nHeight >= nHeight) {
-                // might have happened while we didn't hold cs
+            LOCK2(cs_main, cs);
+            // The active-chain anchor or published winner may have changed
+            // while quorum shares were inspected. Do not consume this
+            // quorum's per-height signing slot for a target that publication
+            // would already reject.
+            const CBlockIndex* signingTarget = chainman.m_blockman.LookupBlockIndex(targetHash);
+            CChainLockSig candidate;
+            candidate.nHeight = nHeight;
+            candidate.blockHash = targetHash;
+            if (!IsCandidateStillAdmissible(
+                    chainman.ActiveChain(), bestChainLockWithKnownBlock, candidate, signingTarget)) {
                 return;
             }
-            mapSignedRequestIds.emplace(requestId, heightHashKP);
+            mapSignedRequestIds.emplace(requestId, std::make_pair(nHeight, targetHash));
         }
-        quorumSigningManager->AsyncSignIfMember(requestId, msgHash, quorum->qc->quorumHash);
+        // AsyncSignIfMember can reach quorum manager/cs_main.
+        quorumSigningManager->AsyncSignIfMember(requestId, targetHash, quorum->qc->quorumHash);
     }
     if (!fMemberOfSomeQuorum || signingState.GetAttempt() >= (int)quorums_scanned.size()) {
         // not a member or tried too many times, nothing to do
-        signingState.SetLastSigned(nHeight, msgHash);
+        signingState.SetLastSigned(nHeight, targetHash);
     }
 }
 

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -235,6 +235,14 @@ bool CChainLocksHandler::IsAlternativeCommitmentWindowStable(
     return true;
 }
 
+bool CChainLocksHandler::IsActiveHeightSnapshotCurrent(
+    const CChain& active_chain,
+    int32_t height,
+    const CBlockIndex* active_height_index)
+{
+    return height >= 0 && active_chain[height] == active_height_index;
+}
+
 bool CChainLocksHandler::BuildQuorumContext(
     const CBlockIndex* candidate_index,
     CQuorumContext& context) const
@@ -249,8 +257,8 @@ bool CChainLocksHandler::BuildQuorumContext(
     int32_t common_height{-1};
     {
         LOCK(cs_main);
-        context.active_tip = chainman.ActiveChain().Tip();
         active_index = chainman.ActiveChain()[candidate_index->nHeight];
+        context.active_height_index = active_index;
         const CBlockIndex* ancestor = candidate_index;
         while (ancestor != nullptr && !chainman.ActiveChain().Contains(ancestor)) {
             ancestor = ancestor->pprev;
@@ -896,7 +904,10 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
             // BLS verification runs without cs_main. Revalidate the mutable
             // chain anchor and winner slot at the publication point so the
             // first valid aggregate remains the unique ChainLock.
-            if (chainman.ActiveChain().Tip() != publication_context.active_tip ||
+            if (!IsActiveHeightSnapshotCurrent(
+                    chainman.ActiveChain(),
+                    clsig.nHeight,
+                    publication_context.active_height_index) ||
                 !IsCandidateStillAdmissible(
                     chainman.ActiveChain(), bestChainLockWithKnownBlock, clsig, pindexScan)) {
                 if (from != -1) {
@@ -995,7 +1006,10 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
                 LOCK2(cs_main, cs);
                 // Serialize publication with chain activation and competing
                 // verified aggregates. Enforcement never revokes this winner.
-                if (chainman.ActiveChain().Tip() != publication_context.active_tip ||
+                if (!IsActiveHeightSnapshotCurrent(
+                        chainman.ActiveChain(),
+                        clsig.nHeight,
+                        publication_context.active_height_index) ||
                     !IsCandidateStillAdmissible(
                         chainman.ActiveChain(), bestChainLockWithKnownBlock, clsig, pindexScan)) {
                     if (from != -1) {
@@ -1320,7 +1334,8 @@ void CChainLocksHandler::TrySignChainTip()
                             __func__, nQuorumIndexPrev, quorums_scanned[nQuorumIndexPrev]->qc->quorumHash.ToString(), it2->second->blockHash.ToString(), targetHash.ToString(), nHeight);
                     pindex = alternativeTarget;
                     targetHash = alternativeTarget->GetBlockHash();
-                    signing_context.active_tip = alternative_context.active_tip;
+                    signing_context.active_height_index =
+                        alternative_context.active_height_index;
                 } else if (signingState.GetAttempt() <= (int)i) {
                     // previous quorum signed some different hash we have no idea about, bail out for now
                     LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- previous quorum (%d, %s) signed an unknown or an invalid blockHash (%s != %s) at height %d\n",
@@ -1345,7 +1360,10 @@ void CChainLocksHandler::TrySignChainTip()
             CChainLockSig candidate;
             candidate.nHeight = nHeight;
             candidate.blockHash = targetHash;
-            if (chainman.ActiveChain().Tip() != signing_context.active_tip ||
+            if (!IsActiveHeightSnapshotCurrent(
+                    chainman.ActiveChain(),
+                    nHeight,
+                    signing_context.active_height_index) ||
                 !IsCandidateStillAdmissible(
                     chainman.ActiveChain(), bestChainLockWithKnownBlock, candidate, signingTarget)) {
                 return;

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -262,7 +262,7 @@ bool CChainLocksHandler::BuildQuorumContext(
 
     context.quorums =
         llmq::quorumManager->ScanQuorums(candidate_index, quorum_count);
-    if (context.quorums.empty()) {
+    if (context.quorums.size() != quorum_count) {
         return false;
     }
 
@@ -500,7 +500,8 @@ bool CChainLocksHandler::VerifyChainLockShare(
     };
     {
         LOCK(cs);
-        if(sigChecked.find(hash) != sigChecked.end()) {
+        if (sigChecked.find(std::make_pair(hash, context.fingerprint)) !=
+            sigChecked.end()) {
             // Cache hits must still resolve signer/quorum context for callers.
             return resolveSignerAndQuorum();
         }
@@ -535,7 +536,10 @@ bool CChainLocksHandler::VerifyChainLockShare(
             ret = std::make_pair(i, quorum);
             {
                 LOCK(cs);
-                sigChecked.emplace(hash, TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()));
+                sigChecked.emplace(
+                    std::make_pair(hash, context.fingerprint),
+                    TicksSinceEpoch<std::chrono::milliseconds>(
+                        SystemClock::now()));
             }
             return true;
         }
@@ -580,7 +584,8 @@ bool CChainLocksHandler::VerifyAggregatedChainLock(
 
     {
         LOCK(cs);
-        if(sigChecked.find(hash) != sigChecked.end()) {
+        if (sigChecked.find(std::make_pair(hash, context.fingerprint)) !=
+            sigChecked.end()) {
             return true;
         }
     }
@@ -617,7 +622,9 @@ bool CChainLocksHandler::VerifyAggregatedChainLock(
     bool result = clsig.sig.VerifyInsecureAggregated(quorumPublicKeys, hashes);
     if(result) {
         LOCK(cs);
-        sigChecked.emplace(hash, TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()));
+        sigChecked.emplace(
+            std::make_pair(hash, context.fingerprint),
+            TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()));
     } else {
         LogPrintf("CChainLocksHandler::%s -- aggregated verify failed nHeight=%d blockHash=%s pindexScan=%s signers_count=%d signers_size=%d quorums_scanned=%d\n",
                 __func__,
@@ -906,11 +913,17 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
                 }
                 return state.Invalid(BlockValidationResult::BLOCK_CHAINLOCK, "clsig-invalid-signer-count");
             }
-            auto it = bestChainLockShares.find(clsig.nHeight);
-            if (it == bestChainLockShares.end()) {
-                bestChainLockShares[clsig.nHeight].emplace(ret.second, std::make_shared<const CChainLockSig>(clsig));
-            } else {
-                it->second.emplace(ret.second, std::make_shared<const CChainLockSig>(clsig));
+            auto& shares = bestChainLockShares[clsig.nHeight];
+            const auto existing_share = std::find_if(
+                shares.begin(),
+                shares.end(),
+                [&](const auto& entry) {
+                    return SameQuorumIdentity(entry.first, ret.second);
+                });
+            if (existing_share == shares.end()) {
+                shares.emplace(
+                    ret.second,
+                    std::make_shared<const CChainLockSig>(clsig));
             }
             mostRecentChainLockShare = clsig;
             if (TryUpdateBestChainLock(
@@ -1063,6 +1076,7 @@ void CChainLocksHandler::UpdatedBlockTip(const CBlockIndex* pindexNew, bool fIni
         tryLockChainTipScheduled = true;
         scheduler->scheduleFromNow([&]() {
             CheckActiveState();
+            ProcessPendingRecoveredChainLockSigs();
             bool enforced = false;
             const CBlockIndex* pindex;
             {       
@@ -1233,6 +1247,16 @@ void CChainLocksHandler::TrySignChainTip()
             mapSharesAtTip = it->second;
         }
     }
+    const auto findShareForQuorum =
+        [&](const CQuorumCPtr& expected_quorum) {
+            return std::find_if(
+                mapSharesAtTip.begin(),
+                mapSharesAtTip.end(),
+                [&](const auto& entry) {
+                    return SameQuorumIdentity(
+                        entry.first, expected_quorum);
+                });
+        };
     bool fMemberOfSomeQuorum{false};
     signingState.BumpAttempt();
     auto proTxHash = WITH_LOCK(activeMasternodeInfoCs, return activeMasternodeInfo.proTxHash);
@@ -1250,12 +1274,14 @@ void CChainLocksHandler::TrySignChainTip()
         fMemberOfSomeQuorum = true;
         if (i > 0) {
             int nQuorumIndexPrev = (nQuorumIndex + 1) % quorums_scanned.size();
-            auto it2 = mapSharesAtTip.find(quorums_scanned[nQuorumIndexPrev]);
+            auto it2 =
+                findShareForQuorum(quorums_scanned[nQuorumIndexPrev]);
             if (it2 == mapSharesAtTip.end() && signingState.GetAttempt() > (int)i) {
                 // look deeper after 'i' attempts
                 while (nQuorumIndexPrev != nQuorumIndex) {
                     nQuorumIndexPrev = (nQuorumIndexPrev + 1) % quorums_scanned.size();
-                    it2 = mapSharesAtTip.find(quorums_scanned[nQuorumIndexPrev]);
+                    it2 =
+                        findShareForQuorum(quorums_scanned[nQuorumIndexPrev]);
                     if (it2 != mapSharesAtTip.end()) {
                         break;
                     }
@@ -1327,7 +1353,8 @@ void CChainLocksHandler::TrySignChainTip()
             mapSignedRequestIds.emplace(requestId, std::make_pair(nHeight, targetHash));
         }
         // AsyncSignIfMember can reach quorum manager/cs_main.
-        quorumSigningManager->AsyncSignIfMember(requestId, targetHash, quorum->qc->quorumHash);
+        quorumSigningManager->AsyncSignIfMember(
+            requestId, targetHash, quorum);
     }
     if (!fMemberOfSomeQuorum || signingState.GetAttempt() >= (int)quorums_scanned.size()) {
         // not a member or tried too many times, nothing to do
@@ -1359,10 +1386,36 @@ void CChainLocksHandler::HandleNewRecoveredSig(const llmq::CRecoveredSig& recove
         clsig.nHeight = it->second.first;
         clsig.blockHash = it->second.second;
         clsig.sig = recoveredSig.sig.Get();
-        mapSignedRequestIds.erase(recoveredSig.getId());
     }
     BlockValidationState state;
-    ProcessNewChainLock(-1, clsig, state, ::SerializeHash(clsig), recoveredSig.getId());
+    if (ProcessNewChainLock(
+            -1,
+            clsig,
+            state,
+            ::SerializeHash(clsig),
+            recoveredSig.getId())) {
+        LOCK(cs);
+        mapSignedRequestIds.erase(recoveredSig.getId());
+    }
+}
+
+void CChainLocksHandler::ProcessPendingRecoveredChainLockSigs()
+{
+    std::vector<uint256> request_ids;
+    {
+        LOCK(cs);
+        request_ids.reserve(mapSignedRequestIds.size());
+        for (const auto& entry : mapSignedRequestIds) {
+            request_ids.emplace_back(entry.first);
+        }
+    }
+    for (const auto& request_id : request_ids) {
+        CRecoveredSig recovered_sig;
+        if (quorumSigningManager->GetRecoveredSigForId(
+                request_id, recovered_sig)) {
+            HandleNewRecoveredSig(recovered_sig);
+        }
+    }
 }
 
 bool CChainLocksHandler::HasChainLock(int nHeight, const uint256& blockHash)

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -9,6 +9,7 @@
 #include <llmq/quorums_commitment.h>
 #include <chain.h>
 #include <consensus/validation.h>
+#include <hash.h>
 #include <masternode/activemasternode.h>
 #include <masternode/masternodesync.h>
 #include <net_processing.h>
@@ -190,7 +191,123 @@ std::map<CQuorumCPtr, CChainLockSigCPtr> CChainLocksHandler::GetBestChainLockSha
     return it->second;
 }
 
-bool CChainLocksHandler::TryUpdateBestChainLock(const CBlockIndex* pindex)
+bool CChainLocksHandler::SameQuorumIdentity(
+    const CQuorumCPtr& lhs,
+    const CQuorumCPtr& rhs)
+{
+    return lhs != nullptr &&
+           rhs != nullptr &&
+           lhs->m_quorum_base_block_index->GetBlockHash() ==
+               rhs->m_quorum_base_block_index->GetBlockHash() &&
+           lhs->minedBlockHash == rhs->minedBlockHash &&
+           ::SerializeHash(*lhs->qc) == ::SerializeHash(*rhs->qc);
+}
+
+bool CChainLocksHandler::IsAlternativeCommitmentWindowStable(
+    int32_t height,
+    int32_t common_height,
+    int32_t dkg_interval,
+    int32_t mining_window_start,
+    int32_t mining_window_end)
+{
+    if (height < 0 ||
+        common_height < 0 ||
+        common_height > height ||
+        dkg_interval <= 0 ||
+        mining_window_start < 0 ||
+        mining_window_end < mining_window_start) {
+        return false;
+    }
+    for (int64_t base_height = height - (height % dkg_interval);
+         base_height >= 0;
+         base_height -= dkg_interval) {
+        const int64_t mining_start = base_height + mining_window_start;
+        const int64_t mining_end = base_height + mining_window_end;
+        if (mining_end <= common_height) {
+            break;
+        }
+        if (height >= mining_start &&
+            common_height <
+                std::min(static_cast<int64_t>(height), mining_end)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool CChainLocksHandler::BuildQuorumContext(
+    const CBlockIndex* candidate_index,
+    CQuorumContext& context) const
+{
+    if (candidate_index == nullptr) {
+        return false;
+    }
+
+    const auto& llmq_params = Params().GetConsensus().llmqTypeChainLocks;
+    const size_t quorum_count = llmq_params.signingActiveQuorumCount;
+    const CBlockIndex* active_index{nullptr};
+    int32_t common_height{-1};
+    {
+        LOCK(cs_main);
+        context.active_tip = chainman.ActiveChain().Tip();
+        active_index = chainman.ActiveChain()[candidate_index->nHeight];
+        const CBlockIndex* ancestor = candidate_index;
+        while (ancestor != nullptr && !chainman.ActiveChain().Contains(ancestor)) {
+            ancestor = ancestor->pprev;
+        }
+        if (ancestor != nullptr) {
+            common_height = ancestor->nHeight;
+        }
+    }
+
+    context.quorums =
+        llmq::quorumManager->ScanQuorums(candidate_index, quorum_count);
+    if (context.quorums.empty()) {
+        return false;
+    }
+
+    if (active_index != nullptr && active_index != candidate_index) {
+        const auto active_quorums =
+            llmq::quorumManager->ScanQuorums(active_index, quorum_count);
+        if (active_quorums.size() != context.quorums.size()) {
+            return false;
+        }
+        for (size_t i = 0; i < context.quorums.size(); ++i) {
+            if (!SameQuorumIdentity(context.quorums[i], active_quorums[i])) {
+                return false;
+            }
+        }
+    }
+
+    if (active_index != candidate_index) {
+        if (!IsAlternativeCommitmentWindowStable(
+                candidate_index->nHeight,
+                common_height,
+                llmq_params.dkgInterval,
+                llmq_params.dkgMiningWindowStart,
+                llmq_params.dkgMiningWindowEnd)) {
+            return false;
+        }
+    }
+
+    CHashWriter fingerprint_writer(SER_NETWORK, 0);
+    fingerprint_writer << static_cast<uint64_t>(context.quorums.size());
+    for (const auto& quorum : context.quorums) {
+        if (quorum == nullptr || quorum->m_quorum_base_block_index == nullptr) {
+            return false;
+        }
+        fingerprint_writer
+            << quorum->m_quorum_base_block_index->GetBlockHash()
+            << quorum->minedBlockHash
+            << ::SerializeHash(*quorum->qc);
+    }
+    context.fingerprint = fingerprint_writer.GetHash();
+    return true;
+}
+
+bool CChainLocksHandler::TryUpdateBestChainLock(
+    const CBlockIndex* pindex,
+    const std::vector<CQuorumCPtr>* quorums)
 {
     if (pindex == nullptr || pindex->nHeight <= bestChainLockWithKnownBlock.nHeight) {
         return false;
@@ -216,7 +333,7 @@ bool CChainLocksHandler::TryUpdateBestChainLock(const CBlockIndex* pindex)
     }
 
     auto it2 = bestChainLockShares.find(pindex->nHeight);
-    if (it2 == bestChainLockShares.end()) {
+    if (it2 == bestChainLockShares.end() || quorums == nullptr) {
         return false;
     }
     const auto& llmqParams = Params().GetConsensus().llmqTypeChainLocks;
@@ -225,31 +342,43 @@ bool CChainLocksHandler::TryUpdateBestChainLock(const CBlockIndex* pindex)
     std::vector<CBLSSignature> sigs;
     CChainLockSig clsigAgg;
 
-    for (const auto& pair : it2->second) {
-        if (pair.second->blockHash == pindex->GetBlockHash()) {
-            assert(std::count(pair.second->signers.begin(), pair.second->signers.end(), true) <= 1);
+    for (size_t quorum_index = 0; quorum_index < quorums->size(); ++quorum_index) {
+        for (const auto& pair : it2->second) {
+            if (pair.second->blockHash != pindex->GetBlockHash() ||
+                !SameQuorumIdentity(pair.first, (*quorums)[quorum_index]) ||
+                quorum_index >= pair.second->signers.size() ||
+                !pair.second->signers[quorum_index]) {
+                continue;
+            }
+            assert(std::count(pair.second->signers.begin(), pair.second->signers.end(), true) == 1);
             sigs.emplace_back(pair.second->sig);
             if (clsigAgg.IsNull()) {
                 clsigAgg = *pair.second;
             } else {
-                assert(clsigAgg.signers.size() == pair.second->signers.size());
-                std::transform(clsigAgg.signers.begin(), clsigAgg.signers.end(), pair.second->signers.begin(), clsigAgg.signers.begin(), std::logical_or<bool>());
+                std::transform(
+                    clsigAgg.signers.begin(),
+                    clsigAgg.signers.end(),
+                    pair.second->signers.begin(),
+                    clsigAgg.signers.begin(),
+                    std::logical_or<bool>());
             }
-            if (sigs.size() >= threshold) {
-                // all sigs should be validated already
-                clsigAgg.sig = CBLSSignature::AggregateInsecure(sigs);
-                bestChainLockWithKnownBlock = clsigAgg;
-                bestChainLockBlockIndex = pindex;
-                bestChainLockCandidates[clsigAgg.nHeight] = std::make_shared<const CChainLockSig>(clsigAgg);
-                AddRecentChainLock(bestChainLockWithKnownBlock);
-                // only prune blob data upon chainlock so we cannot rollback on pruned blob transactions. If we rolled back on pruned blob data then upon new inclusion there could be situation
-                // where new block would fall within 2-hour time window of enforcement and include the pruned blob tx
-                if(!pnevmdatadb->PruneStandalone(bestChainLockBlockIndex->GetMedianTimePast())) {
-                    LogPrintf("CChainLocksHandler::%s -- CNEVMDataDB::Prune failed\n", __func__);
-                }
-                LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- CLSIG aggregated (%s)\n", __func__, bestChainLockWithKnownBlock.ToString());
-                return true;
+            break;
+        }
+        if (sigs.size() >= threshold) {
+            // Every share was verified against the same exact quorum vector.
+            clsigAgg.sig = CBLSSignature::AggregateInsecure(sigs);
+            bestChainLockWithKnownBlock = clsigAgg;
+            bestChainLockBlockIndex = pindex;
+            bestChainLockCandidates[clsigAgg.nHeight] =
+                std::make_shared<const CChainLockSig>(clsigAgg);
+            AddRecentChainLock(bestChainLockWithKnownBlock);
+            // only prune blob data upon chainlock so we cannot rollback on pruned blob transactions. If we rolled back on pruned blob data then upon new inclusion there could be situation
+            // where new block would fall within 2-hour time window of enforcement and include the pruned blob tx
+            if(!pnevmdatadb->PruneStandalone(bestChainLockBlockIndex->GetMedianTimePast())) {
+                LogPrintf("CChainLocksHandler::%s -- CNEVMDataDB::Prune failed\n", __func__);
             }
+            LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- CLSIG aggregated (%s)\n", __func__, bestChainLockWithKnownBlock.ToString());
+            return true;
         }
     }
     return false;
@@ -321,7 +450,13 @@ const CBlockIndex* CChainLocksHandler::SelectAlternativeSigningTarget(
 }
 
 
-bool CChainLocksHandler::VerifyChainLockShare(const CChainLockSig& clsig, const CBlockIndex* pindexScan, const uint256& idIn, std::pair<int, CQuorumCPtr>& ret, const uint256& hash, bool* retSigVerifyAttempted)
+bool CChainLocksHandler::VerifyChainLockShare(
+    const CChainLockSig& clsig,
+    const uint256& idIn,
+    std::pair<int, CQuorumCPtr>& ret,
+    const uint256& hash,
+    const CQuorumContext& context,
+    bool* retSigVerifyAttempted)
 {
     if (retSigVerifyAttempted) {
         *retSigVerifyAttempted = false;
@@ -341,7 +476,7 @@ bool CChainLocksHandler::VerifyChainLockShare(const CChainLockSig& clsig, const 
         return false;
     }
     bool fHaveSigner{std::count(clsig.signers.begin(), clsig.signers.end(), true) > 0};
-    const auto quorums_scanned = llmq::quorumManager->ScanQuorums(pindexScan, signingActiveQuorumCount);
+    const auto& quorums_scanned = context.quorums;
     if (quorums_scanned.empty()) {
         return false;
     }
@@ -411,7 +546,29 @@ bool CChainLocksHandler::VerifyChainLockShare(const CChainLockSig& clsig, const 
     return false;
 }
 
-bool CChainLocksHandler::VerifyAggregatedChainLock(const CChainLockSig& clsig, const CBlockIndex* pindexScan, const uint256 &hash, bool* retSigVerifyAttempted)
+bool CChainLocksHandler::VerifyAggregatedChainLock(
+    const CChainLockSig& clsig,
+    const CBlockIndex* pindexScan,
+    const uint256& hash,
+    bool* retSigVerifyAttempted)
+{
+    CQuorumContext context;
+    if (!BuildQuorumContext(pindexScan, context)) {
+        if (retSigVerifyAttempted) {
+            *retSigVerifyAttempted = false;
+        }
+        return false;
+    }
+    return VerifyAggregatedChainLock(
+        clsig, pindexScan, hash, context, retSigVerifyAttempted);
+}
+
+bool CChainLocksHandler::VerifyAggregatedChainLock(
+    const CChainLockSig& clsig,
+    const CBlockIndex* pindexScan,
+    const uint256& hash,
+    const CQuorumContext& context,
+    bool* retSigVerifyAttempted)
 {
     if (retSigVerifyAttempted) {
         *retSigVerifyAttempted = false;
@@ -434,7 +591,7 @@ bool CChainLocksHandler::VerifyAggregatedChainLock(const CChainLockSig& clsig, c
     std::vector<uint256> hashes;
     std::vector<CBLSPublicKey> quorumPublicKeys;
 
-    const auto quorums_scanned = llmq::quorumManager->ScanQuorums(pindexScan, signingActiveQuorumCount);
+    const auto& quorums_scanned = context.quorums;
     if (quorums_scanned.size() != static_cast<size_t>(signingActiveQuorumCount)) {
         return false;
     }
@@ -688,10 +845,22 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
     }
     if (from == -1 || signers_count == 1) {
         // A part of a multi-quorum CLSIG signed by a single quorum
+        CQuorumContext verification_context;
+        if (!BuildQuorumContext(pindexScan, verification_context)) {
+            return state.Invalid(
+                BlockValidationResult::BLOCK_CHAINLOCK,
+                "clsig-unstable-quorum-context");
+        }
         std::pair<int, CQuorumCPtr> ret;
         clsig.signers.resize(signingActiveQuorumCount, false);
         bool sig_verify_attempted{false};
-        if (!VerifyChainLockShare(clsig, pindexScan, idIn, ret, hash, &sig_verify_attempted)) {
+        if (!VerifyChainLockShare(
+                clsig,
+                idIn,
+                ret,
+                hash,
+                verification_context,
+                &sig_verify_attempted)) {
             LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- invalid CLSIG (%s), peer=%d\n", __func__, clsig.ToString(), from);
             if (from != -1) {
                 if (sig_verify_attempted) {
@@ -708,12 +877,20 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
             return state.Invalid(BlockValidationResult::BLOCK_CHAINLOCK, "clsig-invalid-share-sig");
         }
         CInv clsigAggInv;
+        CQuorumContext publication_context;
+        if (!BuildQuorumContext(pindexScan, publication_context) ||
+            publication_context.fingerprint != verification_context.fingerprint) {
+            return state.Invalid(
+                BlockValidationResult::BLOCK_CHAINLOCK,
+                "stale-clsig-quorum-context");
+        }
         {
             LOCK2(cs_main, cs);
             // BLS verification runs without cs_main. Revalidate the mutable
             // chain anchor and winner slot at the publication point so the
             // first valid aggregate remains the unique ChainLock.
-            if (!IsCandidateStillAdmissible(
+            if (chainman.ActiveChain().Tip() != publication_context.active_tip ||
+                !IsCandidateStillAdmissible(
                     chainman.ActiveChain(), bestChainLockWithKnownBlock, clsig, pindexScan)) {
                 if (from != -1) {
                     peerman.ForgetTxHash(from, hash);
@@ -736,7 +913,8 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
                 it->second.emplace(ret.second, std::make_shared<const CChainLockSig>(clsig));
             }
             mostRecentChainLockShare = clsig;
-            if (TryUpdateBestChainLock(pindexScan)) {
+            if (TryUpdateBestChainLock(
+                    pindexScan, &publication_context.quorums)) {
                 clsigAggInv = CInv(MSG_CLSIG, ::SerializeHash(bestChainLockWithKnownBlock));
             }
         }
@@ -765,8 +943,19 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
     } else {
         CInv clsigInv(MSG_CLSIG, hash);
         // An aggregated CLSIG
+        CQuorumContext verification_context;
+        if (!BuildQuorumContext(pindexScan, verification_context)) {
+            return state.Invalid(
+                BlockValidationResult::BLOCK_CHAINLOCK,
+                "clsig-unstable-quorum-context");
+        }
         bool sig_verify_attempted{false};
-        if (!VerifyAggregatedChainLock(clsig, pindexScan, hash, &sig_verify_attempted)) {
+        if (!VerifyAggregatedChainLock(
+                clsig,
+                pindexScan,
+                hash,
+                verification_context,
+                &sig_verify_attempted)) {
             LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- invalid CLSIG (%s), peer=%d\n", __func__, clsig.ToString(), from);
             if (from != -1) {
                 if (sig_verify_attempted) {
@@ -782,11 +971,19 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
             }
             return state.Invalid(BlockValidationResult::BLOCK_CHAINLOCK, "clsig-invalid-sig");
         }
+            CQuorumContext publication_context;
+            if (!BuildQuorumContext(pindexScan, publication_context) ||
+                publication_context.fingerprint != verification_context.fingerprint) {
+                return state.Invalid(
+                    BlockValidationResult::BLOCK_CHAINLOCK,
+                    "stale-clsig-quorum-context");
+            }
             {
                 LOCK2(cs_main, cs);
                 // Serialize publication with chain activation and competing
                 // verified aggregates. Enforcement never revokes this winner.
-                if (!IsCandidateStillAdmissible(
+                if (chainman.ActiveChain().Tip() != publication_context.active_tip ||
+                    !IsCandidateStillAdmissible(
                         chainman.ActiveChain(), bestChainLockWithKnownBlock, clsig, pindexScan)) {
                     if (from != -1) {
                         peerman.ForgetTxHash(from, hash);
@@ -1016,9 +1213,18 @@ void CChainLocksHandler::TrySignChainTip()
     LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- trying to sign %s, height=%d\n", __func__, targetHash.ToString(), nHeight);
     const auto& consensus = Params().GetConsensus();
     const auto& llmqParams = consensus.llmqTypeChainLocks;
-    const auto& signingActiveQuorumCount = llmqParams.signingActiveQuorumCount;
     
-    const auto quorums_scanned = llmq::quorumManager->ScanQuorums(pindex, signingActiveQuorumCount);
+    CQuorumContext signing_context;
+    if (!BuildQuorumContext(pindex, signing_context)) {
+        LogPrint(
+            BCLog::CHAINLOCKS,
+            "CChainLocksHandler::%s -- unstable quorum context for %s at height %d\n",
+            __func__,
+            targetHash.ToString(),
+            nHeight);
+        return;
+    }
+    const auto& quorums_scanned = signing_context.quorums;
     std::map<CQuorumCPtr, CChainLockSigCPtr> mapSharesAtTip;
     {
         LOCK(cs);
@@ -1067,16 +1273,28 @@ void CChainLocksHandler::TrySignChainTip()
                 // waiting for previous quorum(s) to sign anything for too long already,
                 // just sign whatever we think is a good tip
             } else if (it2->second->blockHash != targetHash) {
-                LOCK(cs_main);
-                auto shareBlockIndex = chainman.m_blockman.LookupBlockIndex(it2->second->blockHash);
-                const CBlockIndex* alternativeTarget = SelectAlternativeSigningTarget(
-                    nHeight, pindex, *it2->second, shareBlockIndex, llmqParams.dkgInterval);
-                if (alternativeTarget != nullptr) {
+                const CBlockIndex* alternativeTarget{nullptr};
+                {
+                    LOCK(cs_main);
+                    auto shareBlockIndex =
+                        chainman.m_blockman.LookupBlockIndex(it2->second->blockHash);
+                    alternativeTarget = SelectAlternativeSigningTarget(
+                        nHeight,
+                        pindex,
+                        *it2->second,
+                        shareBlockIndex,
+                        llmqParams.dkgInterval);
+                }
+                CQuorumContext alternative_context;
+                if (alternativeTarget != nullptr &&
+                    BuildQuorumContext(alternativeTarget, alternative_context) &&
+                    alternative_context.fingerprint == signing_context.fingerprint) {
                     // previous quorum signed an alternative chain tip, sign it too instead
                     LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- previous quorum (%d, %s) signed an alternative chaintip (%s != %s) at height %d, join it\n",
                             __func__, nQuorumIndexPrev, quorums_scanned[nQuorumIndexPrev]->qc->quorumHash.ToString(), it2->second->blockHash.ToString(), targetHash.ToString(), nHeight);
                     pindex = alternativeTarget;
                     targetHash = alternativeTarget->GetBlockHash();
+                    signing_context.active_tip = alternative_context.active_tip;
                 } else if (signingState.GetAttempt() <= (int)i) {
                     // previous quorum signed some different hash we have no idea about, bail out for now
                     LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- previous quorum (%d, %s) signed an unknown or an invalid blockHash (%s != %s) at height %d\n",
@@ -1101,7 +1319,8 @@ void CChainLocksHandler::TrySignChainTip()
             CChainLockSig candidate;
             candidate.nHeight = nHeight;
             candidate.blockHash = targetHash;
-            if (!IsCandidateStillAdmissible(
+            if (chainman.ActiveChain().Tip() != signing_context.active_tip ||
+                !IsCandidateStillAdmissible(
                     chainman.ActiveChain(), bestChainLockWithKnownBlock, candidate, signingTarget)) {
                 return;
             }

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -850,6 +850,12 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
     const auto& llmqParams = consensus.llmqTypeChainLocks;
     const auto& signingActiveQuorumCount = llmqParams.signingActiveQuorumCount;
     size_t signers_count = std::count(clsig.signers.begin(), clsig.signers.end(), true);
+    const auto forgetPeerRequest = [&]() {
+        if (from != -1) {
+            LOCK(cs_main);
+            peerman.ForgetTxHash(from, hash);
+        }
+    };
     if (from != -1 && (clsig.signers.empty() || signers_count == 0)) {
         LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler::%s -- invalid signers count (%d) for CLSIG (%s), peer=%d\n", __func__, signers_count, clsig.ToString(), from);
         {
@@ -862,6 +868,7 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
         // A part of a multi-quorum CLSIG signed by a single quorum
         CQuorumContext verification_context;
         if (!BuildQuorumContext(pindexScan, verification_context)) {
+            forgetPeerRequest();
             return state.Invalid(
                 BlockValidationResult::BLOCK_CHAINLOCK,
                 "clsig-unstable-quorum-context");
@@ -895,6 +902,7 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
         CQuorumContext publication_context;
         if (!BuildQuorumContext(pindexScan, publication_context) ||
             publication_context.fingerprint != verification_context.fingerprint) {
+            forgetPeerRequest();
             return state.Invalid(
                 BlockValidationResult::BLOCK_CHAINLOCK,
                 "stale-clsig-quorum-context");
@@ -969,6 +977,7 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
         // An aggregated CLSIG
         CQuorumContext verification_context;
         if (!BuildQuorumContext(pindexScan, verification_context)) {
+            forgetPeerRequest();
             return state.Invalid(
                 BlockValidationResult::BLOCK_CHAINLOCK,
                 "clsig-unstable-quorum-context");
@@ -998,6 +1007,7 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
             CQuorumContext publication_context;
             if (!BuildQuorumContext(pindexScan, publication_context) ||
                 publication_context.fingerprint != verification_context.fingerprint) {
+                forgetPeerRequest();
                 return state.Invalid(
                     BlockValidationResult::BLOCK_CHAINLOCK,
                     "stale-clsig-quorum-context");

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -10,6 +10,7 @@
 
 
 class CBlockIndex;
+class CChain;
 class CConnman;
 class PeerManager;
 class CScheduler;
@@ -133,6 +134,16 @@ public:
     bool GetRecentChainLockByHeight(int32_t nHeight, CChainLockSig& ret) EXCLUSIVE_LOCKS_REQUIRED(!cs);
 private:
     // these require locks to be held already
+    static bool IsCandidateStillAdmissible(
+        const CChain& active_chain,
+        const CChainLockSig& best_chainlock,
+        const CChainLockSig& candidate,
+        const CBlockIndex* candidate_index);
+    static const CBlockIndex* SelectAlternativeSigningTarget(
+        int32_t height,
+        const uint256& current_hash,
+        const CChainLockSig& previous_share,
+        const CBlockIndex* previous_share_index);
     bool InternalHasChainLock(int nHeight, const uint256& blockHash) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     bool InternalHasConflictingChainLock(int nHeight, const uint256& blockHash) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -133,6 +133,13 @@ public:
     bool VerifyAggregatedChainLock(const CChainLockSig& clsig, const CBlockIndex* pindexScan, const uint256& hash, bool* retSigVerifyAttempted = nullptr) EXCLUSIVE_LOCKS_REQUIRED(!cs);
     bool GetRecentChainLockByHeight(int32_t nHeight, CChainLockSig& ret) EXCLUSIVE_LOCKS_REQUIRED(!cs);
 private:
+    struct CQuorumContext
+    {
+        std::vector<CQuorumCPtr> quorums;
+        uint256 fingerprint;
+        const CBlockIndex* active_tip{nullptr};
+    };
+
     // these require locks to be held already
     static bool IsCandidateStillAdmissible(
         const CChain& active_chain,
@@ -150,8 +157,34 @@ private:
 
     void AddRecentChainLock(const CChainLockSig& clsig) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    bool TryUpdateBestChainLock(const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs);
-    bool VerifyChainLockShare(const CChainLockSig& clsig, const CBlockIndex* pindexScan, const uint256& idIn, std::pair<int, CQuorumCPtr>& ret, const uint256& hash, bool* retSigVerifyAttempted = nullptr) EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    bool BuildQuorumContext(
+        const CBlockIndex* candidate_index,
+        CQuorumContext& context) const EXCLUSIVE_LOCKS_REQUIRED(!cs_main, !cs);
+    static bool SameQuorumIdentity(
+        const CQuorumCPtr& lhs,
+        const CQuorumCPtr& rhs);
+    static bool IsAlternativeCommitmentWindowStable(
+        int32_t height,
+        int32_t common_height,
+        int32_t dkg_interval,
+        int32_t mining_window_start,
+        int32_t mining_window_end);
+    bool TryUpdateBestChainLock(
+        const CBlockIndex* pindex,
+        const std::vector<CQuorumCPtr>* quorums = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    bool VerifyChainLockShare(
+        const CChainLockSig& clsig,
+        const uint256& idIn,
+        std::pair<int, CQuorumCPtr>& ret,
+        const uint256& hash,
+        const CQuorumContext& context,
+        bool* retSigVerifyAttempted = nullptr) EXCLUSIVE_LOCKS_REQUIRED(!cs);
+    bool VerifyAggregatedChainLock(
+        const CChainLockSig& clsig,
+        const CBlockIndex* pindexScan,
+        const uint256& hash,
+        const CQuorumContext& context,
+        bool* retSigVerifyAttempted) EXCLUSIVE_LOCKS_REQUIRED(!cs);
     void MarkRejectedChainLock(const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(!cs);
     void Cleanup() EXCLUSIVE_LOCKS_REQUIRED(!cs);
 

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -99,7 +99,7 @@ private:
     std::map<uint256, std::pair<int, uint256> > mapSignedRequestIds GUARDED_BY(cs);
     std::map<uint256, int64_t> seenChainLocks GUARDED_BY(cs);
     std::map<uint256, int64_t> rejectedChainLocks GUARDED_BY(cs);
-    std::map<uint256, int64_t> sigChecked GUARDED_BY(cs);
+    std::map<std::pair<uint256, uint256>, int64_t> sigChecked GUARDED_BY(cs);
 
     int64_t lastCleanupTime GUARDED_BY(cs) {0};
 
@@ -156,6 +156,7 @@ private:
     bool InternalHasConflictingChainLock(int nHeight, const uint256& blockHash) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     void AddRecentChainLock(const CChainLockSig& clsig) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void ProcessPendingRecoveredChainLockSigs() EXCLUSIVE_LOCKS_REQUIRED(!cs);
 
     bool BuildQuorumContext(
         const CBlockIndex* candidate_index,

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -5,6 +5,7 @@
 #ifndef SYSCOIN_LLMQ_QUORUMS_CHAINLOCKS_H
 #define SYSCOIN_LLMQ_QUORUMS_CHAINLOCKS_H
 
+#include <kernel/cs_main.h>
 #include <llmq/quorums_signing.h>
 #include <atomic>
 

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -141,9 +141,10 @@ private:
         const CBlockIndex* candidate_index);
     static const CBlockIndex* SelectAlternativeSigningTarget(
         int32_t height,
-        const uint256& current_hash,
+        const CBlockIndex* current_index,
         const CChainLockSig& previous_share,
-        const CBlockIndex* previous_share_index);
+        const CBlockIndex* previous_share_index,
+        int32_t dkg_interval);
     bool InternalHasChainLock(int nHeight, const uint256& blockHash) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     bool InternalHasConflictingChainLock(int nHeight, const uint256& blockHash) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -137,7 +137,7 @@ private:
     {
         std::vector<CQuorumCPtr> quorums;
         uint256 fingerprint;
-        const CBlockIndex* active_tip{nullptr};
+        const CBlockIndex* active_height_index{nullptr};
     };
 
     // these require locks to be held already
@@ -170,6 +170,10 @@ private:
         int32_t dkg_interval,
         int32_t mining_window_start,
         int32_t mining_window_end);
+    static bool IsActiveHeightSnapshotCurrent(
+        const CChain& active_chain,
+        int32_t height,
+        const CBlockIndex* active_height_index);
     bool TryUpdateBestChainLock(
         const CBlockIndex* pindex,
         const std::vector<CQuorumCPtr>* quorums = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs);

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -745,7 +745,21 @@ bool CSigningManager::AsyncSignIfMember(const uint256& id, const uint256& msgHas
             return quorumManager->GetQuorum(quorumHash);
         }
     }();
+    return AsyncSignIfMember(id, msgHash, quorum, allowReSign);
+}
 
+bool CSigningManager::AsyncSignIfMember(
+    const uint256& id,
+    const uint256& msgHash,
+    const CQuorumCPtr& quorum,
+    bool allowReSign)
+{
+    if (!fMasternodeMode ||
+        WITH_LOCK(
+            activeMasternodeInfoCs,
+            return activeMasternodeInfo.proTxHash.IsNull())) {
+        return false;
+    }
     if (!quorum) {
         LogPrint(BCLog::LLMQ, "CSigningManager::%s -- failed to select quorum. id=%s, msgHash=%s\n", __func__, id.ToString(), msgHash.ToString());
         return false;

--- a/src/llmq/quorums_signing.h
+++ b/src/llmq/quorums_signing.h
@@ -207,6 +207,11 @@ public:
     void UnregisterRecoveredSigsListener(CRecoveredSigsListener* l) EXCLUSIVE_LOCKS_REQUIRED(!cs_listeners);
 
     bool AsyncSignIfMember(const uint256& id, const uint256& msgHash, const uint256& quorumHash = uint256(), bool allowReSign = false);
+    bool AsyncSignIfMember(
+        const uint256& id,
+        const uint256& msgHash,
+        const CQuorumCPtr& quorum,
+        bool allowReSign = false);
     bool HasRecoveredSig(const uint256& id, const uint256& msgHash) const;
     bool HasRecoveredSigForId(const uint256& id) const;
     bool HasRecoveredSigForSession(const uint256& signHash) const;

--- a/src/test/llmq_sigshare_cache_tests.cpp
+++ b/src/test/llmq_sigshare_cache_tests.cpp
@@ -274,19 +274,23 @@ BOOST_AUTO_TEST_CASE(chainlock_alternative_tip_selects_exact_signing_hash)
         fork_blocks[i].pprev = i == 0 ? &active_blocks[4] : &fork_blocks[i - 1];
     }
 
-    previous_share.blockHash = fork_blocks.back().GetBlockHash();
+    previous_share.blockHash = active_blocks.back().GetBlockHash();
     selected = llmq_tests::CChainLocksHandlerTestAccess::SelectAlternativeSigningTarget(
-        10, active_blocks[10].GetBlockHash(), previous_share, &fork_blocks.back());
-    BOOST_REQUIRE(selected == &fork_blocks.back());
+        10, fork_blocks.back().GetBlockHash(), previous_share, &active_blocks.back());
+    BOOST_REQUIRE(selected == &active_blocks.back());
 
     CChain active_chain;
     active_chain.SetTip(active_blocks.back());
-    llmq::CChainLockSig lower_winner;
-    lower_winner.nHeight = 5;
-    lower_winner.blockHash = active_blocks[5].GetBlockHash();
     llmq::CChainLockSig signing_candidate;
     signing_candidate.nHeight = 10;
     signing_candidate.blockHash = selected->GetBlockHash();
+    llmq::CChainLockSig no_winner;
+    BOOST_CHECK(llmq_tests::CChainLocksHandlerTestAccess::IsCandidateStillAdmissible(
+        active_chain, no_winner, signing_candidate, selected));
+
+    llmq::CChainLockSig lower_winner;
+    lower_winner.nHeight = 5;
+    lower_winner.blockHash = fork_blocks.front().GetBlockHash();
     BOOST_CHECK(!llmq_tests::CChainLocksHandlerTestAccess::IsCandidateStillAdmissible(
         active_chain, lower_winner, signing_candidate, selected));
 }

--- a/src/test/llmq_sigshare_cache_tests.cpp
+++ b/src/test/llmq_sigshare_cache_tests.cpp
@@ -54,12 +54,13 @@ public:
 
     static const CBlockIndex* SelectAlternativeSigningTarget(
         int32_t height,
-        const uint256& current_hash,
+        const CBlockIndex* current_index,
         const llmq::CChainLockSig& previous_share,
-        const CBlockIndex* previous_share_index)
+        const CBlockIndex* previous_share_index,
+        int32_t dkg_interval)
     {
         return llmq::CChainLocksHandler::SelectAlternativeSigningTarget(
-            height, current_hash, previous_share, previous_share_index);
+            height, current_index, previous_share, previous_share_index, dkg_interval);
     }
 };
 
@@ -227,36 +228,6 @@ BOOST_AUTO_TEST_CASE(chainlock_publication_rechecks_anchor_and_winner)
 
 BOOST_AUTO_TEST_CASE(chainlock_alternative_tip_selects_exact_signing_hash)
 {
-    const uint256 current_hash = GetRandHash();
-    const uint256 alternative_hash = GetRandHash();
-    CBlockIndex current;
-    current.phashBlock = &current_hash;
-    current.nHeight = 10;
-    CBlockIndex alternative;
-    alternative.phashBlock = &alternative_hash;
-    alternative.nHeight = 10;
-
-    llmq::CChainLockSig previous_share;
-    previous_share.nHeight = 10;
-    previous_share.blockHash = alternative_hash;
-    const CBlockIndex* selected =
-        llmq_tests::CChainLocksHandlerTestAccess::SelectAlternativeSigningTarget(
-            10, current_hash, previous_share, &alternative);
-    BOOST_REQUIRE(selected != nullptr);
-    BOOST_CHECK_EQUAL(selected->GetBlockHash(), alternative_hash);
-
-    alternative.nHeight = 9;
-    BOOST_CHECK(
-        llmq_tests::CChainLocksHandlerTestAccess::SelectAlternativeSigningTarget(
-            10, current_hash, previous_share, &alternative) == nullptr);
-    alternative.nHeight = 10;
-    previous_share.blockHash = current_hash;
-    BOOST_CHECK(
-        llmq_tests::CChainLocksHandlerTestAccess::SelectAlternativeSigningTarget(
-            10, current_hash, previous_share, &current) == nullptr);
-
-    // A target selected from a previously observed share must still be
-    // rejected before signing if a lower, non-ancestor ChainLock wins.
     std::array<CBlockIndex, 11> active_blocks;
     std::array<uint256, 11> active_hashes;
     for (size_t i = 0; i < active_blocks.size(); ++i) {
@@ -274,9 +245,30 @@ BOOST_AUTO_TEST_CASE(chainlock_alternative_tip_selects_exact_signing_hash)
         fork_blocks[i].pprev = i == 0 ? &active_blocks[4] : &fork_blocks[i - 1];
     }
 
+    llmq::CChainLockSig previous_share;
+    previous_share.nHeight = 10;
+    previous_share.blockHash = fork_blocks.back().GetBlockHash();
+    const CBlockIndex* selected =
+        llmq_tests::CChainLocksHandlerTestAccess::SelectAlternativeSigningTarget(
+            10, &active_blocks.back(), previous_share, &fork_blocks.back(), 12);
+    BOOST_REQUIRE(selected == &fork_blocks.back());
+
+    // A DKG boundary after the common ancestor makes ScanQuorums branch-specific.
+    BOOST_CHECK(
+        llmq_tests::CChainLocksHandlerTestAccess::SelectAlternativeSigningTarget(
+            10, &active_blocks.back(), previous_share, &fork_blocks.back(), 5) == nullptr);
+
+    previous_share.nHeight = 9;
+    BOOST_CHECK(
+        llmq_tests::CChainLocksHandlerTestAccess::SelectAlternativeSigningTarget(
+            10, &active_blocks.back(), previous_share, &fork_blocks.back(), 12) == nullptr);
+
+    // A target selected from a previously observed share must still be
+    // rejected before signing if a lower, non-ancestor ChainLock wins.
+    previous_share.nHeight = 10;
     previous_share.blockHash = active_blocks.back().GetBlockHash();
     selected = llmq_tests::CChainLocksHandlerTestAccess::SelectAlternativeSigningTarget(
-        10, fork_blocks.back().GetBlockHash(), previous_share, &active_blocks.back());
+        10, &fork_blocks.back(), previous_share, &active_blocks.back(), 12);
     BOOST_REQUIRE(selected == &active_blocks.back());
 
     CChain active_chain;

--- a/src/test/llmq_sigshare_cache_tests.cpp
+++ b/src/test/llmq_sigshare_cache_tests.cpp
@@ -168,6 +168,15 @@ public:
     {
         return llmq::CChainLocksHandler::SameQuorumIdentity(lhs, rhs);
     }
+
+    static bool IsActiveHeightSnapshotCurrent(
+        const CChain& active_chain,
+        int32_t height,
+        const CBlockIndex* active_height_index)
+    {
+        return llmq::CChainLocksHandler::IsActiveHeightSnapshotCurrent(
+            active_chain, height, active_height_index);
+    }
 };
 
 class CBTCCheckpointsHandlerTestAccess
@@ -383,6 +392,43 @@ BOOST_AUTO_TEST_CASE(chainlock_aggregate_cache_hit_requires_aggregate_structure)
     hash = ::SerializeHash(clsig);
     llmq_tests::CChainLocksHandlerTestAccess::MarkSigChecked(*llmq::chainLocksHandler, hash);
     BOOST_CHECK(!llmq::chainLocksHandler->VerifyAggregatedChainLock(clsig, pindex_tip, hash));
+}
+
+BOOST_AUTO_TEST_CASE(chainlock_publication_allows_same_chain_tip_extension)
+{
+    std::array<CBlockIndex, 12> active_blocks;
+    std::array<uint256, 12> active_hashes;
+    for (size_t i = 0; i < active_blocks.size(); ++i) {
+        active_hashes[i] = GetRandHash();
+        active_blocks[i].phashBlock = &active_hashes[i];
+        active_blocks[i].nHeight = i;
+        active_blocks[i].pprev = i == 0 ? nullptr : &active_blocks[i - 1];
+    }
+
+    std::array<CBlockIndex, 6> fork_blocks;
+    std::array<uint256, 6> fork_hashes;
+    for (size_t i = 0; i < fork_blocks.size(); ++i) {
+        fork_hashes[i] = GetRandHash();
+        fork_blocks[i].phashBlock = &fork_hashes[i];
+        fork_blocks[i].nHeight = i + 6;
+        fork_blocks[i].pprev = i == 0 ? &active_blocks[5] : &fork_blocks[i - 1];
+    }
+
+    CChain active_chain;
+    active_chain.SetTip(active_blocks[10]);
+    const CBlockIndex* signing_height_snapshot = active_chain[10];
+
+    active_chain.SetTip(active_blocks[11]);
+    BOOST_CHECK(
+        llmq_tests::CChainLocksHandlerTestAccess::
+            IsActiveHeightSnapshotCurrent(
+                active_chain, 10, signing_height_snapshot));
+
+    active_chain.SetTip(fork_blocks.back());
+    BOOST_CHECK(
+        !llmq_tests::CChainLocksHandlerTestAccess::
+            IsActiveHeightSnapshotCurrent(
+                active_chain, 10, signing_height_snapshot));
 }
 
 BOOST_AUTO_TEST_CASE(chainlock_publication_rechecks_anchor_and_winner)

--- a/src/test/llmq_sigshare_cache_tests.cpp
+++ b/src/test/llmq_sigshare_cache_tests.cpp
@@ -85,10 +85,24 @@ public:
 class CChainLocksHandlerTestAccess
 {
 public:
-    static void MarkSigChecked(llmq::CChainLocksHandler& handler, const uint256& hash)
+    static void MarkSigChecked(
+        llmq::CChainLocksHandler& handler,
+        const uint256& hash,
+        const uint256& fingerprint = uint256())
     {
         LOCK(handler.cs);
-        handler.sigChecked.emplace(hash, TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()));
+        handler.sigChecked.emplace(
+            std::make_pair(hash, fingerprint),
+            TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()));
+    }
+
+    static bool IsSigChecked(
+        llmq::CChainLocksHandler& handler,
+        const uint256& hash,
+        const uint256& fingerprint)
+    {
+        LOCK(handler.cs);
+        return handler.sigChecked.count(std::make_pair(hash, fingerprint)) != 0;
     }
 
     static void MarkRejected(llmq::CChainLocksHandler& handler, const uint256& hash)
@@ -322,6 +336,22 @@ BOOST_AUTO_TEST_CASE(chainlock_rejected_cache_suppresses_repeated_requests)
 
     llmq_tests::CChainLocksHandlerTestAccess::MarkRejected(*llmq::chainLocksHandler, hash);
     BOOST_CHECK(llmq::chainLocksHandler->AlreadyHave(hash));
+}
+
+BOOST_AUTO_TEST_CASE(chainlock_signature_cache_is_quorum_context_bound)
+{
+    BOOST_REQUIRE(llmq::chainLocksHandler != nullptr);
+
+    const uint256 hash = GetRandHash();
+    const uint256 old_fingerprint = GetRandHash();
+    const uint256 new_fingerprint = GetRandHash();
+    llmq_tests::CChainLocksHandlerTestAccess::MarkSigChecked(
+        *llmq::chainLocksHandler, hash, old_fingerprint);
+
+    BOOST_CHECK(llmq_tests::CChainLocksHandlerTestAccess::IsSigChecked(
+        *llmq::chainLocksHandler, hash, old_fingerprint));
+    BOOST_CHECK(!llmq_tests::CChainLocksHandlerTestAccess::IsSigChecked(
+        *llmq::chainLocksHandler, hash, new_fingerprint));
 }
 
 BOOST_AUTO_TEST_CASE(chainlock_aggregate_cache_hit_requires_aggregate_structure)

--- a/src/test/llmq_sigshare_cache_tests.cpp
+++ b/src/test/llmq_sigshare_cache_tests.cpp
@@ -4,7 +4,9 @@
 
 #include <llmq/quorums.h>
 #include <llmq/quorums_btccheckpoints.h>
+#include <llmq/quorums_blockprocessor.h>
 #include <llmq/quorums_chainlocks.h>
+#include <llmq/quorums_commitment.h>
 #include <chainparams.h>
 #include <random.h>
 #include <test/util/setup_common.h>
@@ -16,6 +18,69 @@
 
 namespace llmq_tests
 {
+
+class CQuorumManagerTestAccess
+{
+public:
+    static llmq::CQuorumPtr MakeQuorum(
+        llmq::CQuorumManager& manager,
+        const CBlockIndex* base,
+        const uint256& mined_block_hash,
+        const uint256& commitment_tag)
+    {
+        auto commitment = std::make_unique<llmq::CFinalCommitment>(base->GetBlockHash());
+        commitment->quorumVvecHash = commitment_tag;
+        auto quorum = std::make_shared<llmq::CQuorum>(manager.blsWorker);
+        quorum->Init(
+            std::move(commitment),
+            base,
+            mined_block_hash,
+            Span<CDeterministicMNCPtr>{});
+        return quorum;
+    }
+
+    static void CacheQuorum(
+        llmq::CQuorumManager& manager,
+        const llmq::CQuorumCPtr& quorum)
+    {
+        LOCK(manager.cs_quorums);
+        manager.vecQuorumsCache.emplace_back(quorum);
+    }
+
+    static void RemoveCachedBase(
+        llmq::CQuorumManager& manager,
+        const uint256& quorum_hash)
+    {
+        LOCK(manager.cs_quorums);
+        manager.vecQuorumsCache.erase(
+            std::remove_if(
+                manager.vecQuorumsCache.begin(),
+                manager.vecQuorumsCache.end(),
+                [&](const llmq::CQuorumCPtr& quorum) {
+                    return quorum->m_quorum_base_block_index->GetBlockHash() == quorum_hash;
+                }),
+            manager.vecQuorumsCache.end());
+    }
+
+    static llmq::CQuorumCPtr GetQuorum(
+        llmq::CQuorumManager& manager,
+        const CBlockIndex* base)
+    {
+        return manager.GetQuorum(base);
+    }
+
+    static uint256 MakeQuorumKey(const llmq::CQuorum& quorum)
+    {
+        return llmq::CQuorumManager::MakeQuorumKey(quorum);
+    }
+
+    static bool IsQuorumMinedOnChain(
+        const llmq::CQuorum& quorum,
+        const CBlockIndex* tip)
+    {
+        return llmq::CQuorumManager::IsQuorumMinedOnChain(quorum, tip);
+    }
+};
 
 class CChainLocksHandlerTestAccess
 {
@@ -39,7 +104,12 @@ public:
         std::pair<int, llmq::CQuorumCPtr>& ret,
         const uint256& hash)
     {
-        return handler.VerifyChainLockShare(clsig, pindexScan, idIn, ret, hash);
+        llmq::CChainLocksHandler::CQuorumContext context;
+        if (!handler.BuildQuorumContext(pindexScan, context)) {
+            return false;
+        }
+        return handler.VerifyChainLockShare(
+            clsig, idIn, ret, hash, context);
     }
 
     static bool IsCandidateStillAdmissible(
@@ -61,6 +131,28 @@ public:
     {
         return llmq::CChainLocksHandler::SelectAlternativeSigningTarget(
             height, current_index, previous_share, previous_share_index, dkg_interval);
+    }
+
+    static bool IsAlternativeCommitmentWindowStable(
+        int32_t height,
+        int32_t common_height,
+        int32_t dkg_interval,
+        int32_t mining_window_start,
+        int32_t mining_window_end)
+    {
+        return llmq::CChainLocksHandler::IsAlternativeCommitmentWindowStable(
+            height,
+            common_height,
+            dkg_interval,
+            mining_window_start,
+            mining_window_end);
+    }
+
+    static bool SameQuorumIdentity(
+        const llmq::CQuorumCPtr& lhs,
+        const llmq::CQuorumCPtr& rhs)
+    {
+        return llmq::CChainLocksHandler::SameQuorumIdentity(lhs, rhs);
     }
 };
 
@@ -93,6 +185,102 @@ public:
 } // namespace llmq_tests
 
 BOOST_FIXTURE_TEST_SUITE(llmq_sigshare_cache_tests, RegTestingSetup)
+
+BOOST_AUTO_TEST_CASE(quorum_cache_distinguishes_reorg_commitments)
+{
+    BOOST_REQUIRE(llmq::quorumManager != nullptr);
+    BOOST_REQUIRE(llmq::quorumBlockProcessor != nullptr);
+
+    const uint256 base_hash = GetRandHash();
+    CBlockIndex base;
+    base.phashBlock = &base_hash;
+    base.nHeight = 0;
+
+    const uint256 old_mined_hash = GetRandHash();
+    const uint256 new_mined_hash = GetRandHash();
+    auto old_quorum = llmq_tests::CQuorumManagerTestAccess::MakeQuorum(
+        *llmq::quorumManager, &base, old_mined_hash, GetRandHash());
+    auto new_quorum = llmq_tests::CQuorumManagerTestAccess::MakeQuorum(
+        *llmq::quorumManager, &base, new_mined_hash, GetRandHash());
+
+    llmq_tests::CQuorumManagerTestAccess::CacheQuorum(
+        *llmq::quorumManager, old_quorum);
+    llmq_tests::CQuorumManagerTestAccess::CacheQuorum(
+        *llmq::quorumManager, new_quorum);
+    llmq::quorumBlockProcessor->m_commitment_evoDb.WriteCache(
+        base_hash, std::make_pair(*new_quorum->qc, new_mined_hash));
+
+    const auto resolved = llmq_tests::CQuorumManagerTestAccess::GetQuorum(
+        *llmq::quorumManager, &base);
+
+    llmq::quorumBlockProcessor->m_commitment_evoDb.EraseCache(base_hash);
+    llmq_tests::CQuorumManagerTestAccess::RemoveCachedBase(
+        *llmq::quorumManager, base_hash);
+
+    BOOST_REQUIRE(resolved != nullptr);
+    BOOST_CHECK_EQUAL(resolved->minedBlockHash, new_mined_hash);
+    BOOST_CHECK_EQUAL(
+        ::SerializeHash(*resolved->qc),
+        ::SerializeHash(*new_quorum->qc));
+}
+
+BOOST_AUTO_TEST_CASE(quorum_contribution_key_is_commitment_specific)
+{
+    BOOST_REQUIRE(llmq::quorumManager != nullptr);
+
+    const uint256 base_hash = GetRandHash();
+    CBlockIndex base;
+    base.phashBlock = &base_hash;
+    base.nHeight = 0;
+
+    auto quorum_a = llmq_tests::CQuorumManagerTestAccess::MakeQuorum(
+        *llmq::quorumManager, &base, GetRandHash(), GetRandHash());
+    auto quorum_b = llmq_tests::CQuorumManagerTestAccess::MakeQuorum(
+        *llmq::quorumManager, &base, GetRandHash(), GetRandHash());
+
+    BOOST_CHECK(
+        llmq_tests::CQuorumManagerTestAccess::MakeQuorumKey(*quorum_a) !=
+        llmq_tests::CQuorumManagerTestAccess::MakeQuorumKey(*quorum_b));
+    BOOST_CHECK(llmq_tests::CChainLocksHandlerTestAccess::SameQuorumIdentity(
+        quorum_a, quorum_a));
+    BOOST_CHECK(!llmq_tests::CChainLocksHandlerTestAccess::SameQuorumIdentity(
+        quorum_a, quorum_b));
+}
+
+BOOST_AUTO_TEST_CASE(quorum_mining_block_must_be_in_target_ancestry)
+{
+    BOOST_REQUIRE(llmq::quorumManager != nullptr);
+
+    std::array<CBlockIndex, 4> branch_a;
+    std::array<uint256, 4> branch_a_hashes;
+    std::array<CBlockIndex, 3> branch_b;
+    std::array<uint256, 3> branch_b_hashes;
+    for (size_t i = 0; i < branch_a.size(); ++i) {
+        branch_a_hashes[i] = GetRandHash();
+        branch_a[i].phashBlock = &branch_a_hashes[i];
+        branch_a[i].nHeight = i;
+        branch_a[i].pprev = i == 0 ? nullptr : &branch_a[i - 1];
+    }
+    for (size_t i = 0; i < branch_b.size(); ++i) {
+        branch_b_hashes[i] = GetRandHash();
+        branch_b[i].phashBlock = &branch_b_hashes[i];
+        branch_b[i].nHeight = i + 1;
+        branch_b[i].pprev = i == 0 ? &branch_a[0] : &branch_b[i - 1];
+    }
+
+    auto quorum = llmq_tests::CQuorumManagerTestAccess::MakeQuorum(
+        *llmq::quorumManager,
+        &branch_a[0],
+        branch_a[2].GetBlockHash(),
+        GetRandHash());
+
+    BOOST_CHECK(llmq_tests::CQuorumManagerTestAccess::IsQuorumMinedOnChain(
+        *quorum, &branch_a[3]));
+    BOOST_CHECK(!llmq_tests::CQuorumManagerTestAccess::IsQuorumMinedOnChain(
+        *quorum, &branch_a[1]));
+    BOOST_CHECK(!llmq_tests::CQuorumManagerTestAccess::IsQuorumMinedOnChain(
+        *quorum, &branch_b[2]));
+}
 
 BOOST_AUTO_TEST_CASE(chainlock_share_cache_hit_requires_signer_context)
 {
@@ -285,6 +473,32 @@ BOOST_AUTO_TEST_CASE(chainlock_alternative_tip_selects_exact_signing_hash)
     lower_winner.blockHash = fork_blocks.front().GetBlockHash();
     BOOST_CHECK(!llmq_tests::CChainLocksHandlerTestAccess::IsCandidateStillAdmissible(
         active_chain, lower_winner, signing_candidate, selected));
+}
+
+BOOST_AUTO_TEST_CASE(chainlock_alternative_rejects_unresolved_commitment_window)
+{
+    constexpr int32_t interval = 24;
+    constexpr int32_t mining_start = 10;
+    constexpr int32_t mining_end = 18;
+    const auto stable = [&](int32_t height, int32_t common_height) {
+        return llmq_tests::CChainLocksHandlerTestAccess::
+            IsAlternativeCommitmentWindowStable(
+                height,
+                common_height,
+                interval,
+                mining_start,
+                mining_end);
+    };
+
+    BOOST_CHECK(stable(9, 4));
+    BOOST_CHECK(!stable(12, 7));
+    BOOST_CHECK(!stable(20, 15));
+    BOOST_CHECK(stable(20, 18));
+
+    // The current round has not started at height 25, but a fork before the
+    // preceding round's end can still replace that round's final commitment.
+    BOOST_CHECK(!stable(25, 17));
+    BOOST_CHECK(stable(25, 18));
 }
 
 BOOST_AUTO_TEST_CASE(btccheckpoint_share_cache_hit_requires_signer_context)

--- a/src/test/llmq_sigshare_cache_tests.cpp
+++ b/src/test/llmq_sigshare_cache_tests.cpp
@@ -214,37 +214,52 @@ BOOST_AUTO_TEST_CASE(quorum_cache_distinguishes_reorg_commitments)
     BOOST_REQUIRE(llmq::quorumManager != nullptr);
     BOOST_REQUIRE(llmq::quorumBlockProcessor != nullptr);
 
-    const uint256 base_hash = GetRandHash();
-    CBlockIndex base;
-    base.phashBlock = &base_hash;
-    base.nHeight = 0;
+    const CBlockIndex* base =
+        WITH_LOCK(::cs_main, return m_node.chainman->ActiveChain()[0]);
+    BOOST_REQUIRE(base != nullptr);
+    const uint256 base_hash = base->GetBlockHash();
 
     const uint256 old_mined_hash = GetRandHash();
     const uint256 new_mined_hash = GetRandHash();
     auto old_quorum = llmq_tests::CQuorumManagerTestAccess::MakeQuorum(
-        *llmq::quorumManager, &base, old_mined_hash, GetRandHash());
+        *llmq::quorumManager, base, old_mined_hash, GetRandHash());
     auto new_quorum = llmq_tests::CQuorumManagerTestAccess::MakeQuorum(
-        *llmq::quorumManager, &base, new_mined_hash, GetRandHash());
+        *llmq::quorumManager, base, new_mined_hash, GetRandHash());
 
-    llmq_tests::CQuorumManagerTestAccess::CacheQuorum(
-        *llmq::quorumManager, old_quorum);
-    llmq_tests::CQuorumManagerTestAccess::CacheQuorum(
-        *llmq::quorumManager, new_quorum);
+    llmq_tests::CQuorumManagerTestAccess::RemoveCachedBase(
+        *llmq::quorumManager, base_hash);
+    llmq::quorumBlockProcessor->m_commitment_evoDb.WriteCache(
+        base_hash, std::make_pair(*old_quorum->qc, old_mined_hash));
+
+    const auto resolved_old = llmq_tests::CQuorumManagerTestAccess::GetQuorum(
+        *llmq::quorumManager, base);
+    BOOST_REQUIRE(resolved_old != nullptr);
+    BOOST_CHECK_EQUAL(resolved_old->minedBlockHash, old_mined_hash);
+    BOOST_CHECK_EQUAL(
+        ::SerializeHash(*resolved_old->qc),
+        ::SerializeHash(*old_quorum->qc));
+
+    // Simulate a reorg selecting a different final commitment under the same
+    // DKG base. GetQuorum must reject the stale same-base cache object and
+    // publish a quorum built from the replacement commitment.
     llmq::quorumBlockProcessor->m_commitment_evoDb.WriteCache(
         base_hash, std::make_pair(*new_quorum->qc, new_mined_hash));
-
-    const auto resolved = llmq_tests::CQuorumManagerTestAccess::GetQuorum(
-        *llmq::quorumManager, &base);
+    const auto resolved_new = llmq_tests::CQuorumManagerTestAccess::GetQuorum(
+        *llmq::quorumManager, base);
+    const auto cached_new = llmq_tests::CQuorumManagerTestAccess::GetQuorum(
+        *llmq::quorumManager, base);
 
     llmq::quorumBlockProcessor->m_commitment_evoDb.EraseCache(base_hash);
     llmq_tests::CQuorumManagerTestAccess::RemoveCachedBase(
         *llmq::quorumManager, base_hash);
 
-    BOOST_REQUIRE(resolved != nullptr);
-    BOOST_CHECK_EQUAL(resolved->minedBlockHash, new_mined_hash);
+    BOOST_REQUIRE(resolved_new != nullptr);
+    BOOST_REQUIRE(cached_new != nullptr);
+    BOOST_CHECK_EQUAL(resolved_new->minedBlockHash, new_mined_hash);
     BOOST_CHECK_EQUAL(
-        ::SerializeHash(*resolved->qc),
+        ::SerializeHash(*resolved_new->qc),
         ::SerializeHash(*new_quorum->qc));
+    BOOST_CHECK(resolved_new == cached_new);
 }
 
 BOOST_AUTO_TEST_CASE(quorum_contribution_key_is_commitment_specific)

--- a/src/test/llmq_sigshare_cache_tests.cpp
+++ b/src/test/llmq_sigshare_cache_tests.cpp
@@ -11,6 +11,7 @@
 #include <util/time.h>
 #include <validation.h>
 
+#include <array>
 #include <boost/test/unit_test.hpp>
 
 namespace llmq_tests
@@ -39,6 +40,26 @@ public:
         const uint256& hash)
     {
         return handler.VerifyChainLockShare(clsig, pindexScan, idIn, ret, hash);
+    }
+
+    static bool IsCandidateStillAdmissible(
+        const CChain& active_chain,
+        const llmq::CChainLockSig& best_chainlock,
+        const llmq::CChainLockSig& candidate,
+        const CBlockIndex* candidate_index)
+    {
+        return llmq::CChainLocksHandler::IsCandidateStillAdmissible(
+            active_chain, best_chainlock, candidate, candidate_index);
+    }
+
+    static const CBlockIndex* SelectAlternativeSigningTarget(
+        int32_t height,
+        const uint256& current_hash,
+        const llmq::CChainLockSig& previous_share,
+        const CBlockIndex* previous_share_index)
+    {
+        return llmq::CChainLocksHandler::SelectAlternativeSigningTarget(
+            height, current_hash, previous_share, previous_share_index);
     }
 };
 
@@ -143,6 +164,131 @@ BOOST_AUTO_TEST_CASE(chainlock_aggregate_cache_hit_requires_aggregate_structure)
     hash = ::SerializeHash(clsig);
     llmq_tests::CChainLocksHandlerTestAccess::MarkSigChecked(*llmq::chainLocksHandler, hash);
     BOOST_CHECK(!llmq::chainLocksHandler->VerifyAggregatedChainLock(clsig, pindex_tip, hash));
+}
+
+BOOST_AUTO_TEST_CASE(chainlock_publication_rechecks_anchor_and_winner)
+{
+    std::array<CBlockIndex, 21> active_blocks;
+    std::array<uint256, 21> active_hashes;
+    for (size_t i = 0; i < active_blocks.size(); ++i) {
+        active_hashes[i] = GetRandHash();
+        active_blocks[i].phashBlock = &active_hashes[i];
+        active_blocks[i].nHeight = i;
+        active_blocks[i].pprev = i == 0 ? nullptr : &active_blocks[i - 1];
+    }
+
+    CChain active_chain;
+    active_chain.SetTip(active_blocks.back());
+
+    llmq::CChainLockSig candidate;
+    candidate.nHeight = 10;
+    candidate.blockHash = active_blocks[10].GetBlockHash();
+    llmq::CChainLockSig no_winner;
+
+    // Tip movement alone must not invalidate an in-flight, anchor-compatible
+    // aggregate. The expected signing height is intentionally not rechecked.
+    BOOST_CHECK(llmq_tests::CChainLocksHandlerTestAccess::IsCandidateStillAdmissible(
+        active_chain, no_winner, candidate, &active_blocks[10]));
+
+    std::array<CBlockIndex, 6> fork_blocks;
+    std::array<uint256, 6> fork_hashes;
+    for (size_t i = 0; i < fork_blocks.size(); ++i) {
+        fork_hashes[i] = GetRandHash();
+        fork_blocks[i].phashBlock = &fork_hashes[i];
+        fork_blocks[i].nHeight = i + 5;
+        fork_blocks[i].pprev = i == 0 ? &active_blocks[4] : &fork_blocks[i - 1];
+    }
+    candidate.blockHash = fork_blocks.back().GetBlockHash();
+    BOOST_CHECK(!llmq_tests::CChainLocksHandlerTestAccess::IsCandidateStillAdmissible(
+        active_chain, no_winner, candidate, &fork_blocks.back()));
+
+    candidate.blockHash = active_blocks[10].GetBlockHash();
+    llmq::CChainLockSig existing_winner;
+    existing_winner.nHeight = candidate.nHeight;
+    existing_winner.blockHash = candidate.blockHash;
+    BOOST_CHECK(!llmq_tests::CChainLocksHandlerTestAccess::IsCandidateStillAdmissible(
+        active_chain, existing_winner, candidate, &active_blocks[10]));
+
+    // A higher candidate must descend from the already-published winner, even
+    // while the active chain has not yet enforced that winner.
+    existing_winner.blockHash = fork_blocks.back().GetBlockHash();
+    llmq::CChainLockSig higher_candidate;
+    higher_candidate.nHeight = 15;
+    higher_candidate.blockHash = active_blocks[15].GetBlockHash();
+    BOOST_CHECK(!llmq_tests::CChainLocksHandlerTestAccess::IsCandidateStillAdmissible(
+        active_chain, existing_winner, higher_candidate, &active_blocks[15]));
+
+    // If the higher window publishes first, the lower candidate cannot replace it.
+    llmq::CChainLockSig higher_winner = higher_candidate;
+    candidate.blockHash = fork_blocks.back().GetBlockHash();
+    BOOST_CHECK(!llmq_tests::CChainLocksHandlerTestAccess::IsCandidateStillAdmissible(
+        active_chain, higher_winner, candidate, &fork_blocks.back()));
+}
+
+BOOST_AUTO_TEST_CASE(chainlock_alternative_tip_selects_exact_signing_hash)
+{
+    const uint256 current_hash = GetRandHash();
+    const uint256 alternative_hash = GetRandHash();
+    CBlockIndex current;
+    current.phashBlock = &current_hash;
+    current.nHeight = 10;
+    CBlockIndex alternative;
+    alternative.phashBlock = &alternative_hash;
+    alternative.nHeight = 10;
+
+    llmq::CChainLockSig previous_share;
+    previous_share.nHeight = 10;
+    previous_share.blockHash = alternative_hash;
+    const CBlockIndex* selected =
+        llmq_tests::CChainLocksHandlerTestAccess::SelectAlternativeSigningTarget(
+            10, current_hash, previous_share, &alternative);
+    BOOST_REQUIRE(selected != nullptr);
+    BOOST_CHECK_EQUAL(selected->GetBlockHash(), alternative_hash);
+
+    alternative.nHeight = 9;
+    BOOST_CHECK(
+        llmq_tests::CChainLocksHandlerTestAccess::SelectAlternativeSigningTarget(
+            10, current_hash, previous_share, &alternative) == nullptr);
+    alternative.nHeight = 10;
+    previous_share.blockHash = current_hash;
+    BOOST_CHECK(
+        llmq_tests::CChainLocksHandlerTestAccess::SelectAlternativeSigningTarget(
+            10, current_hash, previous_share, &current) == nullptr);
+
+    // A target selected from a previously observed share must still be
+    // rejected before signing if a lower, non-ancestor ChainLock wins.
+    std::array<CBlockIndex, 11> active_blocks;
+    std::array<uint256, 11> active_hashes;
+    for (size_t i = 0; i < active_blocks.size(); ++i) {
+        active_hashes[i] = GetRandHash();
+        active_blocks[i].phashBlock = &active_hashes[i];
+        active_blocks[i].nHeight = i;
+        active_blocks[i].pprev = i == 0 ? nullptr : &active_blocks[i - 1];
+    }
+    std::array<CBlockIndex, 6> fork_blocks;
+    std::array<uint256, 6> fork_hashes;
+    for (size_t i = 0; i < fork_blocks.size(); ++i) {
+        fork_hashes[i] = GetRandHash();
+        fork_blocks[i].phashBlock = &fork_hashes[i];
+        fork_blocks[i].nHeight = i + 5;
+        fork_blocks[i].pprev = i == 0 ? &active_blocks[4] : &fork_blocks[i - 1];
+    }
+
+    previous_share.blockHash = fork_blocks.back().GetBlockHash();
+    selected = llmq_tests::CChainLocksHandlerTestAccess::SelectAlternativeSigningTarget(
+        10, active_blocks[10].GetBlockHash(), previous_share, &fork_blocks.back());
+    BOOST_REQUIRE(selected == &fork_blocks.back());
+
+    CChain active_chain;
+    active_chain.SetTip(active_blocks.back());
+    llmq::CChainLockSig lower_winner;
+    lower_winner.nHeight = 5;
+    lower_winner.blockHash = active_blocks[5].GetBlockHash();
+    llmq::CChainLockSig signing_candidate;
+    signing_candidate.nHeight = 10;
+    signing_candidate.blockHash = selected->GetBlockHash();
+    BOOST_CHECK(!llmq_tests::CChainLocksHandlerTestAccess::IsCandidateStillAdmissible(
+        active_chain, lower_winner, signing_candidate, selected));
 }
 
 BOOST_AUTO_TEST_CASE(btccheckpoint_share_cache_hit_requires_signer_context)

--- a/test/functional/feature_llmqsigning.py
+++ b/test/functional/feature_llmqsigning.py
@@ -121,8 +121,10 @@ class LLMQSigningTest(DashTestFramework):
         assert node.quorum_verify(id, msgHash, recsig["sig"])
         assert node.quorum_verify(id, msgHash, recsig["sig"], "", height)
         assert not node.quorum_verify(id, msgHashConflict, recsig["sig"])
-        # SYSCOIN will find the right quorum based on latching to dkgInterval from height_bad passed in to ScanQuorums
-        assert node.quorum_verify(id, msgHash, recsig["sig"], "", height_bad)
+        # The quorum's final commitment was mined after its DKG base. A signature
+        # must not verify at the base height because that commitment is not yet in
+        # the candidate chain ancestry.
+        assert not node.quorum_verify(id, msgHash, recsig["sig"], "", height_bad)
         # Use specific quorum
         assert node.quorum_verify(id, msgHash, recsig["sig"], recsig["quorumHash"])
         assert not node.quorum_verify(id, msgHashConflict, recsig["sig"], recsig["quorumHash"])


### PR DESCRIPTION
## Summary
- Revalidate ChainLock candidates atomically at publication so the first valid winner cannot be replaced after verification races.
- Keep alternative-tip signing hashes coherent and recheck anchor/winner admissibility before consuming a quorum signing attempt.
- Add regressions for publication races, lower-winner ancestry, and alternative signing targets.

## Test plan
- [x] Independent concurrency and lock-order review
- [x] IDE diagnostics
- [x] `git diff --check`
- [x] Full Core unit/functional CI

Made with [Cursor](https://cursor.com)