### PR TITLE
Harden SPT amount tallies

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -184,19 +184,19 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, TxValidationState& state, 
                 strprintf("tried to spend coinbase at depth %d", nSpendHeight - coin.nHeight));
         }
         if (hasAssets && !coin.out.assetInfo.IsNull()) {
-            auto inRes = mapAssetIn.try_emplace(coin.out.assetInfo.nAsset, coin.out.assetInfo.nValue);
-            if (!inRes.second) {
-                inRes.first->second += coin.out.assetInfo.nValue;
-                if(!MoneyRange(inRes.first->second) || !MoneyRange(coin.out.assetInfo.nValue)) {
-                    return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-asset-inputvalues-outofrange");
-                }
+            const CAmount& nAssetValue = coin.out.assetInfo.nValue;
+            // Same form as GetValueOut / Bitcoin: range-check before mutating total.
+            auto it = mapAssetIn.try_emplace(coin.out.assetInfo.nAsset, 0).first;
+            if (!MoneyRange(nAssetValue) || !MoneyRange(it->second + nAssetValue)) {
+                return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-asset-inputvalues-outofrange");
             }
+            it->second += nAssetValue;
         }
         // Check for negative or overflow input values
-        nValueIn += coin.out.nValue;
-        if (!MoneyRange(coin.out.nValue) || !MoneyRange(nValueIn)) {
+        if (!MoneyRange(coin.out.nValue) || !MoneyRange(nValueIn + coin.out.nValue)) {
             return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-inputvalues-outofrange");
         }
+        nValueIn += coin.out.nValue;
         
     }
     const CAmount &value_out = tx.GetValueOut();

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -439,14 +439,13 @@ bool CTransaction::GetAssetValueOut(CAssetsMap &mapAssetOut, std::string &err) c
         }
         const uint64_t &nAsset = out.assetInfo.nAsset;
         const CAmount& nAmount = out.assetInfo.nValue;
-        auto itRes = mapAssetOut.try_emplace(nAsset, nAmount);
-        if(!itRes.second) {
-            itRes.first->second += nAmount;
-            if (!MoneyRange(nAmount) || !MoneyRange(itRes.first->second)) {
-                err = "bad-txns-asset-out-outofrange";
-                return false;
-            }
+        // Same form as GetValueOut / Bitcoin: range-check before mutating total.
+        auto it = mapAssetOut.try_emplace(nAsset, 0).first;
+        if (!MoneyRange(nAmount) || !MoneyRange(it->second + nAmount)) {
+            err = "bad-txns-asset-out-outofrange";
+            return false;
         }
+        it->second += nAmount;
     }
     return true;
 }

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -985,6 +985,81 @@ BOOST_AUTO_TEST_CASE(syscoin_bridge_uses_clreceipt_activation)
     BOOST_CHECK_EQUAL(regtest->GetConsensus().nCLReceiptStartBlock, 123);
 }
 
+BOOST_AUTO_TEST_CASE(asset_amount_aggregate_range_checks)
+{
+    constexpr uint64_t SYSX = 123456;
+    constexpr CAmount M = MAX_MONEY;
+    // R = 2^64 - 18*M; each component is individually MoneyRange-valid.
+    constexpr CAmount R = 446744073709551634LL;
+    BOOST_REQUIRE(MoneyRange(R));
+    BOOST_REQUIRE(MoneyRange(M));
+    // Pairwise sums of MoneyRange values fit in int64.
+    BOOST_REQUIRE(M <= std::numeric_limits<CAmount>::max() - M);
+
+    std::vector<CAmount> amounts;
+    amounts.push_back(1);
+    for (int i = 0; i < 18; ++i) {
+        amounts.push_back(M);
+    }
+    amounts.push_back(R);
+    BOOST_REQUIRE_EQUAL(amounts.size(), 20U);
+
+    // Per-output amounts are each in range and use unique indices.
+    std::unordered_set<uint32_t> setOutputs;
+    for (size_t i = 0; i < amounts.size(); ++i) {
+        BOOST_CHECK(MoneyRange(amounts[i]));
+        BOOST_CHECK(setOutputs.insert(static_cast<uint32_t>(i)).second);
+    }
+
+    // Without an aggregate range check, uint64 modular sum of this vector is 1
+    // (mathematical total is 2^64+1). Use unsigned addition for defined wrap.
+    uint64_t unchecked_sum = 0;
+    for (CAmount a : amounts) {
+        unchecked_sum += static_cast<uint64_t>(a);
+    }
+    BOOST_CHECK_EQUAL(unchecked_sum, uint64_t{1});
+
+    // Consensus GetAssetValueOut must reject the same vector.
+    CMutableTransaction mtx;
+    mtx.nVersion = SYSCOIN_TX_VERSION_ALLOCATION_SEND;
+    mtx.vout.resize(amounts.size());
+    for (size_t i = 0; i < amounts.size(); ++i) {
+        mtx.vout[i].nValue = 0;
+        mtx.vout[i].scriptPubKey = CScript() << OP_TRUE;
+        mtx.vout[i].assetInfo = CAssetCoinInfo(SYSX, amounts[i]);
+    }
+    CAssetsMap mapAssetOut;
+    std::string err;
+    BOOST_CHECK(!CTransaction(mtx).GetAssetValueOut(mapAssetOut, err));
+    BOOST_CHECK_EQUAL(err, "bad-txns-asset-out-outofrange");
+
+    // Two MAX_MONEY outputs for one asset are also rejected before the total
+    // is updated past MAX_MONEY.
+    BOOST_CHECK(!MoneyRange(M + M));
+    CMutableTransaction two_max;
+    two_max.nVersion = SYSCOIN_TX_VERSION_ALLOCATION_SEND;
+    two_max.vout.resize(2);
+    two_max.vout[0].assetInfo = CAssetCoinInfo(SYSX, M);
+    two_max.vout[1].assetInfo = CAssetCoinInfo(SYSX, M);
+    CAssetsMap two_max_map;
+    std::string two_max_err;
+    BOOST_CHECK(!CTransaction(two_max).GetAssetValueOut(two_max_map, two_max_err));
+    BOOST_CHECK_EQUAL(two_max_err, "bad-txns-asset-out-outofrange");
+    BOOST_CHECK(two_max_map.find(SYSX) == two_max_map.end() ||
+                two_max_map.at(SYSX) == M);
+
+    // In-range aggregate still succeeds.
+    CMutableTransaction ok_mtx;
+    ok_mtx.nVersion = SYSCOIN_TX_VERSION_ALLOCATION_SEND;
+    ok_mtx.vout.resize(2);
+    ok_mtx.vout[0].assetInfo = CAssetCoinInfo(SYSX, 1);
+    ok_mtx.vout[1].assetInfo = CAssetCoinInfo(SYSX, 2);
+    CAssetsMap ok_map;
+    std::string ok_err;
+    BOOST_CHECK(CTransaction(ok_mtx).GetAssetValueOut(ok_map, ok_err));
+    BOOST_CHECK_EQUAL(ok_map.at(SYSX), 3);
+}
+
 BOOST_AUTO_TEST_CASE(test_Get)
 {
     FillableSigningProvider keystore;


### PR DESCRIPTION
## Summary
- Align `GetAssetValueOut` and asset/native input tallies in `CheckTxInputs` with Bitcoin’s `MoneyRange(x) || MoneyRange(total + x)` before `+=`.
- Add `asset_amount_aggregate_range_checks` covering modular uint64 sum of an out-of-range aggregate vector and consensus rejection via `bad-txns-asset-out-outofrange`.

## Test plan
- [x] `./src/test/test_syscoin --run_test=transaction_tests/asset_amount_aggregate_range_checks`
- [ ] CI unit tests on PR