### PR TITLE
Harden ChainLock governance validation

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -138,6 +138,13 @@ enum BlockStatus : uint32_t {
     BLOCK_ASSUMED_VALID      =   256,
     // SYSCOIN
     BLOCK_CONFLICT_CHAINLOCK =   512, //!< conflicts with chainlock system
+    /**
+     * Exact governance validation was performed for this superblock while the
+     * required governance data was available. This is persisted so ChainLock
+     * signing never relies only on BLOCK_VALID_SCRIPTS, which can be reached
+     * through the bounded historical-sync fallback.
+     */
+    BLOCK_GOVERNANCE_VALIDATED = 1024,
 };
 
 /** The block chain is a tree shaped structure starting with the

--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -343,7 +343,8 @@ void CGovernanceManager::AddGovernanceObject(CGovernanceObject& govobj, PeerMana
     LogPrint(BCLog::GOBJECT, "CGovernanceManager::AddGovernanceObject -- Before trigger block, GetDataAsPlainString = %s, nObjectType = %d\n",
                 govObjRef.GetDataAsPlainString(), govObjRef.GetObjectType());
 
-    if (govObjRef.GetObjectType() == GOVERNANCE_OBJECT_TRIGGER && !AddNewTrigger(nHash)) {
+    if (govObjRef.GetObjectType() == GOVERNANCE_OBJECT_TRIGGER &&
+        !AddNewTrigger(nHash, chainman.ActiveHeight())) {
         LogPrint(BCLog::GOBJECT, "CGovernanceManager::AddGovernanceObject -- undo adding invalid trigger object: hash = %s\n", nHash.ToString());
         govObjRef.PrepareDeletion(GetTime<std::chrono::seconds>().count());
         return;
@@ -1061,13 +1062,16 @@ bool CGovernanceManager::ProcessVoteAndRelay(const CGovernanceVote& vote, const 
 
 bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, CGovernanceException& exception, CConnman& connman)
 {
+    ENTER_CRITICAL_SECTION(chainman.GetMutex());
     ENTER_CRITICAL_SECTION(cs);
     const uint256 nHashVote = vote.GetHash();
     const uint256 nHashGovobj = vote.GetParentHash();
+    const int active_height = chainman.ActiveHeight();
 
     if (cmapVoteToObject.HasKey(nHashVote)) {
         LogPrint(BCLog::GOBJECT, "CGovernanceObject::ProcessVote -- skipping known valid vote %s for object %s\n", nHashVote.ToString(), nHashGovobj.ToString());
         LEAVE_CRITICAL_SECTION(cs);
+        LEAVE_CRITICAL_SECTION(chainman.GetMutex());
         return false;
     }
 
@@ -1079,6 +1083,7 @@ bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, 
         LogPrint(BCLog::GOBJECT, "%s\n", ostr.str());
         exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_PERMANENT_ERROR, 20);
         LEAVE_CRITICAL_SECTION(cs);
+        LEAVE_CRITICAL_SECTION(chainman.GetMutex());
         return false;
     }
 
@@ -1090,6 +1095,7 @@ bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, 
         exception = CGovernanceException(ostr.str(), GOVERNANCE_EXCEPTION_WARNING);
         if (cmmapOrphanVotes.Insert(nHashGovobj, vote_time_pair_t(vote, GetTime<std::chrono::seconds>().count() + GOVERNANCE_ORPHAN_EXPIRATION_TIME))) {
             LEAVE_CRITICAL_SECTION(cs);
+            LEAVE_CRITICAL_SECTION(chainman.GetMutex());
             RequestGovernanceObject(pfrom, nHashGovobj, connman);
             LogPrint(BCLog::GOBJECT, "%s\n", ostr.str());
             return false;
@@ -1097,6 +1103,7 @@ bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, 
 
         LogPrint(BCLog::GOBJECT, "%s\n", ostr.str());
         LEAVE_CRITICAL_SECTION(cs);
+        LEAVE_CRITICAL_SECTION(chainman.GetMutex());
         return false;
     }
 
@@ -1105,11 +1112,32 @@ bool CGovernanceManager::ProcessVote(CNode* pfrom, const CGovernanceVote& vote, 
     if (govobj.IsSetCachedDelete() || govobj.IsSetExpired()) {
         LogPrint(BCLog::GOBJECT, "CGovernanceObject::ProcessVote -- ignoring vote for expired or deleted object, hash = %s\n", nHashGovobj.ToString());
         LEAVE_CRITICAL_SECTION(cs);
+        LEAVE_CRITICAL_SECTION(chainman.GetMutex());
         return false;
+    }
+
+    if (govobj.GetObjectType() == GOVERNANCE_OBJECT_TRIGGER) {
+        const auto trigger_it = mapTrigger.find(nHashGovobj);
+        if (trigger_it == mapTrigger.end() ||
+            trigger_it->second->GetBlockHeight() <= active_height) {
+            std::ostringstream ostr;
+            ostr << "CGovernanceManager::ProcessVote -- Trigger event height has passed"
+                 << ", governance object hash = "
+                 << nHashGovobj.ToString()
+                 << ", current block height = "
+                 << active_height;
+            LogPrint(BCLog::GOBJECT, "%s\n", ostr.str());
+            exception = CGovernanceException(
+                ostr.str(), GOVERNANCE_EXCEPTION_WARNING);
+            LEAVE_CRITICAL_SECTION(cs);
+            LEAVE_CRITICAL_SECTION(chainman.GetMutex());
+            return false;
+        }
     }
 
     bool fOk = govobj.ProcessVote(deterministicMNManager->GetListAtChainTip(), vote, exception) && cmapVoteToObject.Insert(nHashVote, &govobj);
     LEAVE_CRITICAL_SECTION(cs);
+    LEAVE_CRITICAL_SECTION(chainman.GetMutex());
     return fOk;
 }
 
@@ -1356,7 +1384,7 @@ void CGovernanceManager::RebuildIndexes()
     }
 }
 
-void CGovernanceManager::AddCachedTriggers()
+void CGovernanceManager::AddCachedTriggers(int active_height)
 {
     LOCK(cs);
 
@@ -1369,7 +1397,7 @@ void CGovernanceManager::AddCachedTriggers()
             continue;
         }
 
-        if (!AddNewTrigger(govobj.GetHash())) {
+        if (!AddNewTrigger(govobj.GetHash(), active_height)) {
             govobj.PrepareDeletion(nNow);
         }
     }
@@ -1377,11 +1405,12 @@ void CGovernanceManager::AddCachedTriggers()
 
 void CGovernanceManager::InitOnLoad()
 {
-    LOCK(cs);
+    LOCK2(chainman.GetMutex(), cs);
+    const int active_height = chainman.ActiveHeight();
     int64_t nStart = TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now());
     LogPrintf("Preparing masternode indexes and governance triggers...\n");
     RebuildIndexes();
-    AddCachedTriggers();
+    AddCachedTriggers(active_height);
     LogPrintf("Masternode indexes and governance triggers prepared  %dms\n", TicksSinceEpoch<std::chrono::milliseconds>(SystemClock::now()) - nStart);
     LogPrintf("     %s\n", ToString());
 }

--- a/src/governance/governance.h
+++ b/src/governance/governance.h
@@ -36,6 +36,10 @@ static constexpr bool DEFAULT_GOVERNANCE_ENABLE{true};
 class CDeterministicMNList;
 using CDeterministicMNListPtr = std::shared_ptr<CDeterministicMNList>;
 
+namespace governance_tests {
+class CGovernanceManagerTestAccess;
+}
+
 class CRateCheckBuffer
 {
 private:
@@ -224,6 +228,8 @@ public:
 class CGovernanceManager : public GovernanceStore
 {
     friend class CGovernanceObject;
+    friend class governance_tests::CGovernanceManagerTestAccess;
+
 private:
     using hash_s_t = std::set<uint256>;
     using db_type = CFlatDB<GovernanceStore>;
@@ -360,7 +366,7 @@ public:
      *   - After triggers are activated and executed, they can be removed
     */
     std::vector<std::shared_ptr<CSuperblock>> GetActiveTriggers() EXCLUSIVE_LOCKS_REQUIRED(cs);
-    bool AddNewTrigger(uint256 nHash) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    bool AddNewTrigger(uint256 nHash, int active_height) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void CleanAndRemoveTriggers();
     bool UndoBlock(const CBlockIndex* pindex);
 
@@ -392,7 +398,7 @@ private:
 
     void RebuildIndexes();
 
-    void AddCachedTriggers();
+    void AddCachedTriggers(int active_height);
 
     void RequestOrphanObjects(CConnman& connman);
 

--- a/src/governance/governanceclasses.cpp
+++ b/src/governance/governanceclasses.cpp
@@ -94,7 +94,7 @@ CAmount ParsePaymentAmount(const std::string& strAmount)
 *   Add Governance Object
 */
 
-bool CGovernanceManager::AddNewTrigger(uint256 nHash)
+bool CGovernanceManager::AddNewTrigger(uint256 nHash, int active_height)
 {
     AssertLockHeld(cs);
     // IF WE ALREADY HAVE THIS HASH, RETURN
@@ -112,6 +112,17 @@ bool CGovernanceManager::AddNewTrigger(uint256 nHash)
         return false;
     } catch (...) {
         LogPrintf("CGovernanceManager::%s -- Unknown Error creating superblock\n", __func__);
+        return false;
+    }
+
+    if (pSuperblock->GetBlockHeight() <= active_height) {
+        LogPrint(
+            BCLog::GOBJECT,
+            "CGovernanceManager::%s -- Rejecting trigger %s for past event height %d (tip %d)\n",
+            __func__,
+            nHash.ToString(),
+            pSuperblock->GetBlockHeight(),
+            active_height);
         return false;
     }
 
@@ -749,4 +760,3 @@ CGovernancePayment::CGovernancePayment(const CTxDestination& destIn, CAmount nAm
                   EncodeDestination(destIn), nAmountIn);
     }
 }
-

--- a/src/llmq/quorums_chainlocks.cpp
+++ b/src/llmq/quorums_chainlocks.cpp
@@ -20,10 +20,12 @@
 #include <util/thread.h>
 #include <services/nevmconsensus.h>
 #include <evo/deterministicmns.h>
+#include <governance/governanceclasses.h>
 #include <logging.h>
 #include <llmq/quorums_blockprocessor.h>
 #include <netmessagemaker.h>
 
+#include <algorithm>
 #include <iterator>
 namespace llmq
 {
@@ -43,6 +45,42 @@ static bool HasAggregatedChainLockStructure(const CChainLockSig& clsig)
     return std::count(clsig.signers.begin(), clsig.signers.end(), true) >= (signingActiveQuorumCount / 2 + 1);
 }
 
+static bool HasChainLockTargetDataAndValidity(const CBlockIndex* candidate_index)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    return candidate_index != nullptr &&
+           (candidate_index->nStatus & BLOCK_HAVE_DATA) &&
+           !(candidate_index->nStatus & BLOCK_FAILED_MASK) &&
+           candidate_index->IsValid(BLOCK_VALID_SCRIPTS);
+}
+
+static bool HasRequiredGovernanceProvenance(
+    const CChainLockSig& best_chainlock,
+    const CBlockIndex* candidate_index)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    if (candidate_index == nullptr) {
+        return false;
+    }
+
+    // A candidate commits its previous signing-window anchor as well as every
+    // block after it. A signer with an existing winner must prove every newly
+    // committed superblock passed exact governance validation.
+    const int32_t committed_height = best_chainlock.IsNull()
+        ? std::max<int32_t>(
+              -1, candidate_index->nHeight - SIGN_HEIGHT_OFFSET - 1)
+        : best_chainlock.nHeight;
+    for (const CBlockIndex* walk = candidate_index;
+         walk != nullptr && walk->nHeight > committed_height;
+         walk = walk->pprev) {
+        if (CSuperblock::IsValidBlockHeight(walk->nHeight) &&
+            !(walk->nStatus & BLOCK_GOVERNANCE_VALIDATED)) {
+            return false;
+        }
+    }
+    return true;
+}
+
 bool CChainLockSig::IsNull() const
 {
     return nHeight == -1 && blockHash == uint256();
@@ -55,7 +93,7 @@ std::string CChainLockSig::ToString() const
                 std::count(signers.begin(), signers.end(), true));
 }
 
-CChainLocksHandler::CChainLocksHandler(CConnman& _connman, PeerManager& _peerman, ChainstateManager& _chainman):     
+CChainLocksHandler::CChainLocksHandler(CConnman& _connman, PeerManager& _peerman, ChainstateManager& _chainman):
     connman(_connman),
     peerman(_peerman),
     chainman(_chainman)
@@ -400,7 +438,10 @@ bool CChainLocksHandler::IsCandidateStillAdmissible(
 {
     if (candidate_index == nullptr ||
         candidate_index->nHeight != candidate.nHeight ||
-        candidate_index->GetBlockHash() != candidate.blockHash) {
+        candidate_index->GetBlockHash() != candidate.blockHash ||
+        !HasChainLockTargetDataAndValidity(candidate_index) ||
+        (CSuperblock::IsValidBlockHeight(candidate_index->nHeight) &&
+         !(candidate_index->nStatus & BLOCK_GOVERNANCE_VALIDATED))) {
         return false;
     }
     if (!best_chainlock.IsNull()) {
@@ -423,6 +464,17 @@ bool CChainLocksHandler::IsCandidateStillAdmissible(
            candidate_index->GetAncestor(anchor_height) == active_chain[anchor_height];
 }
 
+bool CChainLocksHandler::IsSigningCandidateStillAdmissible(
+    const CChain& active_chain,
+    const CChainLockSig& best_chainlock,
+    const CChainLockSig& candidate,
+    const CBlockIndex* candidate_index)
+{
+    return IsCandidateStillAdmissible(
+               active_chain, best_chainlock, candidate, candidate_index) &&
+           HasRequiredGovernanceProvenance(best_chainlock, candidate_index);
+}
+
 const CBlockIndex* CChainLocksHandler::SelectAlternativeSigningTarget(
     int32_t height,
     const CBlockIndex* current_index,
@@ -437,6 +489,7 @@ const CBlockIndex* CChainLocksHandler::SelectAlternativeSigningTarget(
         previous_share_index == nullptr ||
         previous_share_index->nHeight != height ||
         previous_share_index->GetBlockHash() != previous_share.blockHash ||
+        !HasChainLockTargetDataAndValidity(previous_share_index) ||
         dkg_interval <= 0) {
         return nullptr;
     }
@@ -774,6 +827,14 @@ bool CChainLocksHandler::ProcessNewChainLock(const NodeId from, llmq::CChainLock
                 peerman.ForgetTxHash(from, hash);                  
             }
             return state.Invalid(BlockValidationResult::BLOCK_CHAINLOCK, "bad-clsig-height");
+        }
+        if (!HasChainLockTargetDataAndValidity(pindexScan)) {
+            LogPrintf("CChainLocksHandler::%s -- block data or full validation missing for CLSIG (%s)\n",
+                      __func__, clsig.ToString());
+            if (from != -1) {
+                peerman.ForgetTxHash(from, hash);
+            }
+            return state.Invalid(BlockValidationResult::BLOCK_CHAINLOCK, "bad-clsig-block-state");
         }
         if ((clsig.nHeight%SIGN_HEIGHT_OFFSET) != 0) {
             // Should not happen
@@ -1128,7 +1189,7 @@ void CChainLocksHandler::CheckActiveState()
         isEnabled = sporkActive;
         isEnforced = isEnabled;
         if (!oldIsEnforced && isEnforced) {
-            
+
             // ChainLocks got activated just recently, but it's possible that it was already running before, leaving
             // us with some stale values which we should not try to enforce anymore (there probably was a good reason
             // to disable spork19)
@@ -1182,7 +1243,7 @@ void CChainLocksHandler::TrySignChainTip()
         return;
     }
 
-    if (!masternodeSync.IsBlockchainSynced()) {
+    if (!masternodeSync.IsSynced()) {
         LogPrint(BCLog::CHAINLOCKS, "CChainLocksHandler: -- mnsync false\n");
         return;
     }
@@ -1374,7 +1435,7 @@ void CChainLocksHandler::TrySignChainTip()
                     chainman.ActiveChain(),
                     nHeight,
                     signing_context.active_height_index) ||
-                !IsCandidateStillAdmissible(
+                !IsSigningCandidateStillAdmissible(
                     chainman.ActiveChain(), bestChainLockWithKnownBlock, candidate, signingTarget)) {
                 return;
             }

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -146,13 +146,21 @@ private:
         const CChain& active_chain,
         const CChainLockSig& best_chainlock,
         const CChainLockSig& candidate,
-        const CBlockIndex* candidate_index);
+        const CBlockIndex* candidate_index)
+        EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    static bool IsSigningCandidateStillAdmissible(
+        const CChain& active_chain,
+        const CChainLockSig& best_chainlock,
+        const CChainLockSig& candidate,
+        const CBlockIndex* candidate_index)
+        EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     static const CBlockIndex* SelectAlternativeSigningTarget(
         int32_t height,
         const CBlockIndex* current_index,
         const CChainLockSig& previous_share,
         const CBlockIndex* previous_share_index,
-        int32_t dkg_interval);
+        int32_t dkg_interval)
+        EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     bool InternalHasChainLock(int nHeight, const uint256& blockHash) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     bool InternalHasConflictingChainLock(int nHeight, const uint256& blockHash) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 

--- a/src/masternode/masternodepayments.cpp
+++ b/src/masternode/masternodepayments.cpp
@@ -45,8 +45,11 @@ void CheckAndWriteBudget(const CAmount& nSuperblockPayment, const CAmount& nPaym
 *   - When non-superblocks are detected, the normal schedule should be maintained
 */
 
-bool IsBlockValueValid(const CBlock& block, const CBlockIndex* pindex, const CAmount &blockReward, std::string& strErrorRet, bool fJustCheck, bool check_superblock)
+bool IsBlockValueValid(const CBlock& block, const CBlockIndex* pindex, const CAmount &blockReward, std::string& strErrorRet, bool fJustCheck, bool check_superblock, bool* exact_superblock_validation)
 {
+    if (exact_superblock_validation != nullptr) {
+        *exact_superblock_validation = false;
+    }
     bool isBlockRewardValueMet = (block.vtx[0]->GetValueOut() <= blockReward);
     const int nBlockHeight = pindex->nHeight;
     strErrorRet = "";
@@ -99,6 +102,9 @@ bool IsBlockValueValid(const CBlock& block, const CBlockIndex* pindex, const CAm
     // we are synced and possibly on a superblock now
 
     if (!AreSuperblocksEnabled()) {
+        if (exact_superblock_validation != nullptr) {
+            *exact_superblock_validation = true;
+        }
         // should NOT allow superblocks at all, when superblocks are disabled
         // revert to block reward limits in this case
         LogPrint(BCLog::GOBJECT, "%s -- Superblocks are disabled, no superblocks allowed\n", __func__);
@@ -112,6 +118,9 @@ bool IsBlockValueValid(const CBlock& block, const CBlockIndex* pindex, const CAm
         if(!fJustCheck)
             CheckAndWriteBudget(nSuperblockPayment, nPaymentLimit, nGovernanceBudgetUp, pindex);
         return true;
+    }
+    if (exact_superblock_validation != nullptr) {
+        *exact_superblock_validation = true;
     }
     if (!CSuperblockManager::IsSuperblockTriggered(nBlockHeight)) {
         // we are on a valid superblock height but a superblock was not triggered

--- a/src/masternode/masternodepayments.h
+++ b/src/masternode/masternodepayments.h
@@ -11,7 +11,7 @@ class CMasternodePayments;
 class CChain;
 class CBlockIndex;
 /// TODO: all 4 functions do not belong here really, they should be refactored/moved somewhere (main.cpp ?)
-bool IsBlockValueValid(const CBlock& block, const CBlockIndex* pindex, const CAmount &blockReward, std::string& strErrorRet, bool fJustCheck, bool check_superblock);
+bool IsBlockValueValid(const CBlock& block, const CBlockIndex* pindex, const CAmount &blockReward, std::string& strErrorRet, bool fJustCheck, bool check_superblock, bool* exact_superblock_validation = nullptr);
 bool IsBlockPayeeValid(CChain& activeChain, const CTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount &fees, CAmount& nMNSeniorityRet, CAmount &nMNFloorDiffRet);
 void FillBlockPayments(CChain& activeChain, CMutableTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount &fees, std::vector<CTxOut>& voutMasternodePaymentsRet, std::vector<CTxOut>& voutSuperblockPaymentsRet);
 

--- a/src/test/llmq_sigshare_cache_tests.cpp
+++ b/src/test/llmq_sigshare_cache_tests.cpp
@@ -8,6 +8,7 @@
 #include <llmq/quorums_chainlocks.h>
 #include <llmq/quorums_commitment.h>
 #include <chainparams.h>
+#include <governance/governanceclasses.h>
 #include <random.h>
 #include <test/util/setup_common.h>
 #include <util/time.h>
@@ -15,6 +16,8 @@
 
 #include <array>
 #include <boost/test/unit_test.hpp>
+#include <memory>
+#include <vector>
 
 namespace llmq_tests
 {
@@ -131,8 +134,20 @@ public:
         const llmq::CChainLockSig& best_chainlock,
         const llmq::CChainLockSig& candidate,
         const CBlockIndex* candidate_index)
+        EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         return llmq::CChainLocksHandler::IsCandidateStillAdmissible(
+            active_chain, best_chainlock, candidate, candidate_index);
+    }
+
+    static bool IsSigningCandidateStillAdmissible(
+        const CChain& active_chain,
+        const llmq::CChainLockSig& best_chainlock,
+        const llmq::CChainLockSig& candidate,
+        const CBlockIndex* candidate_index)
+        EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+    {
+        return llmq::CChainLocksHandler::IsSigningCandidateStillAdmissible(
             active_chain, best_chainlock, candidate, candidate_index);
     }
 
@@ -142,6 +157,7 @@ public:
         const llmq::CChainLockSig& previous_share,
         const CBlockIndex* previous_share_index,
         int32_t dkg_interval)
+        EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         return llmq::CChainLocksHandler::SelectAlternativeSigningTarget(
             height, current_index, previous_share, previous_share_index, dkg_interval);
@@ -448,6 +464,8 @@ BOOST_AUTO_TEST_CASE(chainlock_publication_allows_same_chain_tip_extension)
 
 BOOST_AUTO_TEST_CASE(chainlock_publication_rechecks_anchor_and_winner)
 {
+    LOCK(cs_main);
+
     std::array<CBlockIndex, 21> active_blocks;
     std::array<uint256, 21> active_hashes;
     for (size_t i = 0; i < active_blocks.size(); ++i) {
@@ -455,6 +473,7 @@ BOOST_AUTO_TEST_CASE(chainlock_publication_rechecks_anchor_and_winner)
         active_blocks[i].phashBlock = &active_hashes[i];
         active_blocks[i].nHeight = i;
         active_blocks[i].pprev = i == 0 ? nullptr : &active_blocks[i - 1];
+        active_blocks[i].nStatus = BLOCK_VALID_SCRIPTS | BLOCK_HAVE_DATA;
     }
 
     CChain active_chain;
@@ -477,6 +496,7 @@ BOOST_AUTO_TEST_CASE(chainlock_publication_rechecks_anchor_and_winner)
         fork_blocks[i].phashBlock = &fork_hashes[i];
         fork_blocks[i].nHeight = i + 5;
         fork_blocks[i].pprev = i == 0 ? &active_blocks[4] : &fork_blocks[i - 1];
+        fork_blocks[i].nStatus = BLOCK_VALID_SCRIPTS | BLOCK_HAVE_DATA;
     }
     candidate.blockHash = fork_blocks.back().GetBlockHash();
     BOOST_CHECK(!llmq_tests::CChainLocksHandlerTestAccess::IsCandidateStillAdmissible(
@@ -507,6 +527,8 @@ BOOST_AUTO_TEST_CASE(chainlock_publication_rechecks_anchor_and_winner)
 
 BOOST_AUTO_TEST_CASE(chainlock_alternative_tip_selects_exact_signing_hash)
 {
+    LOCK(cs_main);
+
     std::array<CBlockIndex, 11> active_blocks;
     std::array<uint256, 11> active_hashes;
     for (size_t i = 0; i < active_blocks.size(); ++i) {
@@ -514,6 +536,7 @@ BOOST_AUTO_TEST_CASE(chainlock_alternative_tip_selects_exact_signing_hash)
         active_blocks[i].phashBlock = &active_hashes[i];
         active_blocks[i].nHeight = i;
         active_blocks[i].pprev = i == 0 ? nullptr : &active_blocks[i - 1];
+        active_blocks[i].nStatus = BLOCK_VALID_SCRIPTS | BLOCK_HAVE_DATA;
     }
     std::array<CBlockIndex, 6> fork_blocks;
     std::array<uint256, 6> fork_hashes;
@@ -522,6 +545,7 @@ BOOST_AUTO_TEST_CASE(chainlock_alternative_tip_selects_exact_signing_hash)
         fork_blocks[i].phashBlock = &fork_hashes[i];
         fork_blocks[i].nHeight = i + 5;
         fork_blocks[i].pprev = i == 0 ? &active_blocks[4] : &fork_blocks[i - 1];
+        fork_blocks[i].nStatus = BLOCK_VALID_SCRIPTS | BLOCK_HAVE_DATA;
     }
 
     llmq::CChainLockSig previous_share;
@@ -564,6 +588,136 @@ BOOST_AUTO_TEST_CASE(chainlock_alternative_tip_selects_exact_signing_hash)
     lower_winner.blockHash = fork_blocks.front().GetBlockHash();
     BOOST_CHECK(!llmq_tests::CChainLocksHandlerTestAccess::IsCandidateStillAdmissible(
         active_chain, lower_winner, signing_candidate, selected));
+}
+
+BOOST_AUTO_TEST_CASE(chainlock_alternative_tip_rejects_failed_block)
+{
+    LOCK(cs_main);
+
+    std::array<CBlockIndex, 16> active_blocks;
+    std::array<uint256, 16> active_hashes;
+    for (size_t i = 0; i < active_blocks.size(); ++i) {
+        active_hashes[i] = GetRandHash();
+        active_blocks[i].phashBlock = &active_hashes[i];
+        active_blocks[i].nHeight = i;
+        active_blocks[i].pprev = i == 0 ? nullptr : &active_blocks[i - 1];
+        active_blocks[i].nStatus = BLOCK_VALID_SCRIPTS | BLOCK_HAVE_DATA;
+    }
+
+    uint256 failed_hash = GetRandHash();
+    CBlockIndex failed_alternative;
+    failed_alternative.phashBlock = &failed_hash;
+    failed_alternative.nHeight = 10;
+    failed_alternative.pprev = &active_blocks[9];
+    failed_alternative.nStatus =
+        BLOCK_VALID_SCRIPTS | BLOCK_HAVE_DATA | BLOCK_FAILED_VALID;
+
+    llmq::CChainLockSig previous_share;
+    previous_share.nHeight = 10;
+    previous_share.blockHash = failed_hash;
+
+    failed_alternative.nStatus = BLOCK_VALID_SCRIPTS;
+    BOOST_CHECK(
+        llmq_tests::CChainLocksHandlerTestAccess::SelectAlternativeSigningTarget(
+            10, &active_blocks[10], previous_share, &failed_alternative, 12) == nullptr);
+
+    failed_alternative.nStatus = BLOCK_VALID_CHAIN | BLOCK_HAVE_DATA;
+    BOOST_CHECK(
+        llmq_tests::CChainLocksHandlerTestAccess::SelectAlternativeSigningTarget(
+            10, &active_blocks[10], previous_share, &failed_alternative, 12) == nullptr);
+
+    failed_alternative.nStatus =
+        BLOCK_VALID_SCRIPTS | BLOCK_HAVE_DATA | BLOCK_FAILED_VALID;
+    BOOST_CHECK(
+        llmq_tests::CChainLocksHandlerTestAccess::SelectAlternativeSigningTarget(
+            10, &active_blocks[10], previous_share, &failed_alternative, 12) == nullptr);
+
+    CChain active_chain;
+    active_chain.SetTip(active_blocks.back());
+    llmq::CChainLockSig signing_candidate;
+    signing_candidate.nHeight = 10;
+    signing_candidate.blockHash = failed_hash;
+    llmq::CChainLockSig no_winner;
+    BOOST_CHECK(!llmq_tests::CChainLocksHandlerTestAccess::IsCandidateStillAdmissible(
+        active_chain, no_winner, signing_candidate, &failed_alternative));
+}
+
+BOOST_AUTO_TEST_CASE(chainlock_signing_requires_governance_provenance)
+{
+    LOCK(cs_main);
+
+    const int32_t superblock_height =
+        Params().GetConsensus().SuperBlockCycle(/*nHeight=*/0);
+    BOOST_REQUIRE(CSuperblock::IsValidBlockHeight(superblock_height));
+    BOOST_REQUIRE_EQUAL(superblock_height % llmq::SIGN_HEIGHT_OFFSET, 0);
+    const int32_t previous_height =
+        superblock_height - llmq::SIGN_HEIGHT_OFFSET;
+    const int32_t candidate_height =
+        superblock_height + llmq::SIGN_HEIGHT_OFFSET;
+
+    std::vector<uint256> active_hashes(candidate_height + 1);
+    std::vector<std::unique_ptr<CBlockIndex>> active_blocks(candidate_height + 1);
+    for (int32_t i = 0; i <= candidate_height; ++i) {
+        active_blocks[i] = std::make_unique<CBlockIndex>();
+        active_hashes[i] = GetRandHash();
+        active_blocks[i]->phashBlock = &active_hashes[i];
+        active_blocks[i]->nHeight = i;
+        active_blocks[i]->pprev =
+            i == 0 ? nullptr : active_blocks[i - 1].get();
+        active_blocks[i]->nStatus = BLOCK_VALID_SCRIPTS | BLOCK_HAVE_DATA;
+    }
+
+    CChain active_chain;
+    active_chain.SetTip(*active_blocks.back());
+
+    llmq::CChainLockSig previous_winner;
+    previous_winner.nHeight = previous_height;
+    previous_winner.blockHash =
+        active_blocks[previous_height]->GetBlockHash();
+
+    // Build a later candidate that would newly commit the superblock.
+    llmq::CChainLockSig candidate;
+    candidate.nHeight = candidate_height;
+    candidate.blockHash =
+        active_blocks[candidate_height]->GetBlockHash();
+    llmq::CChainLockSig no_winner;
+    // A verified later ChainLock can be received by a syncing node that
+    // validated this now-historical superblock through the bounded fallback.
+    BOOST_CHECK(llmq_tests::CChainLocksHandlerTestAccess::IsCandidateStillAdmissible(
+        active_chain, no_winner, candidate,
+        active_blocks[candidate_height].get()));
+    BOOST_CHECK(llmq_tests::CChainLocksHandlerTestAccess::IsCandidateStillAdmissible(
+        active_chain, previous_winner, candidate,
+        active_blocks[candidate_height].get()));
+
+    // Signing that ChainLock is stricter: all superblocks newly committed by
+    // it must have local proof of exact governance validation.
+    BOOST_CHECK(!llmq_tests::CChainLocksHandlerTestAccess::IsSigningCandidateStillAdmissible(
+        active_chain, no_winner, candidate,
+        active_blocks[candidate_height].get()));
+    BOOST_CHECK(!llmq_tests::CChainLocksHandlerTestAccess::IsSigningCandidateStillAdmissible(
+        active_chain, previous_winner, candidate,
+        active_blocks[candidate_height].get()));
+
+    // The ChainLocked block itself is never eligible for historical fallback.
+    llmq::CChainLockSig superblock_candidate;
+    superblock_candidate.nHeight = superblock_height;
+    superblock_candidate.blockHash =
+        active_blocks[superblock_height]->GetBlockHash();
+    BOOST_CHECK(!llmq_tests::CChainLocksHandlerTestAccess::IsCandidateStillAdmissible(
+        active_chain, previous_winner, superblock_candidate,
+        active_blocks[superblock_height].get()));
+
+    active_blocks[superblock_height]->nStatus |= BLOCK_GOVERNANCE_VALIDATED;
+    BOOST_CHECK(llmq_tests::CChainLocksHandlerTestAccess::IsCandidateStillAdmissible(
+        active_chain, previous_winner, superblock_candidate,
+        active_blocks[superblock_height].get()));
+    BOOST_CHECK(llmq_tests::CChainLocksHandlerTestAccess::IsSigningCandidateStillAdmissible(
+        active_chain, no_winner, candidate,
+        active_blocks[candidate_height].get()));
+    BOOST_CHECK(llmq_tests::CChainLocksHandlerTestAccess::IsSigningCandidateStillAdmissible(
+        active_chain, previous_winner, candidate,
+        active_blocks[candidate_height].get()));
 }
 
 BOOST_AUTO_TEST_CASE(chainlock_alternative_rejects_unresolved_commitment_window)

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -1858,7 +1858,7 @@ static std::vector<unsigned char> SerializeNEVMHeaderPayload(const CNEVMHeader& 
     std::vector<unsigned char> payload(std::begin(NEVM_MAGIC_BYTES), std::end(NEVM_MAGIC_BYTES));
     CDataStream ds(SER_NETWORK, PROTOCOL_VERSION);
     ds << header;
-    payload.insert(payload.end(), ds.begin(), ds.end());
+    payload.insert(payload.end(), UCharCast(ds.data()), UCharCast(ds.data() + ds.size()));
     if (with_trailing) {
         // Trailing BTCC-style bytes after the header must be ignored by GetNEVMData.
         payload.insert(payload.end(), {0x62, 0x74, 0x63, 0x63, 0x01, 0x02, 0x03});

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -3,20 +3,88 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //
 #include <chainparams.h>
+#include <addresstype.h>
 #include <consensus/validation.h>
+#include <governance/governanceclasses.h>
+#include <governance/governanceexceptions.h>
+#include <governance/governancevote.h>
+#include <masternode/masternodepayments.h>
+#include <masternode/masternodesync.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
 #include <random.h>
 #include <rpc/blockchain.h>
+#include <script/script.h>
 #include <sync.h>
 #include <test/util/chainstate.h>
 #include <test/util/coins.h>
 #include <test/util/random.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
+#include <util/time.h>
 #include <validation.h>
 
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+
+namespace governance_tests {
+
+class CGovernanceManagerTestAccess
+{
+public:
+    static bool AddTriggerAtHeight(
+        CGovernanceManager& manager,
+        int observed_height,
+        CGovernanceObject&& trigger,
+        uint256& trigger_hash)
+    {
+        const int active_height = WITH_LOCK(
+            manager.chainman.GetMutex(),
+            return manager.chainman.ActiveHeight());
+        trigger_hash = trigger.GetHash();
+        LOCK(manager.cs);
+        manager.nCachedBlockHeight = observed_height;
+        const auto [it, inserted] =
+            manager.mapObjects.emplace(trigger_hash, std::move(trigger));
+        return inserted &&
+            manager.AddNewTrigger(trigger_hash, active_height);
+    }
+
+    static bool ProcessVoteAtHeight(
+        CGovernanceManager& manager,
+        int observed_height,
+        const CGovernanceVote& vote,
+        CGovernanceException& exception,
+        CConnman& connman)
+    {
+        {
+            LOCK(manager.cs);
+            manager.nCachedBlockHeight = observed_height;
+        }
+        return manager.ProcessVote(
+            /*pfrom=*/nullptr, vote, exception, connman);
+    }
+
+    static bool InsertPreviouslyAdmittedTrigger(
+        CGovernanceManager& manager,
+        CGovernanceObject&& trigger,
+        uint256& trigger_hash)
+    {
+        trigger_hash = trigger.GetHash();
+        LOCK(manager.cs);
+        const auto [it, inserted] =
+            manager.mapObjects.emplace(trigger_hash, std::move(trigger));
+        if (!inserted) return false;
+
+        auto superblock = std::make_shared<CSuperblock>(trigger_hash);
+        superblock->SetStatus(SeenObjectStatus::Valid);
+        return manager.mapTrigger.emplace(
+            trigger_hash, std::move(superblock)).second;
+    }
+};
+
+} // namespace governance_tests
 
 BOOST_FIXTURE_TEST_SUITE(validation_chainstate_tests, ChainTestingSetup)
 
@@ -138,6 +206,172 @@ BOOST_FIXTURE_TEST_CASE(chainstate_update_tip, TestChain100Setup)
     // validation chain.
     BOOST_CHECK(block_added);
     BOOST_CHECK_EQUAL(curr_tip, ::g_best_block);
+}
+
+BOOST_FIXTURE_TEST_CASE(superblock_chainlock_requires_exact_governance_provenance,
+                        TestChainDIP3V19Setup)
+{
+    struct SyncModeGuard {
+        const int old_mode;
+        ~SyncModeGuard() { masternodeSync.SetSyncMode(old_mode); }
+    } sync_mode_guard{masternodeSync.GetAssetID()};
+
+    const CBlockIndex* pindex;
+    {
+        LOCK(::cs_main);
+        pindex = m_node.chainman->ActiveChain().Tip();
+    }
+    BOOST_REQUIRE(pindex != nullptr);
+    BOOST_REQUIRE(pindex->nHeight >= Params().GetConsensus().DIP0003Height);
+    BOOST_REQUIRE(CSuperblock::IsValidBlockHeight(pindex->nHeight));
+
+    const CAmount regular_reward =
+        GetBlockSubsidy(pindex->nHeight, Params().GetConsensus());
+    const CAmount unbacked_issuance = COIN;
+
+    BOOST_REQUIRE(!m_coinbase_txns.empty());
+    CMutableTransaction coinbase{*m_coinbase_txns.back()};
+    coinbase.vout.emplace_back(unbacked_issuance, CScript() << OP_TRUE);
+
+    CBlock block;
+    block.vtx.emplace_back(MakeTransactionRef(coinbase));
+
+    CAmount mn_seniority = 0;
+    CAmount mn_floor_diff = 0;
+    {
+        LOCK(::cs_main);
+        BOOST_REQUIRE(IsBlockPayeeValid(m_node.chainman->ActiveChain(),
+                                        *block.vtx[0], pindex->nHeight,
+                                        regular_reward, /*fees=*/0, mn_seniority,
+                                        mn_floor_diff));
+    }
+    const CAmount value_limit =
+        regular_reward + mn_seniority + mn_floor_diff;
+    BOOST_REQUIRE_EQUAL(m_coinbase_txns.back()->GetValueOut(), value_limit);
+    BOOST_REQUIRE_EQUAL(block.vtx[0]->GetValueOut(),
+                        value_limit + unbacked_issuance);
+
+    std::string error;
+    bool exact_superblock_validation{true};
+
+    // The historical sync fallback remains bounded by the adaptive cap, but
+    // must not produce exact-governance provenance for ChainLock signing.
+    masternodeSync.SetSyncMode(MASTERNODE_SYNC_GOVERNANCE);
+    BOOST_REQUIRE(masternodeSync.IsBlockchainSynced());
+    BOOST_REQUIRE(!masternodeSync.IsSynced());
+    BOOST_CHECK(IsBlockValueValid(block, pindex, value_limit, error,
+                                  /*fJustCheck=*/true,
+                                  /*check_superblock=*/true,
+                                  &exact_superblock_validation));
+    BOOST_CHECK(!exact_superblock_validation);
+
+    masternodeSync.SetSyncMode(MASTERNODE_SYNC_FINISHED);
+    error.clear();
+    exact_superblock_validation = false;
+    BOOST_CHECK(!IsBlockValueValid(block, pindex, value_limit, error,
+                                   /*fJustCheck=*/true,
+                                   /*check_superblock=*/true,
+                                   &exact_superblock_validation));
+    BOOST_CHECK(exact_superblock_validation);
+
+    // Equal height is not historical: the ChainLocked block itself must take
+    // the exact path. Only a strict ancestor may set this predicate false.
+    const int best_chainlock_height = pindex->nHeight;
+    const bool check_superblock =
+        best_chainlock_height <= pindex->nHeight;
+    BOOST_REQUIRE(check_superblock);
+
+    error.clear();
+    exact_superblock_validation = false;
+    BOOST_CHECK(!IsBlockValueValid(block, pindex, value_limit, error,
+                                   /*fJustCheck=*/true, check_superblock,
+                                   &exact_superblock_validation));
+    BOOST_CHECK(exact_superblock_validation);
+
+    error.clear();
+    exact_superblock_validation = true;
+    BOOST_CHECK(IsBlockValueValid(block, pindex, value_limit, error,
+                                  /*fJustCheck=*/true,
+                                  /*check_superblock=*/false,
+                                  &exact_superblock_validation));
+    BOOST_CHECK(!exact_superblock_validation);
+}
+
+BOOST_FIXTURE_TEST_CASE(
+    past_superblock_trigger_and_funding_vote_are_rejected,
+    TestChainDIP3V19Setup)
+{
+    const CBlockIndex* tip =
+        WITH_LOCK(::cs_main, return m_node.chainman->ActiveChain().Tip());
+    BOOST_REQUIRE(tip != nullptr);
+    const int event_height = tip->nHeight;
+    BOOST_REQUIRE(CSuperblock::IsValidBlockHeight(event_height));
+
+    const CTxDestination destination =
+        PKHash(coinbaseKey.GetPubKey());
+    const auto make_trigger = [&](const int trigger_height,
+                                  const uint256& proposal_hash) {
+        std::vector<CGovernancePayment> payments;
+        payments.emplace_back(destination, COIN, proposal_hash);
+        CSuperblock schedule{trigger_height, std::move(payments)};
+        return CGovernanceObject{
+            uint256{},
+            /*revision=*/1,
+            GetTime<std::chrono::seconds>().count(),
+            uint256{},
+            schedule.GetHexStrData()};
+    };
+
+    uint256 late_trigger_hash;
+    BOOST_CHECK(
+        !governance_tests::CGovernanceManagerTestAccess::
+            AddTriggerAtHeight(
+                *governance,
+                event_height - 1,
+                make_trigger(event_height, InsecureRand256()),
+                late_trigger_hash));
+
+    const int future_event_height =
+        event_height +
+        Params().GetConsensus().SuperBlockCycle(event_height);
+    BOOST_REQUIRE(CSuperblock::IsValidBlockHeight(future_event_height));
+    uint256 future_trigger_hash;
+    BOOST_REQUIRE(
+        governance_tests::CGovernanceManagerTestAccess::
+            AddTriggerAtHeight(
+                *governance,
+                event_height - 1,
+                make_trigger(future_event_height, InsecureRand256()),
+                future_trigger_hash));
+
+    uint256 on_time_trigger_hash;
+    BOOST_REQUIRE(
+        governance_tests::CGovernanceManagerTestAccess::
+            InsertPreviouslyAdmittedTrigger(
+                *governance,
+                make_trigger(event_height, InsecureRand256()),
+                on_time_trigger_hash));
+
+    CGovernanceVote late_funding_vote{
+        COutPoint{InsecureRand256(), 0},
+        on_time_trigger_hash,
+        VOTE_SIGNAL_FUNDING,
+        VOTE_OUTCOME_YES};
+    CGovernanceException exception;
+    BOOST_CHECK(
+        !governance_tests::CGovernanceManagerTestAccess::
+            ProcessVoteAtHeight(
+                *governance,
+                event_height - 1,
+                late_funding_vote,
+                exception,
+                *m_node.connman));
+    BOOST_CHECK_EQUAL(
+        exception.GetType(), GOVERNANCE_EXCEPTION_WARNING);
+    BOOST_CHECK_EQUAL(exception.GetNodePenalty(), 0);
+    BOOST_CHECK(
+        std::string{exception.what()}.find("event height has passed") !=
+        std::string::npos);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -85,6 +85,7 @@
 #include <llmq/quorums.h>
 #include <llmq/quorums_blockprocessor.h>
 #include <governance/governance.h>
+#include <governance/governanceclasses.h>
 #include <services/assetconsensus.h>
 #include <fstream>
 #include <cachemultimap.h>
@@ -3113,11 +3114,15 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         return false;
     }
     // SYSCOIN : MODIFIED TO CHECK MASTERNODE PAYMENTS AND SUPERBLOCKS
+    bool exact_superblock_validation{false};
     if(fNexusContext) {
         const CAmount blockReward = GetBlockSubsidy(pindex->nHeight, params.GetConsensus());
         CAmount nMNSeniorityRet = 0;
         CAmount nMNFloorDiffRet = 0;
-        const bool check_superblock = llmq::chainLocksHandler->GetBestChainLock().nHeight < pindex->nHeight;
+        // A ChainLock may provide the historical fallback only for strict
+        // ancestors. The ChainLocked block itself must pass exact governance
+        // validation.
+        const bool check_superblock = llmq::chainLocksHandler->GetBestChainLock().nHeight <= pindex->nHeight;
         // detect MN was paid properly, accounting for seniority which is added to subsidy
         if (!IsBlockPayeeValid(m_chain, *block.vtx[0], pindex->nHeight, blockReward, nFees, nMNSeniorityRet, nMNFloorDiffRet)) {
             LogPrintf("ERROR: ConnectBlock(): couldn't find masternode or superblock payments\n");
@@ -3126,7 +3131,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
         std::string strError;
         // add seniority to reward when checking for limit
-        if (!IsBlockValueValid(block, pindex, blockReward+nFees+nMNSeniorityRet+nMNFloorDiffRet, strError, fJustCheck, check_superblock) && (fRegTest || pindex->nHeight >= params.GetConsensus().DIP0003EnforcementHeight)) {
+        if (!IsBlockValueValid(block, pindex, blockReward+nFees+nMNSeniorityRet+nMNFloorDiffRet, strError, fJustCheck, check_superblock, &exact_superblock_validation) && (fRegTest || pindex->nHeight >= params.GetConsensus().DIP0003EnforcementHeight)) {
             LogPrintf("ERROR: ConnectBlock(): %s\n", strError);
             // hack for feature_signet.py to pass which uses bitcoin blocks signed by the signet witness
             if(!fSigNet || pindex->nHeight > 100) {
@@ -3161,6 +3166,11 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
 
     if (!m_blockman.WriteUndoDataForBlock(blockundo, state, *pindex)) {
         return false;
+    }
+
+    if (exact_superblock_validation) {
+        pindex->nStatus |= BLOCK_GOVERNANCE_VALIDATED;
+        m_blockman.m_dirty_blockindex.insert(pindex);
     }
 
     const auto time_5{SteadyClock::now()};
@@ -4195,7 +4205,9 @@ bool Chainstate::EnforceBestChainLock(const CBlockIndex* bestChainLockBlockIndex
     BlockValidationState state;
     // Go backwards through the chain referenced by clsig until we find a block that is part of the main chain and invalidate the fork block (next block in main chain).
     LogPrint(BCLog::CHAINLOCKS, "Chainstate::%s -- enforcing block %s via CLSIG\n", __func__, bestChainLockBlockIndex->GetBlockHash().ToString());
-    EnforceBlock(state, bestChainLockBlockIndex);
+    if (!EnforceBlock(state, bestChainLockBlockIndex)) {
+        return false;
+    }
     // no cs_main allowed
     const bool activateNeeded = WITH_LOCK(::cs_main, return m_chain.Tip()->GetAncestor(bestChainLockBlockIndex->nHeight)) != bestChainLockBlockIndex;
     if (!activateNeeded) {
@@ -4218,7 +4230,7 @@ bool Chainstate::EnforceBestChainLock(const CBlockIndex* bestChainLockBlockIndex
     }
     return true;
 }
-void Chainstate::EnforceBlock(BlockValidationState& state, const CBlockIndex *pindex)
+bool Chainstate::EnforceBlock(BlockValidationState& state, const CBlockIndex *pindex)
 {
     AssertLockNotHeld(m_chainstate_mutex);
     AssertLockNotHeld(cs_main);
@@ -4227,6 +4239,15 @@ void Chainstate::EnforceBlock(BlockValidationState& state, const CBlockIndex *pi
     // blocks.
     LOCK(m_chainstate_mutex);
     LOCK(cs_main);
+    if (!(pindex->nStatus & BLOCK_HAVE_DATA) ||
+        (pindex->nStatus & BLOCK_FAILED_MASK) ||
+        !pindex->IsValid(BLOCK_VALID_SCRIPTS) ||
+        (CSuperblock::IsValidBlockHeight(pindex->nHeight) &&
+         !(pindex->nStatus & BLOCK_GOVERNANCE_VALIDATED))) {
+        LogPrintf("Chainstate::%s -- refusing invalid or unverified ChainLock target %s\n",
+                  __func__, pindex->GetBlockHash().ToString());
+        return false;
+    }
     const CBlockIndex* pindex_walk = pindex;
 
     while (pindex_walk && !m_chain.Contains(pindex_walk)) {
@@ -4246,11 +4267,7 @@ void Chainstate::EnforceBlock(BlockValidationState& state, const CBlockIndex *pi
         }
         pindex_walk = pindex_walk->pprev;
     }
-    // In case blocks from the enforced chain are invalid at the moment, reconsider them.
-    if (!pindex->IsValid()) {
-        LogPrintf("Chainstate::%s -- ResetBlockFailureFlags: %s\n", __func__, pindex->GetBlockHash().ToString());
-        ResetBlockFailureFlags(m_blockman.LookupBlockIndex(pindex->GetBlockHash()));
-    }
+    return true;
 }
 // SYSCOIN
 bool Chainstate::InvalidateBlock(BlockValidationState& state, CBlockIndex *pindex, bool bReverify, bool bUpdateSpecialTxState)

--- a/src/validation.h
+++ b/src/validation.h
@@ -742,7 +742,7 @@ public:
     bool StartBTCHeaderNode(bool force_reindex = false);
     bool StopBTCHeaderNode(bool bOnStart = false);
     bool IsManagedBTCHeaderNodeRunning(std::string& reason);
-    void EnforceBlock(BlockValidationState& state, const CBlockIndex* pindex)
+    bool EnforceBlock(BlockValidationState& state, const CBlockIndex* pindex)
         EXCLUSIVE_LOCKS_REQUIRED(!m_chainstate_mutex)
         LOCKS_EXCLUDED(cs_main);
     bool MarkConflictingBlock(BlockValidationState& state, CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/test/functional/feature_governance_cl.py
+++ b/test/functional/feature_governance_cl.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2024 The Dash Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Tests governance checks can be skipped for blocks covered by the best chainlock."""
+"""Tests historical governance checks can be skipped below the best ChainLock."""
 
 import json
 from test_framework.test_framework import DashTestFramework
@@ -133,13 +133,21 @@ class SyscoinGovernanceTest (DashTestFramework):
         # Mine superblock
         self.generate(self.nodes[0], 1, sync_fun=self.no_op)
         self.bump_mocktime(156)
-        cl = self.nodes[0].getbestblockhash()
-        self.generate(self.nodes[0], 5, sync_fun=self.no_op)
+        superblock_height = self.nodes[0].getblockcount()
+        # Advance the ChainLock strictly past the superblock. The ChainLocked
+        # block itself must have exact governance provenance; only committed
+        # ancestors may use the historical sync fallback.
+        self.generate(self.nodes[0], 10, sync_fun=self.no_op)
         self.sync_all_helper(self.nodes[0:5])
-        self.wait_for_chainlocked_block(self.nodes[0], cl)
+        chainlock_source = self.nodes[1]
+        self.wait_until(
+            lambda: chainlock_source.getbestchainlock()["height"] > superblock_height,
+            timeout=60)
+        cl = chainlock_source.getbestchainlock()["blockhash"]
+        self.wait_for_chainlocked_block(chainlock_source, cl)
 
         self.log.info("Reconnect isolated node and confirm the next ChainLock will let it sync")
-        self.reconnect_isolated_node(self.nodes[5], 0)
+        self.reconnect_isolated_node(self.nodes[5], chainlock_source.index)
         # Force isolated node to be fully synced so that it will request gov objects when reconnected
         assert_equal(self.nodes[5].mnsync("status")["IsSynced"], False)
         self.sync_all_helper(self.nodes)
@@ -151,6 +159,10 @@ class SyscoinGovernanceTest (DashTestFramework):
 
         # make sure isolated node is fully synced at this point
         self.wait_until(lambda: sync_gov(self.nodes[5]))
+        self.wait_until(
+            lambda: self.nodes[5].getbestchainlock()["blockhash"] == cl,
+            timeout=60)
+        self.wait_for_chainlocked_block(self.nodes[5], cl)
         # let all fulfilled requests expire for re-sync to work correctly
         self.bump_mocktime(5 * 60)
         self.generate(self.nodes[0], 1)


### PR DESCRIPTION
## Summary

Harden superblock and ChainLock validation so a block accepted through the governance-sync value-cap fallback cannot be locally ChainLocked without exact governance provenance.

This version intentionally keeps the fix at the validation boundary. It has no governance receipt database, historical provenance backfill, ChainLock-boundary persistence, restart republishing, activation height, or historical scan.

## Changes

- Mark a superblock `BLOCK_GOVERNANCE_VALIDATED` only when its connection performs exact governance validation.
- Require full masternode/governance sync before local ChainLock signing.
- Before signing, require exact provenance for every superblock newly committed beyond the current ChainLock winner.
- Never skip exact governance validation for the ChainLocked block itself; only strict ancestors covered by an existing ChainLock may use the historical fallback.
- Reject past-height governance triggers and reject every later vote for a trigger once its event height has been reached. Both admission decisions read the live active-chain height while holding `cs_main` before governance state, so the asynchronous `UpdatedBlockTip` cache cannot reopen a post-event window.
- Require complete block data, `BLOCK_VALID_SCRIPTS`, and no `BLOCK_FAILED_MASK` flags for ChainLock targets and alternative signing targets.
- Never clear block-failure flags during ChainLock enforcement.

## Validation guarantee

Governance admission, block validation, and local ChainLock signing now apply the same synchronized active-chain boundary. Historical governance snapshots and broader governance-state lifecycle changes are intentionally outside this focused patch.

## Runtime behavior

Nodes retain normal longest-work-chain behavior while local ChainLock signing requires the new validation marker.

## Upgrade procedure

This patch relies on the coordinated honest migration:

- disable ChainLocks for the upgrade;
- do not cross a superblock while ChainLocks are disabled;
- upgrade governance-synced nodes;
- re-enable ChainLocks and establish an honest ChainLock before the next superblock.

That first post-upgrade ChainLock is the clean bootstrap boundary. No historical governance reconstruction is performed.

## Validation

Head `c87a9b31b`:

- `make -C src -j18 syscoind test/test_syscoin`
- `validation_chainstate_tests` — 4 cases
- `llmq_sigshare_cache_tests` — 16 cases
- `transaction_tests` — 20 cases
- `governance_validators_tests` — 2 cases
- `feature_governance_cl.py --timeout-factor=3 --portseed=4823` — six-node functional scenario
- `git diff --check`

The focused governance-height regression covers both boundary rejection and the legitimate future-height control.

## Follow-up scope

Additional payment-validation hardening is intentionally being handled separately.
