### PR TITLE
Require distinct coinbase payment outputs

### DIFF
--- a/src/governance/governanceclasses.cpp
+++ b/src/governance/governanceclasses.cpp
@@ -364,14 +364,14 @@ bool CSuperblockManager::GetSuperblockPayments(int nBlockHeight, std::vector<CTx
     return true;
 }
 
-bool CSuperblockManager::IsValidSuperblock(const CTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount& nGovernanceBudget)
+bool CSuperblockManager::IsValidSuperblock(const CTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount& nGovernanceBudget, const std::vector<bool>* matched_outputs)
 {
     // GET BEST SUPERBLOCK, SHOULD MATCH
     LOCK(governance->cs);
 
     CSuperblock_sptr pSuperblock;
     if (CSuperblockManager::GetBestSuperblock(pSuperblock, nBlockHeight)) {
-        return pSuperblock->IsValid(txNew, nBlockHeight, blockReward, nGovernanceBudget);
+        return pSuperblock->IsValid(txNew, nBlockHeight, blockReward, nGovernanceBudget, matched_outputs);
     }
 
     return false;
@@ -591,7 +591,7 @@ CAmount CSuperblock::GetPaymentsTotalAmount()
 *   - Does this transaction match the superblock?
 */
 
-bool CSuperblock::IsValid(const CTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount& nGovernanceBudget)
+bool CSuperblock::IsValid(const CTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount& nGovernanceBudget, const std::vector<bool>* matched_outputs)
 {
     // TODO : LOCK(cs);
     // No reason for a lock here now since this method only accesses data
@@ -608,6 +608,12 @@ bool CSuperblock::IsValid(const CTransaction& txNew, int nBlockHeight, const CAm
     int nOutputs = txNew.vout.size();
     int nPayments = CountPayments();
     int nMinerAndMasternodePayments = nOutputs - nPayments;
+    if (matched_outputs && matched_outputs->size() != txNew.vout.size()) {
+        LogPrintf("CSuperblock::IsValid -- ERROR: Block invalid, inconsistent matched output state\n");
+        return false;
+    }
+    std::vector<bool> outputs_used =
+        matched_outputs ? *matched_outputs : std::vector<bool>(nOutputs);
 
     {
         LOCK(governance->cs);
@@ -652,11 +658,13 @@ bool CSuperblock::IsValid(const CTransaction& txNew, int nBlockHeight, const CAm
 
         for (int j = nVoutIndex; j < nOutputs; j++) {
             // Find superblock payment
-            fPaymentMatch = ((payment.script == txNew.vout[j].scriptPubKey) &&
+            fPaymentMatch = (!outputs_used[j] &&
+                             (payment.script == txNew.vout[j].scriptPubKey) &&
                              (payment.nAmount == txNew.vout[j].nValue));
 
             if (fPaymentMatch) {
-                nVoutIndex = j;
+                outputs_used[j] = true;
+                nVoutIndex = j + 1;
                 break;
             }
         }

--- a/src/governance/governanceclasses.h
+++ b/src/governance/governanceclasses.h
@@ -35,7 +35,7 @@ public:
 
     static bool GetSuperblockPayments(int nBlockHeight, std::vector<CTxOut>& voutSuperblockRet);
     static void ExecuteBestSuperblock(int nBlockHeight);
-    static bool IsValidSuperblock(const CTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount &nGovernanceBudget);
+    static bool IsValidSuperblock(const CTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount &nGovernanceBudget, const std::vector<bool>* matched_outputs = nullptr);
 };
 
 /**
@@ -135,7 +135,7 @@ public:
     bool GetPayment(int nPaymentIndex, CGovernancePayment& paymentRet);
     CAmount GetPaymentsTotalAmount();
 
-    bool IsValid(const CTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount &nGovernanceBudget);
+    bool IsValid(const CTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount &nGovernanceBudget, const std::vector<bool>* matched_outputs = nullptr);
     bool IsExpired() const;
 
     std::vector<uint256> GetProposalHashes() const;

--- a/src/masternode/masternodepayments.cpp
+++ b/src/masternode/masternodepayments.cpp
@@ -45,7 +45,7 @@ void CheckAndWriteBudget(const CAmount& nSuperblockPayment, const CAmount& nPaym
 *   - When non-superblocks are detected, the normal schedule should be maintained
 */
 
-bool IsBlockValueValid(const CBlock& block, const CBlockIndex* pindex, const CAmount &blockReward, std::string& strErrorRet, bool fJustCheck, bool check_superblock, bool* exact_superblock_validation)
+bool IsBlockValueValid(const CBlock& block, const CBlockIndex* pindex, const CAmount &blockReward, std::string& strErrorRet, bool fJustCheck, bool check_superblock, bool* exact_superblock_validation, const std::vector<bool>* matched_outputs)
 {
     if (exact_superblock_validation != nullptr) {
         *exact_superblock_validation = false;
@@ -135,7 +135,7 @@ bool IsBlockValueValid(const CBlock& block, const CBlockIndex* pindex, const CAm
         return isBlockRewardValueMet;
     }
     // this actually also checks for correct payees and not only amount
-    if (!CSuperblockManager::IsValidSuperblock(*block.vtx[0], nBlockHeight, blockReward, nGovernanceBudgetUp)) {
+    if (!CSuperblockManager::IsValidSuperblock(*block.vtx[0], nBlockHeight, blockReward, nGovernanceBudgetUp, matched_outputs)) {
         // triggered but invalid? that's weird
         LogPrintf("%s -- ERROR: Invalid superblock detected at height %d: %s", __func__, nBlockHeight, block.vtx[0]->ToString()); /* Continued */
         // should NOT allow invalid superblocks, when superblocks are enabled
@@ -149,7 +149,7 @@ bool IsBlockValueValid(const CBlock& block, const CBlockIndex* pindex, const CAm
     return true;
 }
 
-bool IsBlockPayeeValid(CChain& activeChain, const CTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount &fees, CAmount& nMNSeniorityRet, CAmount& nMNFloorDiffRet)
+bool IsBlockPayeeValid(CChain& activeChain, const CTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount &fees, CAmount& nMNSeniorityRet, CAmount& nMNFloorDiffRet, std::vector<bool>* matched_outputs)
 {
 
     // we are still using budgets, but we have no data about them anymore,
@@ -167,7 +167,7 @@ bool IsBlockPayeeValid(CChain& activeChain, const CTransaction& txNew, int nBloc
     const CAmount nHalfFee = fees / 2;
 
     // Check for correct masternode payment
-    if(CMasternodePayments::IsTransactionValid(activeChain, txNew, nBlockHeight, blockReward, nHalfFee, nMNSeniorityRet, nMNFloorDiffRet)) {
+    if(CMasternodePayments::IsTransactionValid(activeChain, txNew, nBlockHeight, blockReward, nHalfFee, nMNSeniorityRet, nMNFloorDiffRet, matched_outputs)) {
         LogPrint(BCLog::MNPAYMENTS, "%s -- Valid masternode payment at height %d\n", __func__, nBlockHeight);
         return true;
     }
@@ -292,8 +292,11 @@ bool CMasternodePayments::GetBlockTxOuts(CChain& activeChain, int nBlockHeight, 
     return true;
 }
 
-bool CMasternodePayments::IsTransactionValid(CChain& activeChain, const CTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount& nHalfFee, CAmount& nMNSeniorityRet, CAmount &nMNFloorDiffRet)
+bool CMasternodePayments::IsTransactionValid(CChain& activeChain, const CTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount& nHalfFee, CAmount& nMNSeniorityRet, CAmount &nMNFloorDiffRet, std::vector<bool>* matched_outputs)
 {
+    if (matched_outputs) {
+        matched_outputs->assign(txNew.vout.size(), false);
+    }
     if (!deterministicMNManager || !deterministicMNManager->IsDIP3Enforced(nBlockHeight)) {
         // can't verify historical blocks here
         return true;
@@ -306,8 +309,16 @@ bool CMasternodePayments::IsTransactionValid(CChain& activeChain, const CTransac
         return true;
     }
 
+    std::vector<bool> outputs_used(txNew.vout.size());
     for (const auto& txout : voutMasternodePayments) {
-        bool found = ranges::any_of(txNew.vout, [&txout](const auto& txout2) {return txout == txout2;});
+        bool found = false;
+        for (size_t i = 0; i < txNew.vout.size(); ++i) {
+            if (!outputs_used[i] && txout == txNew.vout[i]) {
+                outputs_used[i] = true;
+                found = true;
+                break;
+            }
+        }
         if (!found) {
             CTxDestination dest;
             if (!ExtractDestination(txout.scriptPubKey, dest))
@@ -315,6 +326,9 @@ bool CMasternodePayments::IsTransactionValid(CChain& activeChain, const CTransac
             LogPrintf("CMasternodePayments::%s -- ERROR failed to find expected payee %s in block at height %s\n", __func__, EncodeDestination(dest), nBlockHeight);
             return false;
         }
+    }
+    if (matched_outputs) {
+        *matched_outputs = std::move(outputs_used);
     }
     return true;
 }

--- a/src/masternode/masternodepayments.h
+++ b/src/masternode/masternodepayments.h
@@ -11,8 +11,8 @@ class CMasternodePayments;
 class CChain;
 class CBlockIndex;
 /// TODO: all 4 functions do not belong here really, they should be refactored/moved somewhere (main.cpp ?)
-bool IsBlockValueValid(const CBlock& block, const CBlockIndex* pindex, const CAmount &blockReward, std::string& strErrorRet, bool fJustCheck, bool check_superblock, bool* exact_superblock_validation = nullptr);
-bool IsBlockPayeeValid(CChain& activeChain, const CTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount &fees, CAmount& nMNSeniorityRet, CAmount &nMNFloorDiffRet);
+bool IsBlockValueValid(const CBlock& block, const CBlockIndex* pindex, const CAmount &blockReward, std::string& strErrorRet, bool fJustCheck, bool check_superblock, bool* exact_superblock_validation = nullptr, const std::vector<bool>* matched_outputs = nullptr);
+bool IsBlockPayeeValid(CChain& activeChain, const CTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount &fees, CAmount& nMNSeniorityRet, CAmount &nMNFloorDiffRet, std::vector<bool>* matched_outputs = nullptr);
 void FillBlockPayments(CChain& activeChain, CMutableTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount &fees, std::vector<CTxOut>& voutMasternodePaymentsRet, std::vector<CTxOut>& voutSuperblockPaymentsRet);
 
 extern CMasternodePayments mnpayments;
@@ -26,7 +26,7 @@ class CMasternodePayments
 {
 public:
     static bool GetBlockTxOuts(CChain& activeChain, int nBlockHeight, const CAmount &blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet, const CAmount &nHalfFee, CAmount& nMNSeniorityRet, CAmount &nMNFloorDiffRet, int& nCollateralHeight);
-    static bool IsTransactionValid(CChain& activeChain, const CTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount& nHalfFee, CAmount& nMNSeniorityRet, CAmount &nMNFloorDiffRet);
+    static bool IsTransactionValid(CChain& activeChain, const CTransaction& txNew, int nBlockHeight, const CAmount &blockReward, const CAmount& nHalfFee, CAmount& nMNSeniorityRet, CAmount &nMNFloorDiffRet, std::vector<bool>* matched_outputs = nullptr);
     static bool GetMasternodeTxOuts(CChain& activeChain, int nBlockHeight, const CAmount &blockReward, std::vector<CTxOut>& voutMasternodePaymentsRet, const CAmount &nHalfFee);
 };
 

--- a/src/test/evo_deterministicmns_tests.cpp
+++ b/src/test/evo_deterministicmns_tests.cpp
@@ -10,6 +10,7 @@
 #include <base58.h>
 #include <netbase.h>
 #include <messagesigner.h>
+#include <masternode/masternodepayments.h>
 #include <policy/policy.h>
 #include <script/signingprovider.h>
 #include <spork.h>
@@ -707,6 +708,92 @@ BOOST_AUTO_TEST_CASE(dip3_protx_basic)
 {
     TestChainDIP3V19Setup setup;
     FuncDIP3Protx(setup);
+}
+
+BOOST_AUTO_TEST_CASE(masternode_required_outputs_are_matched_once)
+{
+    TestChainDIP3V19Setup setup;
+    auto utxos = BuildSimpleUTXOVec(setup.m_coinbase_txns);
+    const CScript payout =
+        GetScriptForDestination(WitnessV0KeyHash(setup.coinbaseKey.GetPubKey()));
+
+    CKey owner_key;
+    CBLSSecretKey operator_key;
+    const CMutableTransaction pro_reg =
+        CreateProRegTx(
+            setup.m_node,
+            utxos,
+            /*port=*/1,
+            payout,
+            setup.coinbaseKey,
+            owner_key,
+            operator_key);
+    setup.CreateAndProcessBlock(
+        {pro_reg}, GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey()));
+
+    const CMutableTransaction pro_up_serv =
+        CreateProUpServTx(
+            setup.m_node,
+            utxos,
+            pro_reg.GetHash(),
+            operator_key,
+            /*port=*/2,
+            setup.coinbaseKey);
+    setup.CreateAndProcessBlock(
+        {pro_up_serv}, GetScriptForRawPubKey(setup.coinbaseKey.GetPubKey()));
+
+    CChain* active_chain = WITH_LOCK(
+        ::cs_main, return &setup.m_node.chainman->ActiveChain());
+    const int next_height = *setup.m_node.chain->getHeight() + 1;
+    constexpr CAmount block_reward{100 * COIN};
+    CAmount mn_seniority{0};
+    CAmount mn_floor_diff{0};
+    int collateral_height{0};
+    std::vector<CTxOut> required_outputs;
+    BOOST_REQUIRE(
+        CMasternodePayments::GetBlockTxOuts(
+            *active_chain,
+            next_height,
+            block_reward,
+            required_outputs,
+            /*nHalfFee=*/0,
+            mn_seniority,
+            mn_floor_diff,
+            collateral_height));
+    BOOST_REQUIRE_EQUAL(required_outputs.size(), 2);
+    BOOST_REQUIRE(required_outputs[0] == required_outputs[1]);
+
+    CMutableTransaction tx;
+    tx.vout = {required_outputs[0]};
+    mn_seniority = 0;
+    mn_floor_diff = 0;
+    BOOST_CHECK(
+        !CMasternodePayments::IsTransactionValid(
+            *active_chain,
+            CTransaction{tx},
+            next_height,
+            block_reward,
+            /*nHalfFee=*/0,
+            mn_seniority,
+            mn_floor_diff));
+
+    tx.vout.push_back(required_outputs[1]);
+    mn_seniority = 0;
+    mn_floor_diff = 0;
+    std::vector<bool> matched_outputs;
+    BOOST_CHECK(
+        CMasternodePayments::IsTransactionValid(
+            *active_chain,
+            CTransaction{tx},
+            next_height,
+            block_reward,
+            /*nHalfFee=*/0,
+            mn_seniority,
+            mn_floor_diff,
+            &matched_outputs));
+    BOOST_REQUIRE_EQUAL(matched_outputs.size(), tx.vout.size());
+    BOOST_CHECK(matched_outputs[0]);
+    BOOST_CHECK(matched_outputs[1]);
 }
 
 BOOST_AUTO_TEST_CASE(test_mempool_reorg_legacy)

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -82,6 +82,15 @@ public:
         return manager.mapTrigger.emplace(
             trigger_hash, std::move(superblock)).second;
     }
+
+    static CSuperblock_sptr GetTrigger(
+        CGovernanceManager& manager,
+        const uint256& trigger_hash)
+    {
+        LOCK(manager.cs);
+        const auto it = manager.mapTrigger.find(trigger_hash);
+        return it == manager.mapTrigger.end() ? nullptr : it->second;
+    }
 };
 
 } // namespace governance_tests
@@ -372,6 +381,80 @@ BOOST_FIXTURE_TEST_CASE(
     BOOST_CHECK(
         std::string{exception.what()}.find("event height has passed") !=
         std::string::npos);
+}
+
+BOOST_FIXTURE_TEST_CASE(
+    governance_required_outputs_are_matched_once,
+    TestChainDIP3V19Setup)
+{
+    const CBlockIndex* tip =
+        WITH_LOCK(::cs_main, return m_node.chainman->ActiveChain().Tip());
+    BOOST_REQUIRE(tip != nullptr);
+    const int event_height = tip->nHeight;
+    BOOST_REQUIRE(CSuperblock::IsValidBlockHeight(event_height));
+
+    const CTxDestination destination = PKHash(coinbaseKey.GetPubKey());
+    std::vector<CGovernancePayment> payments;
+    payments.emplace_back(destination, COIN, InsecureRand256());
+    payments.emplace_back(destination, COIN, InsecureRand256());
+    CSuperblock schedule{event_height, std::move(payments)};
+    CGovernanceObject trigger{
+        uint256{},
+        /*revision=*/1,
+        GetTime<std::chrono::seconds>().count(),
+        uint256{},
+        schedule.GetHexStrData()};
+
+    uint256 trigger_hash;
+    BOOST_REQUIRE(
+        governance_tests::CGovernanceManagerTestAccess::
+            InsertPreviouslyAdmittedTrigger(
+                *governance, std::move(trigger), trigger_hash));
+    const auto superblock =
+        governance_tests::CGovernanceManagerTestAccess::
+            GetTrigger(*governance, trigger_hash);
+    BOOST_REQUIRE(superblock != nullptr);
+
+    const CTxOut miner_output{10 * COIN, CScript{}};
+    const CTxOut required_output{
+        COIN, GetScriptForDestination(destination)};
+    CMutableTransaction tx;
+    tx.vout = {miner_output, required_output};
+
+    BOOST_CHECK(
+        !superblock->IsValid(
+            CTransaction{tx},
+            event_height,
+            /*blockReward=*/10 * COIN,
+            /*nGovernanceBudget=*/2 * COIN));
+
+    tx.vout.push_back(required_output);
+    BOOST_CHECK(
+        superblock->IsValid(
+            CTransaction{tx},
+            event_height,
+            /*blockReward=*/10 * COIN,
+            /*nGovernanceBudget=*/2 * COIN));
+
+    std::vector<bool> previously_matched(tx.vout.size());
+    previously_matched[1] = true;
+    BOOST_CHECK(
+        !superblock->IsValid(
+            CTransaction{tx},
+            event_height,
+            /*blockReward=*/11 * COIN,
+            /*nGovernanceBudget=*/2 * COIN,
+            &previously_matched));
+
+    tx.vout.push_back(required_output);
+    previously_matched.resize(tx.vout.size());
+    BOOST_CHECK(
+        superblock->IsValid(
+            CTransaction{tx},
+            event_height,
+            /*blockReward=*/11 * COIN,
+            /*nGovernanceBudget=*/2 * COIN,
+            &previously_matched));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3119,19 +3119,20 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         const CAmount blockReward = GetBlockSubsidy(pindex->nHeight, params.GetConsensus());
         CAmount nMNSeniorityRet = 0;
         CAmount nMNFloorDiffRet = 0;
+        std::vector<bool> matched_payment_outputs;
         // A ChainLock may provide the historical fallback only for strict
         // ancestors. The ChainLocked block itself must pass exact governance
         // validation.
         const bool check_superblock = llmq::chainLocksHandler->GetBestChainLock().nHeight <= pindex->nHeight;
         // detect MN was paid properly, accounting for seniority which is added to subsidy
-        if (!IsBlockPayeeValid(m_chain, *block.vtx[0], pindex->nHeight, blockReward, nFees, nMNSeniorityRet, nMNFloorDiffRet)) {
+        if (!IsBlockPayeeValid(m_chain, *block.vtx[0], pindex->nHeight, blockReward, nFees, nMNSeniorityRet, nMNFloorDiffRet, &matched_payment_outputs)) {
             LogPrintf("ERROR: ConnectBlock(): couldn't find masternode or superblock payments\n");
             return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-cb-payee");
         }
 
         std::string strError;
         // add seniority to reward when checking for limit
-        if (!IsBlockValueValid(block, pindex, blockReward+nFees+nMNSeniorityRet+nMNFloorDiffRet, strError, fJustCheck, check_superblock, &exact_superblock_validation) && (fRegTest || pindex->nHeight >= params.GetConsensus().DIP0003EnforcementHeight)) {
+        if (!IsBlockValueValid(block, pindex, blockReward+nFees+nMNSeniorityRet+nMNFloorDiffRet, strError, fJustCheck, check_superblock, &exact_superblock_validation, &matched_payment_outputs) && (fRegTest || pindex->nHeight >= params.GetConsensus().DIP0003EnforcementHeight)) {
             LogPrintf("ERROR: ConnectBlock(): %s\n", strError);
             // hack for feature_signet.py to pass which uses bitcoin blocks signed by the signet witness
             if(!fSigNet || pindex->nHeight > 100) {


### PR DESCRIPTION
## Summary

- require each scheduled masternode and governance payment to match a distinct coinbase output
- preserve matched output positions across the two payment-validation passes
- add focused regression coverage for repeated payment requirements and combined validation

## Rationale

Payment validation previously checked required outputs independently. This change makes the matching invariant explicit and injective across both validators while preserving the existing payment ordering rules.

## Impact

Normal coinbase construction is unchanged. A valid block must provide one actual output for each required payment.

## Validation

- fresh mainnet synchronization completed successfully with the updated validation rules
- full C++ unit suite: 675 test cases passed
- `validation_chainstate_tests`: passed
- `evo_dip3_activation_tests`: passed
- `transaction_tests`: passed
- `llmq_sigshare_cache_tests`: passed
- focused payment-matching regressions: passed
- `git diff --check`: passed