### PR TITLE
Isolate BTCC behind an independent activation height

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -91,6 +91,9 @@ void ReadRegTestArgs(const ArgsManager& args, CChainParams::RegTestOptions& opti
     if (args.IsArgSet("-clreceiptstartheight")) {
         options.clreceiptstartblock = args.GetIntArg("-clreceiptstartheight", std::numeric_limits<int>::max());
     }
+    if (args.IsArgSet("-btccstartheight")) {
+        options.btccstartblock = args.GetIntArg("-btccstartheight", std::numeric_limits<int>::max());
+    }
     if (args.IsArgSet("-bridgev2startheight")) {
         options.bridgev2startblock = args.GetIntArg("-bridgev2startheight", std::numeric_limits<int>::max());
     }

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -171,6 +171,10 @@ struct Params {
     int nBridgeStartBlock;
     int nNEVMStartBlock;
     int nCLReceiptStartBlock;
+    // BTCC signing, in-block carrier receipts, and BTCPREV validation.
+    // Kept independent from bridge receipt activation so a future
+    // post-quantum checkpoint format can activate on its own boundary.
+    int nBTCCStartBlock{std::numeric_limits<int>::max()};
     // Bridge V2 vault-manager cutover (independent of nCLReceiptStartBlock).
     int nBridgeV2StartBlock;
     int64_t nNEVMStartTime;

--- a/src/evo/specialtx.cpp
+++ b/src/evo/specialtx.cpp
@@ -178,11 +178,8 @@ bool ProcessSpecialTxsInBlock(ChainstateManager &chainman, const CBlock& block, 
         {
             const auto& consensus = Params().GetConsensus();
             const int32_t height = pindex->nHeight;
-            const int start = consensus.nCLReceiptStartBlock;
             const int32_t expected = height - BTCCHECK_PROP_BUFFER;
-            const bool receiptRequired = height >= BTCCHECK_PROP_BUFFER &&
-                                        expected >= start &&
-                                        ((height % BTCCHECK_PERIOD) == BTCCHECK_CARRIER_OFFSET);
+            const bool receiptRequired = IsBTCCCarrierHeight(consensus, height);
             if (receiptRequired) {
                 std::vector<unsigned char> vchData;
                 int nOut{-1};

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -619,6 +619,7 @@ void SetupServerArgs(ArgsManager& argsman)
     argsman.AddArg("-dip19params=<n:m>", "DIP19 params used for testing only", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-nevmstartheight=<n>", "NEVM Start height used for testing only", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-clreceiptstartheight=<n>", "CL receipt start height used for testing only", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-btccstartheight=<n>", "BTCC start height used for testing only", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-bridgev2startheight=<n>", "Bridge V2 vault-manager cutover height used for testing only", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-btcheadermanaged", strprintf("Automatically start/stop a local Bitcoin headers-only node for BTCC signer policy checks (default: %u)", DEFAULT_BTC_HEADER_MANAGED), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-btcheaderbinary=<path>", "Path to bitcoind binary used when -btcheadermanaged=1. If unset, syscoin searches common install/build locations.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -1901,9 +1902,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     const bool nevm_miner_addr_configured = HasNEVMMinerFeeRecipientConfig(args);
     const bool hrp_forces_nevm_off = args.IsArgSet("-hrp");
     const bool btcheader_policy_active_chain = !Params().MineBlocksOnDemand() || enforce_btcheader_policy_ondemand;
+    const bool btcc_deployment_configured = IsBTCCDeploymentConfigured(Params().GetConsensus());
     bool btc_header_policy_ready{true};
     bool btcheader_backend_initialized{false};
-    const bool init_btcheader_backend_early = fMasternodeMode && btcheader_policy_active_chain;
+    const bool init_btcheader_backend_early =
+        btcc_deployment_configured && fMasternodeMode && btcheader_policy_active_chain;
     if (init_btcheader_backend_early) {
         btcheader_backend_initialized = true;
         if (!node.chainman->ActiveChainstate().DoBTCHeaderStartupProcedure()) {
@@ -1919,6 +1922,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     }
     LogPrintf("NEVM connection %d\n", fNEVMConnection? 1: 0);
     const bool require_btcheader_backend_post_nevm =
+        btcc_deployment_configured &&
         (fMasternodeMode || ((fNEVMConnection && !hrp_forces_nevm_off) && nevm_miner_addr_configured)) &&
         btcheader_policy_active_chain;
     if (require_btcheader_backend_post_nevm && !btcheader_backend_initialized) {

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -207,6 +207,8 @@ public:
         consensus.nNEVMStartBlock = 1317500;
         // ChainLock receipt activation height (set on deployment to avoid invalidating historical blocks)
         consensus.nCLReceiptStartBlock = std::numeric_limits<int>::max();
+        // Deferred until the post-quantum BTCC format and validation path are defined.
+        consensus.nBTCCStartBlock = std::numeric_limits<int>::max();
         // Independent of nCLReceiptStartBlock; set to Core cutover H when V2 proxy is live.
         consensus.nBridgeV2StartBlock = std::numeric_limits<int>::max();
         consensus.nNEVMStartTime = 1638791667;
@@ -371,6 +373,8 @@ public:
         consensus.nNEVMStartBlock = 840000;
         // Keep canonical receipt hardening active; do not couple manager switch to this.
         consensus.nCLReceiptStartBlock = 1746000;
+        // Deferred independently from canonical bridge receipt hardening.
+        consensus.nBTCCStartBlock = std::numeric_limits<int>::max();
         // Future H2 when V2 vault proxy is deployed (NEVM F2 = H2 - nNEVMStartBlock + 1).
         consensus.nBridgeV2StartBlock = std::numeric_limits<int>::max();
         consensus.nNEVMStartTime = 1632775675;
@@ -618,6 +622,8 @@ public:
         consensus.nBridgeStartBlock = 0;
         consensus.nNEVMStartBlock = opts.nevmstartblock;
         consensus.nCLReceiptStartBlock = opts.clreceiptstartblock;
+        // Disabled by default; BTCC-specific tests opt in explicitly.
+        consensus.nBTCCStartBlock = opts.btccstartblock;
         // Deferred by default; set via -bridgev2startheight for tests/private nets.
         consensus.nBridgeV2StartBlock = opts.bridgev2startblock;
         consensus.nNEVMStartTime = 0;

--- a/src/kernel/chainparams.h
+++ b/src/kernel/chainparams.h
@@ -160,6 +160,7 @@ public:
         int dip3enforcement{432};
         int nevmstartblock{2050};
         int clreceiptstartblock{std::numeric_limits<int>::max()};
+        int btccstartblock{std::numeric_limits<int>::max()};
         int bridgev2startblock{std::numeric_limits<int>::max()};
 
     };

--- a/src/llmq/quorums_btccheckpoints.cpp
+++ b/src/llmq/quorums_btccheckpoints.cpp
@@ -90,7 +90,7 @@ static int32_t GetExpectedBTCCheckpointHeight(const ChainstateManager& chainman)
     // - Emit exactly one checkpoint per BTCCHECK_PERIOD blocks
     // - Sign at heights where height % BTCCHECK_PERIOD == BTCCHECK_SIGN_OFFSET
     const int tip = chainman.ActiveHeight();
-    const int start = Params().GetConsensus().nCLReceiptStartBlock;
+    const auto& consensus = Params().GetConsensus();
     static constexpr int PERIOD{BTCCHECK_PERIOD};
     static constexpr int SIGN_OFFSET{BTCCHECK_SIGN_OFFSET}; // within [0, PERIOD)
 
@@ -98,7 +98,7 @@ static int32_t GetExpectedBTCCheckpointHeight(const ChainstateManager& chainman)
     // Enforce activation: don't return pre-activation heights.
     if (tip < SIGN_OFFSET) return -1;
     const int h = tip - ((tip - SIGN_OFFSET) % PERIOD);
-    if (h < start) return -1;
+    if (!IsBTCCSignHeight(consensus, h)) return -1;
     return h;
 }
 
@@ -163,7 +163,7 @@ static bool RunBTCHeaderRPCCommand(const std::vector<std::string>& method_and_ar
 static bool GetLatestOnChainBTCPREVCommitment(const ChainstateManager& chainman, int32_t sign_height, uint256& out_hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     out_hash.SetNull();
-    const int start = Params().GetConsensus().nCLReceiptStartBlock;
+    const int start = Params().GetConsensus().nBTCCStartBlock;
     for (int32_t h = sign_height - BTCCHECK_PERIOD; h >= start; h -= BTCCHECK_PERIOD) {
         const CBlockIndex* pindex = chainman.ActiveChain()[h];
         if (!pindex) continue;
@@ -414,11 +414,13 @@ CBTCCheckpointsHandler::CBTCCheckpointsHandler(CConnman& _connman, PeerManager& 
 
 void CBTCCheckpointsHandler::Start()
 {
+    if (!IsBTCCDeploymentConfigured(Params().GetConsensus())) return;
     quorumSigningManager->RegisterRecoveredSigsListener(this);
 }
 
 void CBTCCheckpointsHandler::Stop()
 {
+    if (!IsBTCCDeploymentConfigured(Params().GetConsensus())) return;
     quorumSigningManager->UnregisterRecoveredSigsListener(this);
 }
 
@@ -799,7 +801,8 @@ bool CBTCCheckpointsHandler::VerifyAggregatedBTCCheckpointNoCache(const CBTCChec
 
 void CBTCCheckpointsHandler::ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRecv)
 {
-    if (msg_type != NetMsgType::BTCCSIG) {
+    if (msg_type != NetMsgType::BTCCSIG ||
+        !IsBTCCDeploymentConfigured(Params().GetConsensus())) {
         return;
     }
 
@@ -982,6 +985,7 @@ not_older:
 
 void CBTCCheckpointsHandler::TrySignBTCCheckpointTip()
 {
+    if (!IsBTCCDeploymentConfigured(Params().GetConsensus())) return;
     if (!fMasternodeMode) return;
     if (!masternodeSync.IsBlockchainSynced()) return;
 
@@ -993,7 +997,7 @@ void CBTCCheckpointsHandler::TrySignBTCCheckpointTip()
         if (!lockMain) {
             return;
         }
-        const int start = Params().GetConsensus().nCLReceiptStartBlock;
+        const int start = Params().GetConsensus().nBTCCStartBlock;
         if (chainman.ActiveHeight() < start) {
             return;
         }
@@ -1370,6 +1374,8 @@ void CBTCCheckpointsHandler::AcceptVerifiedBTCCSig(const CBTCCheckpointSig& btcc
 
 void CBTCCheckpointsHandler::ProcessPendingVerifiedBTCCheckpointSigs()
 {
+    if (!IsBTCCDeploymentConfigured(Params().GetConsensus())) return;
+
     Cleanup();
 
     int32_t expectedHeight{-1};
@@ -1415,6 +1421,8 @@ void CBTCCheckpointsHandler::ProcessPendingVerifiedBTCCheckpointSigs()
 
 void CBTCCheckpointsHandler::HandleNewRecoveredSig(const CRecoveredSig& recoveredSig)
 {
+    if (!IsBTCCDeploymentConfigured(Params().GetConsensus())) return;
+
     Cleanup();
 
     CBTCCheckpointSig share;
@@ -1613,4 +1621,3 @@ bool CBTCCheckpointsHandler::VerifyAggregatedBTCCheckpoint(const CBTCCheckpointS
 }
 
 } // namespace llmq
-

--- a/src/llmq/quorums_signing.cpp
+++ b/src/llmq/quorums_signing.cpp
@@ -631,8 +631,14 @@ void CSigningManager::ProcessRecoveredSig(NodeId nodeId, const std::shared_ptr<c
                 if(peer) peerman.Misbehaving(*peer, 10, "invalid recovered signature block height");
                 return;
             }
+        } else if (is_btccheck_request &&
+                   !IsBTCCDeploymentConfigured(chainman.GetConsensus())) {
+            // Ignore legacy BTCC recovered signatures while the deployment is
+            // disabled instead of storing them or penalizing the peer.
+            peerman.ForgetTxHash(nodeId, hash);
+            return;
         } else if (is_btccheck_request) {
-            if ((pindex->nHeight % BTCCHECK_PERIOD) != BTCCHECK_SIGN_OFFSET) {
+            if (!IsBTCCSignHeight(chainman.GetConsensus(), pindex->nHeight)) {
                 peerman.ForgetTxHash(nodeId, hash);
                 if (peer) peerman.Misbehaving(*peer, 10, "invalid btcc recovered signature height");
                 return;

--- a/src/masternode/masternodesync.cpp
+++ b/src/masternode/masternodesync.cpp
@@ -140,6 +140,7 @@ void CMasternodeSync::ProcessTick(CConnman& connman, const PeerManager& peerman)
 
     nTimeLastProcess = GetTime();
     const CConnman::NodesSnapshot snap{connman, /* filter = */ FullyConnectedOnly};
+    const bool fBTCCConfigured = IsBTCCDeploymentConfigured(Params().GetConsensus());
     // Gradually request the rest of the votes after sync finished and make sure
     // we recover latest CLSIG/BTCCSIG after startup if local state is still empty.
     if(IsSynced()) {
@@ -147,7 +148,8 @@ void CMasternodeSync::ProcessTick(CConnman& connman, const PeerManager& peerman)
         static int64_t nTimeLastSigSyncRequest = 0;
         const int64_t nNow = GetTime<std::chrono::seconds>().count();
         const bool fNeedCLSIG = llmq::chainLocksHandler && llmq::chainLocksHandler->GetBestChainLock().IsNull();
-        const bool fNeedBTCCSIG = llmq::btcCheckpointsHandler && llmq::btcCheckpointsHandler->GetBestBTCCheckpoint().IsNull();
+        const bool fNeedBTCCSIG = fBTCCConfigured && llmq::btcCheckpointsHandler &&
+                                  llmq::btcCheckpointsHandler->GetBestBTCCheckpoint().IsNull();
         if ((fNeedCLSIG || fNeedBTCCSIG) && nNow - nTimeLastSigSyncRequest >= MASTERNODE_SYNC_TIMEOUT_SECONDS) {
             size_t nRequested = 0;
             for (auto& pnode : snap.Nodes()) {
@@ -200,7 +202,9 @@ void CMasternodeSync::ProcessTick(CConnman& connman, const PeerManager& peerman)
                     if (pNodeTmp->nVersion >= PROTOCOL_VERSION && !pNodeTmp->IsInboundConn() && !fRequestedEarlier) {
                         netfulfilledman->AddFulfilledRequest(pNodeTmp->addr, "mempool-sync");
                         connman.PushMessage(pNodeTmp, msgMaker.Make(NetMsgType::GETCLSIG));
-                        connman.PushMessage(pNodeTmp, msgMaker.Make(NetMsgType::GETBTCCSIG));
+                        if (fBTCCConfigured) {
+                            connman.PushMessage(pNodeTmp, msgMaker.Make(NetMsgType::GETBTCCSIG));
+                        }
                         LogPrint(BCLog::MNSYNC, "CMasternodeSync::ProcessTick -- nTick %d nMode %d -- syncing mempool from peer=%d\n", nTick, nMode, pNodeTmp->GetId());
                     }
                 }
@@ -283,8 +287,11 @@ void CMasternodeSync::ProcessTick(CConnman& connman, const PeerManager& peerman)
                             }
                             // Keep CLSIG/BTCCSIG requests independent from mempool-sync bookkeeping.
                             connman.PushMessage(pNodeTmp, msgMaker.Make(NetMsgType::GETCLSIG));
-                            connman.PushMessage(pNodeTmp, msgMaker.Make(NetMsgType::GETBTCCSIG));
-                            LogPrint(BCLog::MNSYNC, "CMasternodeSync::ProcessTick -- nTick %d nMode %d -- requested CLSIG/BTCCSIG from peer=%d\n", nTick, nMode, pNodeTmp->GetId());
+                            if (fBTCCConfigured) {
+                                connman.PushMessage(pNodeTmp, msgMaker.Make(NetMsgType::GETBTCCSIG));
+                            }
+                            LogPrint(BCLog::MNSYNC, "CMasternodeSync::ProcessTick -- nTick %d nMode %d -- requested CLSIG%s from peer=%d\n",
+                                nTick, nMode, fBTCCConfigured ? "/BTCCSIG" : "", pNodeTmp->GetId());
                         }
                     }
                 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2041,7 +2041,8 @@ bool PeerManagerImpl::AlreadyHaveTx(const GenTxid& gtxid)
     case MSG_CLSIG:
         return llmq::chainLocksHandler->AlreadyHave(hash);
     case MSG_BTCCSIG:
-        return llmq::btcCheckpointsHandler && llmq::btcCheckpointsHandler->AlreadyHave(hash);
+        return !IsBTCCDeploymentConfigured(Params().GetConsensus()) ||
+               (llmq::btcCheckpointsHandler && llmq::btcCheckpointsHandler->AlreadyHave(hash));
     }
 
     if (m_orphanage.HaveTx(gtxid)) return true;
@@ -2501,7 +2502,9 @@ void PeerManagerImpl::ProcessGetData(CNode& pfrom, Peer& peer, const std::atomic
                 }
                 case(MSG_BTCCSIG): {
                     llmq::CBTCCheckpointSig o;
-                    if (llmq::btcCheckpointsHandler && llmq::btcCheckpointsHandler->GetBTCCheckpointByHash(inv.hash, o)) {
+                    if (IsBTCCDeploymentConfigured(Params().GetConsensus()) &&
+                        llmq::btcCheckpointsHandler &&
+                        llmq::btcCheckpointsHandler->GetBTCCheckpointByHash(inv.hash, o)) {
                         m_connman.PushMessage(&pfrom, msgMaker.Make(NetMsgType::BTCCSIG, o));
                         push = true;
                     }
@@ -4972,6 +4975,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         return;
     }
     if (msg_type == NetMsgType::GETBTCCSIG) {
+        if (!IsBTCCDeploymentConfigured(Params().GetConsensus())) return;
         if (auto tx_relay = peer->GetTxRelay(); tx_relay != nullptr) {
             LOCK(tx_relay->m_tx_inventory_mutex);
             tx_relay->m_send_btccsig = true;
@@ -5222,7 +5226,8 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
         llmq::chainLocksHandler->ProcessMessage(&pfrom, msg_type, vRecv);
         return;
     } else if(msg_type == NetMsgType::BTCCSIG) {
-        if (llmq::btcCheckpointsHandler) {
+        if (IsBTCCDeploymentConfigured(Params().GetConsensus()) &&
+            llmq::btcCheckpointsHandler) {
             llmq::btcCheckpointsHandler->ProcessMessage(&pfrom, msg_type, vRecv);
         }
         return;

--- a/src/node/miner.cpp
+++ b/src/node/miner.cpp
@@ -226,11 +226,9 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     // - Sign at epoch offset +2 (avoids CL's mod-5 boundary)
     // - Mine/embed at epoch offset +7 (5-block propagation buffer)
     // Carrier height H where H % 10 == 7 embeds a btcc that attests height (H-5).
-    const int start = Params().GetConsensus().nCLReceiptStartBlock;
+    const auto& consensus = Params().GetConsensus();
     const int32_t expectedHeight = nHeight - BTCCHECK_PROP_BUFFER;
-    if (nHeight >= BTCCHECK_PROP_BUFFER &&
-        expectedHeight >= start &&
-        (nHeight % BTCCHECK_PERIOD) == BTCCHECK_CARRIER_OFFSET) {
+    if (IsBTCCCarrierHeight(consensus, nHeight)) {
         const CBlockIndex* pindexReceipt = pindexPrev->GetAncestor(expectedHeight);
         llmq::CBTCCheckpointSig btcc;
         if (llmq::btcCheckpointsHandler && pindexReceipt != nullptr &&

--- a/src/rpc/auxpow_miner.cpp
+++ b/src/rpc/auxpow_miner.cpp
@@ -218,8 +218,7 @@ AuxpowMiner::getCurrentBlock (ChainstateManager &chainman, const CTxMemPool& mem
   {
     LOCK (cs_main);
     const int nextHeight = chainman.ActiveChain().Height() + 1;
-    const int start = Params().GetConsensus().nCLReceiptStartBlock;
-    const bool btcpRequired = nextHeight >= start && (nextHeight % BTCCHECK_PERIOD) == BTCCHECK_SIGN_OFFSET;
+    const bool btcpRequired = IsBTCCSignHeight(Params().GetConsensus(), nextHeight);
     CScriptID scriptID (scriptPubKey);
     auto iter = curBlocks.find(scriptID);
     if (iter != curBlocks.end())
@@ -369,8 +368,7 @@ AuxpowMiner::createAuxBlock (const node::JSONRPCRequest& request,
       const CBlock* pblock = getCurrentBlock (*node.chainman, mempool, scriptPubKey, target, btcPrevHash);
       CHECK_NONFATAL(pindexPrev != nullptr);
       const int nextHeight = pindexPrev->nHeight + 1;
-      const int start = Params().GetConsensus().nCLReceiptStartBlock;
-      const bool btcpRequired = nextHeight >= start && (nextHeight % BTCCHECK_PERIOD) == BTCCHECK_SIGN_OFFSET;
+      const bool btcpRequired = IsBTCCSignHeight(Params().GetConsensus(), nextHeight);
       int nActiveHeight = pindexPrev->nHeight - 5;
       nActiveHeight -= nActiveHeight % 10;
       const CBlockIndex* refIndex = pindexPrev->GetAncestor(nActiveHeight);

--- a/src/test/auxpow_tests.cpp
+++ b/src/test/auxpow_tests.cpp
@@ -614,12 +614,39 @@ BOOST_FIXTURE_TEST_CASE (auxpow_miner_createAndLookupBlock, TestChain100Setup)
 }
 // SYSCOIN
 
-struct AuxpowCLReceiptStartZeroSetup : TestChain100Setup {
-  AuxpowCLReceiptStartZeroSetup()
-      : TestChain100Setup(ChainType::REGTEST, {"-clreceiptstartheight=102"}) {}
+struct AuxpowCLReceiptOnlySetup : TestChain100Setup {
+  AuxpowCLReceiptOnlySetup()
+      : TestChain100Setup(ChainType::REGTEST, {"-clreceiptstartheight=0"}) {}
 };
 
-BOOST_FIXTURE_TEST_CASE(auxpow_miner_regeneratesTemplateOnBTCPREVChange, AuxpowCLReceiptStartZeroSetup)
+BOOST_FIXTURE_TEST_CASE(auxpow_miner_doesNotEmbedBTCPREVWhenBTCCDisabled, AuxpowCLReceiptOnlySetup)
+{
+  CTxMemPool mempool{MemPoolOptionsForTest(m_node)};
+  AuxpowMinerForTest miner;
+  CScript scriptPubKey;
+
+  // CL receipt rules are active, but BTCC remains at its disabled default.
+  // Move to height 101 so the next template would otherwise be a BTCC
+  // sign-offset block at height 102.
+  CreateAndProcessBlock({}, scriptPubKey);
+  const int next_height = WITH_LOCK(cs_main, return m_node.chainman->ActiveChain().Height() + 1);
+  BOOST_CHECK_EQUAL(next_height, 102);
+
+  LOCK(miner.cs);
+  uint256 target;
+  const CBlock* pblock = miner.getCurrentBlock(*m_node.chainman, mempool, scriptPubKey, target);
+  BOOST_REQUIRE(pblock != nullptr);
+
+  uint256 committed;
+  BOOST_CHECK(!ExtractBTCPREVCommitment(*pblock, committed));
+}
+
+struct AuxpowBTCCStartSetup : TestChain100Setup {
+  AuxpowBTCCStartSetup()
+      : TestChain100Setup(ChainType::REGTEST, {"-btccstartheight=102"}) {}
+};
+
+BOOST_FIXTURE_TEST_CASE(auxpow_miner_regeneratesTemplateOnBTCPREVChange, AuxpowBTCCStartSetup)
 {
   CTxMemPool mempool{MemPoolOptionsForTest(m_node)};
   AuxpowMinerForTest miner;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -997,6 +997,33 @@ BOOST_AUTO_TEST_CASE(syscoin_bridge_uses_clreceipt_activation)
                 regtest_v2->GetConsensus().vchSyscoinVaultManager);
 }
 
+BOOST_AUTO_TEST_CASE(syscoin_btcc_activation_is_independent)
+{
+    const auto main = CreateChainParams(*m_node.args, ChainType::MAIN);
+    const auto testnet = CreateChainParams(*m_node.args, ChainType::TESTNET);
+    BOOST_CHECK_EQUAL(main->GetConsensus().nBTCCStartBlock, std::numeric_limits<int>::max());
+    BOOST_CHECK_EQUAL(testnet->GetConsensus().nBTCCStartBlock, std::numeric_limits<int>::max());
+
+    ArgsManager args_cl;
+    args_cl.ForceSetArg("-clreceiptstartheight", "123");
+    const auto regtest_cl = CreateChainParams(args_cl, ChainType::REGTEST);
+    BOOST_CHECK_EQUAL(regtest_cl->GetConsensus().nCLReceiptStartBlock, 123);
+    BOOST_CHECK_EQUAL(regtest_cl->GetConsensus().nBTCCStartBlock, std::numeric_limits<int>::max());
+    BOOST_CHECK(!IsBTCCDeploymentConfigured(regtest_cl->GetConsensus()));
+    BOOST_CHECK(!IsBTCCSignHeight(regtest_cl->GetConsensus(), 1000002));
+    BOOST_CHECK(!IsBTCCCarrierHeight(regtest_cl->GetConsensus(), 1000007));
+
+    ArgsManager args_btcc;
+    args_btcc.ForceSetArg("-btccstartheight", "321");
+    const auto regtest_btcc = CreateChainParams(args_btcc, ChainType::REGTEST);
+    BOOST_CHECK_EQUAL(regtest_btcc->GetConsensus().nCLReceiptStartBlock, std::numeric_limits<int>::max());
+    BOOST_CHECK_EQUAL(regtest_btcc->GetConsensus().nBTCCStartBlock, 321);
+    BOOST_CHECK(IsBTCCDeploymentConfigured(regtest_btcc->GetConsensus()));
+    BOOST_CHECK(!IsBTCCSignHeight(regtest_btcc->GetConsensus(), 321));
+    BOOST_CHECK(IsBTCCSignHeight(regtest_btcc->GetConsensus(), 322));
+    BOOST_CHECK(IsBTCCCarrierHeight(regtest_btcc->GetConsensus(), 327));
+}
+
 struct BridgeV2CutoverTestingSetup : BasicTestingSetup {
     BridgeV2CutoverTestingSetup()
         : BasicTestingSetup(ChainType::REGTEST, {"-bridgev2startheight=1000"}) {}

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2302,9 +2302,7 @@ bool Chainstate::ConnectNEVMCommitment(BlockValidationState& state, NEVMTxRootMa
     uint256 btcPrevHashForNEVM{};
     {
         const auto& consensus = m_chainman.GetConsensus();
-        const bool carrier_height = nHeight >= BTCCHECK_PROP_BUFFER &&
-                                    (nHeight % BTCCHECK_PERIOD) == BTCCHECK_CARRIER_OFFSET &&
-                                    (static_cast<int>(nHeight) - BTCCHECK_PROP_BUFFER) >= consensus.nCLReceiptStartBlock;
+        const bool carrier_height = IsBTCCCarrierHeight(consensus, nHeight);
         if (carrier_height) {
             // Only forward a BTC anchor if this carrier block has a non-null BTCC receipt.
             // (Null receipts are allowed for censorship resistance and must result in no NEVM checkpoint.)
@@ -2797,8 +2795,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
     // accept->connect flow; otherwise fall back to reparsing.
     if (!fJustCheck) {
         const auto& consensus = params.GetConsensus();
-        const bool btcp_required = pindex->nHeight >= consensus.nCLReceiptStartBlock &&
-                                   (pindex->nHeight % BTCCHECK_PERIOD) == BTCCHECK_SIGN_OFFSET &&
+        const bool btcp_required = IsBTCCSignHeight(consensus, pindex->nHeight) &&
                                    block.auxpow;
         if (btcp_required) {
             const uint256& btcp_expected = block.auxpow->getParentPrevBlockHash();
@@ -5011,8 +5008,7 @@ static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& stat
     // Consensus verifies that it matches this block's AuxPoW parent prev-block hash.
     {
         const Consensus::Params& consensusParams = chainman.GetConsensus();
-        const bool btcpRequired = nHeight >= consensusParams.nCLReceiptStartBlock &&
-                                  (nHeight % BTCCHECK_PERIOD) == BTCCHECK_SIGN_OFFSET;
+        const bool btcpRequired = IsBTCCSignHeight(consensusParams, nHeight);
         if (btcpRequired && block.auxpow) {
             uint256 btcPrevHashCommit;
             if (!ExtractBTCPREVCommitment(block, btcPrevHashCommit)) {
@@ -5312,8 +5308,7 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
     // SYSCOIN: cache the contextually validated BTCPREV so ConnectBlock can reuse it
     // without reparsing the coinbase payload in the common accept->connect flow.
     {
-        const bool btcp_required = pindex->nHeight >= params.GetConsensus().nCLReceiptStartBlock &&
-                                   (pindex->nHeight % BTCCHECK_PERIOD) == BTCCHECK_SIGN_OFFSET &&
+        const bool btcp_required = IsBTCCSignHeight(params.GetConsensus(), pindex->nHeight) &&
                                    block.auxpow;
         if (btcp_required) {
             pindex->m_btcp_prev_contextually_validated = true;
@@ -6401,7 +6396,9 @@ void ChainstateManager::BackfillRecentBTCPREVCommitments()
     LOCK(cs_main);
 
     const auto& consensus = GetConsensus();
-    const int start = consensus.nCLReceiptStartBlock;
+    if (!IsBTCCDeploymentConfigured(consensus)) return;
+
+    const int start = consensus.nBTCCStartBlock;
     const int tip = ActiveHeight();
     if (tip < 0 || tip < start) return;
 
@@ -6409,7 +6406,7 @@ void ChainstateManager::BackfillRecentBTCPREVCommitments()
     const int low = std::max(start, tip - (BTCCHECK_PERIOD * 2));
 
     for (int h = tip; h >= low; --h) {
-        if ((h % BTCCHECK_PERIOD) != BTCCHECK_SIGN_OFFSET) continue;
+        if (!IsBTCCSignHeight(consensus, h)) continue;
         CBlockIndex* pindex = ActiveChain()[h];
         if (!pindex) continue;
         if (!pindex->btcpPrevCommitment.IsNull()) continue;

--- a/src/validation.h
+++ b/src/validation.h
@@ -36,6 +36,7 @@
 #include <versionbits.h>
 
 #include <atomic>
+#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
@@ -135,6 +136,24 @@ static constexpr int BTCCHECK_PERIOD{10};
 static constexpr int BTCCHECK_SIGN_OFFSET{2};   // within [0, BTCCHECK_PERIOD)
 static constexpr int BTCCHECK_PROP_BUFFER{5};   // blocks between signing and carrier mining
 static constexpr int BTCCHECK_CARRIER_OFFSET{BTCCHECK_SIGN_OFFSET + BTCCHECK_PROP_BUFFER}; // 7
+
+inline bool IsBTCCDeploymentConfigured(const Consensus::Params& consensus)
+{
+    return consensus.nBTCCStartBlock != std::numeric_limits<int>::max();
+}
+
+inline bool IsBTCCSignHeight(const Consensus::Params& consensus, const int height)
+{
+    return IsBTCCDeploymentConfigured(consensus) &&
+           height >= consensus.nBTCCStartBlock &&
+           (height % BTCCHECK_PERIOD) == BTCCHECK_SIGN_OFFSET;
+}
+
+inline bool IsBTCCCarrierHeight(const Consensus::Params& consensus, const int height)
+{
+    return height >= BTCCHECK_PROP_BUFFER &&
+           IsBTCCSignHeight(consensus, height - BTCCHECK_PROP_BUFFER);
+}
 
 /** Documentation for argument 'checklevel'. */
 extern const std::vector<std::string> CHECKLEVEL_DOC;

--- a/test/functional/auxpow_mining.py
+++ b/test/functional/auxpow_mining.py
@@ -38,8 +38,8 @@ class AuxpowMiningTest (SyscoinTestFramework):
     # Must set '-dip3params=9000:9000' to create pre-dip3 blocks only.
     # Enable BTCPREV commitment checks for this test.
     self.extra_args = [
-      ['-dip3params=9000:9000', '-clreceiptstartheight=0'],
-      ['-dip3params=9000:9000', '-clreceiptstartheight=0'],
+      ['-dip3params=9000:9000', '-btccstartheight=0'],
+      ['-dip3params=9000:9000', '-btccstartheight=0'],
     ]
 
   def add_options (self, parser):

--- a/test/functional/feature_btcheader_policy_auxpow.py
+++ b/test/functional/feature_btcheader_policy_auxpow.py
@@ -218,6 +218,8 @@ class BTCHeaderPolicyAuxpowTest(DashTestFramework):
 
     def set_test_params(self):
         self.set_dash_test_params(4, 3, fast_dip3_enforcement=True)
+        for args in self.extra_args:
+            args.append("-btccstartheight=0")
         self.btc_nodes = []
         self.external_btcheader_cmd = None
         self.external_btc_p2p_ports = None

--- a/test/functional/feature_llmqchainlocks.py
+++ b/test/functional/feature_llmqchainlocks.py
@@ -68,6 +68,8 @@ class LLMQChainLocksTest(DashTestFramework):
 
     def set_test_params(self):
         self.set_dash_test_params(4, 3, fast_dip3_enforcement=True)
+        for args in self.extra_args:
+            args.append("-btccstartheight=0")
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/feature_llmqdkgerrors.py
+++ b/test/functional/feature_llmqdkgerrors.py
@@ -18,11 +18,6 @@ class LLMQDKGErrors(DashTestFramework):
 
     def set_test_params(self):
         self.set_dash_test_params(4, 3, [["-whitelist=noban@127.0.0.1"]] * 4, fast_dip3_enforcement=True)
-        # Keep this DKG error test focused on DKG behavior only.
-        # BTCC carrier enforcement can intentionally reject blocks on temporary forked views,
-        # which is orthogonal to what this test validates.
-        for i in range(self.num_nodes):
-            self.extra_args[i].append("-clreceiptstartheight=1000000")
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/feature_nevm_data.py
+++ b/test/functional/feature_nevm_data.py
@@ -31,6 +31,7 @@ class NEVMDataTest(DashTestFramework):
         # Activate NEVM commitment path in this test's height range.
         for i in range(self.num_nodes):
             self.extra_args[i].append("-nevmstartheight=1")
+            self.extra_args[i].append("-btccstartheight=0")
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_py3_zmq()


### PR DESCRIPTION
## What changed

- Add an independent `nBTCCStartBlock` consensus parameter and default it to `INT_MAX` on mainnet, testnet, and regtest.
- Add the test-only `-btccstartheight=<n>` regtest override.
- Route BTCPREV commitments, BTCC carrier receipts, signing, recovered signatures, P2P synchronization, NEVM anchor forwarding, and the external Bitcoin-header policy backend through the BTCC-specific activation gate.
- Keep canonical bridge receipt and asset rules on `nCLReceiptStartBlock`.
- Make only BTCC-focused functional tests opt in to the legacy BTCC path.

## Why

BTCC reused `nCLReceiptStartBlock`, coupling Bitcoin checkpoint behavior to bridge receipt activation. That makes it difficult to keep the legacy threshold-BLS checkpoint path dormant while a post-quantum replacement and its block representation are designed.

This change isolates the existing BTCC mechanism behind its own disabled-by-default height. It does not introduce the future post-quantum format, select an activation height, or change bridge receipt activation.

## Impact

- Mainnet and testnet do not activate legacy BTCC by default.
- Blocks do not require or carry BTCPREV/BTCC data while BTCC is disabled.
- Nodes do not sign, relay, synchronize, or start the external Bitcoin-header backend solely for disabled BTCC.
- Existing bridge receipts, asset validation, ChainLocks, and unrelated quorum behavior retain their existing activation rules.
- Regtest can explicitly enable the legacy path for focused coverage.

## Validation

- `git diff --check`
- Fresh native configure and build of `test/test_syscoin` and `syscoind`
- Full native unit suite: 678 test cases passed
- Focused BTCC/bridge/AuxPoW unit tests passed
- Full `llmq_sigshare_cache_tests` suite passed
- `auxpow_mining.py --descriptors` passed with explicit BTCC activation
- `feature_llmqdkgerrors.py --descriptors` passed with BTCC left disabled
- Python compilation passed for all changed functional tests
