### PR TITLE
Schedule Tanenbaum Bridge V2 cutover

### DIFF
--- a/doc/release-notes/release-notes-5.1.0.md
+++ b/doc/release-notes/release-notes-5.1.0.md
@@ -1,0 +1,119 @@
+# Syscoin Core 5.1.0 “Liberty” Release Notes
+
+Syscoin Core version 5.1.0, codename **Liberty**, is available from:
+
+- <https://github.com/syscoin/syscoin/releases/tag/v5.1.0>
+
+Liberty is a consensus, bridge, ChainLock, and node-reliability release. It
+also includes the Syscoin geth 5.1.0 client used by managed NEVM nodes.
+
+## Network activation scope
+
+This release schedules **Bridge V2 on Tanenbaum testnet only**:
+
+- Syscoin Core cutover height: **1,786,999**
+- Paired Tanenbaum NEVM migration block: **947,000**
+- Bridge V2 vault-manager proxy:
+  `0x28bD37C0926575f2568ea8f297c0745EF16174Ab`
+
+Tanenbaum operators should upgrade before the Core cutover height.
+
+**No Bridge V2 or Bitcoin checkpoint (BTCC) activation height is assigned for
+mainnet in this release.** Those mainnet features remain inactive until a
+future coordinated release assigns their parameters. Installing 5.1.0 does
+not independently activate them on mainnet.
+
+## Upgrade instructions
+
+If you are running an older version, shut it down and wait until it has
+completely exited before replacing the binaries:
+
+- On Windows, run the new installer.
+- On macOS, replace `/Applications/Syscoin-Qt`.
+- On Linux, replace `syscoind`, `syscoin-cli`, and any other installed Syscoin
+  Core binaries.
+
+Back up wallets and configuration before upgrading. Existing data directories
+remain supported.
+
+## Notable changes
+
+### Bridge V2 and NEVM proof validation
+
+- Selects the expected vault manager at the exact Core cutover height.
+- Keeps canonical receipt validation independent from the vault-manager
+  switch.
+- Tightens receipt, trie, log, amount, destination, and asset validation.
+- Improves NEVM mint replay-marker durability across connects, disconnects,
+  startup recovery, reindexing, and database flushes.
+- Defers NEVM side effects until the corresponding Core consensus checks have
+  succeeded.
+- Adds focused fuzz and regression coverage for bridge proofs and Syscoin
+  transaction payloads.
+
+### ChainLocks, quorums, and governance
+
+- Strengthens ChainLock signing, publication, alternative-tip selection, and
+  quorum-context validation.
+- Hardens aggregate-signature and signature-share cache handling.
+- Makes ChainLock and governance validation state transitions more consistent
+  across synchronization, restart, and short reorganization paths.
+- Requires distinct coinbase outputs for independently required governance and
+  Sentry-node payments.
+
+### Managed sysgeth
+
+- Updates the bundled Linux x86-64 client to **sysgeth 5.1.0**.
+- Improves managed-client startup, bootstrap, shutdown, and ZMQ request
+  handling.
+- Keeps optional NEVM configurations available to nodes that do not require a
+  managed client.
+- Reduces startup and shutdown stalls and improves failure reporting when NEVM
+  is required.
+
+### Bitcoin data availability and checkpoint groundwork
+
+- Adds Bitcoin header-backend and checkpoint infrastructure for future
+  activation.
+- Extends AuxPoW mining RPC behavior and validation for Bitcoin-header-backed
+  templates.
+- Adds Blake2s-based Bitcoin data-availability support.
+- Keeps BTCC activation independently disabled on public networks in this
+  release.
+
+### PoDA, chainstate, and persistence
+
+- Tightens PoDA sidecar ownership, size, content, and duplicate-metadata
+  validation.
+- Improves deterministic Sentry-node snapshot persistence and EvoDB pruning.
+- Hardens database rewrite, backup, rollback, and flush failure handling.
+- Improves shutdown safety and validation check-queue draining.
+
+### Wallet, RPC, build, and test improvements
+
+- Fixes wallet fee-bump handling when UTXO cluster information is incomplete.
+- Improves Qt wallet-controller lifetime handling.
+- Expands functional, unit, sanitizer, and fuzz coverage.
+- Restores and hardens native Windows, sanitizer, and Guix CI paths.
+- Verifies the macOS SDK archive used by reproducible builds.
+
+## Compatibility
+
+Syscoin Core is supported and tested on current Linux, macOS, and Windows
+systems. It should also work on other Unix-like systems, although those
+environments receive less testing.
+
+This release includes consensus and bridge hardening. Operators should avoid
+mixing 5.1.0 binaries with older bundled sysgeth artifacts.
+
+## Reporting issues
+
+Please report issues at:
+
+- <https://github.com/syscoin/syscoin/issues>
+
+## Credits
+
+Thanks to the Syscoin community and to all contributors who reviewed, tested,
+reported, and fixed issues for Liberty, as well as the upstream Bitcoin Core
+and go-ethereum developers.

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -367,7 +367,7 @@ public:
         consensus.nSYSXAsset = 123456;
         consensus.nNEVMChainID = 5700;
         consensus.vchSyscoinVaultManagerLegacy = ParseHex("7904299b3D3dC1b03d1DdEb45E9fDF3576aCBd5f");
-        consensus.vchSyscoinVaultManager = ParseHex("1111111111111111111111111111111111111111");
+        consensus.vchSyscoinVaultManager = ParseHex("28bD37C0926575f2568ea8f297c0745EF16174Ab");
         consensus.vchTokenFreezeMethod = ParseHex("0b8914e27c9a6c88836bc5547f82ccf331142c761f84e9f1d36934a6a31eefad");
         consensus.nBridgeStartBlock = 1000;
         consensus.nNEVMStartBlock = 840000;
@@ -375,8 +375,8 @@ public:
         consensus.nCLReceiptStartBlock = 1746000;
         // Deferred independently from canonical bridge receipt hardening.
         consensus.nBTCCStartBlock = std::numeric_limits<int>::max();
-        // Future H2 when V2 vault proxy is deployed (NEVM F2 = H2 - nNEVMStartBlock + 1).
-        consensus.nBridgeV2StartBlock = std::numeric_limits<int>::max();
+        // Bridge V2 cutover H, paired with Tanenbaum NEVM F=947000.
+        consensus.nBridgeV2StartBlock = 1786999;
         consensus.nNEVMStartTime = 1632775675;
         consensus.nPODAStartBlock = 1022500;
         consensus.nV19StartBlock = 1063000;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -978,9 +978,16 @@ BOOST_AUTO_TEST_CASE(syscoin_bridge_uses_clreceipt_activation)
     const auto testnet = CreateChainParams(*m_node.args, ChainType::TESTNET);
     BOOST_CHECK_EQUAL(main->GetConsensus().nCLReceiptStartBlock, std::numeric_limits<int>::max());
     BOOST_CHECK_EQUAL(testnet->GetConsensus().nCLReceiptStartBlock, 1746000);
-    // Manager cutover is independent and stays deferred until V2 deploy.
+    // Manager cutover is independent: mainnet is deferred, testnet is scheduled.
     BOOST_CHECK_EQUAL(main->GetConsensus().nBridgeV2StartBlock, std::numeric_limits<int>::max());
-    BOOST_CHECK_EQUAL(testnet->GetConsensus().nBridgeV2StartBlock, std::numeric_limits<int>::max());
+    BOOST_CHECK_EQUAL(testnet->GetConsensus().nBridgeV2StartBlock, 1786999);
+    BOOST_CHECK(
+        testnet->GetConsensus().vchSyscoinVaultManager ==
+        ParseHex("28bD37C0926575f2568ea8f297c0745EF16174Ab"));
+    BOOST_CHECK_EQUAL(
+        testnet->GetConsensus().nBridgeV2StartBlock -
+            testnet->GetConsensus().nNEVMStartBlock + 1,
+        947000);
 
     ArgsManager args;
     args.ForceSetArg("-clreceiptstartheight", "123");


### PR DESCRIPTION
## Summary

- set the Tanenbaum V2 vault manager to `0x28bD37C0926575f2568ea8f297c0745EF16174Ab`
- activate the inclusive Core manager cutover at testnet height `1786999`
- add regressions for the deployed address and the exact Core-to-NEVM height conversion
- bundle the static stripped Linux x86-64 sysgeth `v5.1.0` artifact
- add the Syscoin Core 5.1.0 “Liberty” release notes, explicitly leaving mainnet Bridge V2 and BTCC activation unassigned

## Coordination

This Core cutover `H=1786999` pairs with Tanenbaum NEVM migration block `F=947000` using `F = H - 840000 + 1`.

Companion geth PR: https://github.com/syscoin/go-ethereum/pull/39

Release notes: https://github.com/syscoin/syscoin/blob/agent/tanenbaum-bridge-v2-params/doc/release-notes/release-notes-5.1.0.md

## Validation

- verified the deployment artifact against live Tanenbaum RPC at height `945905`
- verified both proxy implementations, relay-to-vault binding, relay minimum block `947000`, SYS GUID `123456`, initial asset count `11`, and paused start state
- independently recomputed the TokenFreeze event topic and confirmed the existing consensus hash is unchanged
- built sysgeth on the designated Linux server from geth commit `3e3248c58bdbca963ca45dd4452c6774fff12118`
- verified the copied artifact is static and stripped and reports `5.1.0-stable` with that exact commit
- verified artifact SHA-256 `72484a09d37b9fe67ee83866cc9285bf87f7ee885a51219a2900f85c662e0bfa`
- `git diff --check`

The static Syscoin Core release build remains to be produced after this parameter PR merges.