### PR TITLE
validation: prevent direct blocks from serving as AuxPoW parents

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -176,7 +176,7 @@ struct Params {
     // post-quantum checkpoint format can activate on its own boundary.
     int nBTCCStartBlock{std::numeric_limits<int>::max()};
     // Bridge V2 vault-manager cutover (independent of nCLReceiptStartBlock).
-    int nBridgeV2StartBlock;
+    int nBridgeV2StartBlock{std::numeric_limits<int>::max()};
     int64_t nNEVMStartTime;
     int nPODAStartBlock;
     int nNexusStartBlock;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -976,11 +976,13 @@ BOOST_AUTO_TEST_CASE(syscoin_bridge_uses_clreceipt_activation)
 {
     const auto main = CreateChainParams(*m_node.args, ChainType::MAIN);
     const auto testnet = CreateChainParams(*m_node.args, ChainType::TESTNET);
+    const auto signet = CreateChainParams(*m_node.args, ChainType::SIGNET);
     BOOST_CHECK_EQUAL(main->GetConsensus().nCLReceiptStartBlock, std::numeric_limits<int>::max());
     BOOST_CHECK_EQUAL(testnet->GetConsensus().nCLReceiptStartBlock, 1746000);
     // Manager cutover is independent: mainnet is deferred, testnet is scheduled.
     BOOST_CHECK_EQUAL(main->GetConsensus().nBridgeV2StartBlock, std::numeric_limits<int>::max());
     BOOST_CHECK_EQUAL(testnet->GetConsensus().nBridgeV2StartBlock, 1786999);
+    BOOST_CHECK_EQUAL(signet->GetConsensus().nBridgeV2StartBlock, std::numeric_limits<int>::max());
     BOOST_CHECK(
         testnet->GetConsensus().vchSyscoinVaultManager ==
         ParseHex("28bD37C0926575f2568ea8f297c0745EF16174Ab"));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1845,6 +1845,31 @@ bool CheckProofOfWork(const CBlockHeader& block, const Consensus::Params& params
     return true;
 }
 
+static bool CheckDirectBlockNotAuxpowParent(const CBlock& block, BlockValidationState& state,
+                                            int nHeight, const Consensus::Params& consensus)
+{
+    // Reuse the Bridge V2 cutover as the coordinated consensus activation.
+    if (nHeight < consensus.nBridgeV2StartBlock || block.IsAuxpow()) {
+        return true;
+    }
+
+    // Structural validation reports the primary error for malformed blocks.
+    if (block.vtx.empty() || !block.vtx[0] || block.vtx[0]->vin.empty()) {
+        return true;
+    }
+
+    const CScript& script = block.vtx[0]->vin[0].scriptSig;
+    const unsigned char* const header_begin = pchMergedMiningHeader;
+    const unsigned char* const header_end = header_begin + sizeof(pchMergedMiningHeader);
+    if (std::search(script.begin(), script.end(), header_begin, header_end) != script.end()) {
+        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS,
+                             "bad-direct-auxpow-parent",
+                             "non-AuxPoW block coinbase contains merged-mining header");
+    }
+
+    return true;
+}
+
 CAmount GetBlockSubsidyRegtest(int nHeight, const Consensus::Params& consensusParams)
 {
     int halvings = nHeight / consensusParams.nSubsidyHalvingInterval;
@@ -2774,6 +2799,9 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             return FatalError(m_chainman.GetNotifications(), state, "Corrupt block found indicating potential hardware failure; shutting down");
         }
         return error("%s: Consensus::CheckBlock: %s", __func__, state.ToString());
+    }
+    if (!CheckDirectBlockNotAuxpowParent(block, state, pindex->nHeight, params.GetConsensus())) {
+        return error("%s: CheckDirectBlockNotAuxpowParent: %s", __func__, state.ToString());
     }
 
     // verify that the view's current state corresponds to the previous block
@@ -4939,6 +4967,10 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, BlockValidatio
 static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& state, const ChainstateManager& chainman, const CBlockIndex* pindexPrev)
 {
     const int nHeight = pindexPrev == nullptr ? 0 : pindexPrev->nHeight + 1;
+
+    if (!CheckDirectBlockNotAuxpowParent(block, state, nHeight, chainman.GetConsensus())) {
+        return false;
+    }
 
     // Enforce BIP113 (Median Time Past).
     bool enforce_locktime_median_time_past{false};

--- a/test/functional/auxpow_self_parent.py
+++ b/test/functional/auxpow_self_parent.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The Syscoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test rejection of a direct Syscoin block reused as its own AuxPoW parent."""
+
+import copy
+import struct
+
+from test_framework.messages import (
+    CAuxPow,
+    CBlock,
+    CBlockHeader,
+    CTxOut,
+    CHAIN_ID,
+    VERSION_AUXPOW,
+    VERSION_START_BIT,
+    from_hex,
+)
+from test_framework.script import CScript
+from test_framework.test_framework import SyscoinTestFramework
+from test_framework.util import assert_equal
+
+
+CHAIN_ID_MASK = 0x1F << VERSION_START_BIT
+
+
+class AuxpowSelfParentTest(SyscoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+        self.extra_args = [
+            ["-dip3params=0:0", "-bridgev2startheight=1"],
+            ["-dip3params=0:0", "-bridgev2startheight=2"],
+        ]
+
+    def build_pair(self, node, parent_chain_id=CHAIN_ID):
+        address = node.get_deterministic_priv_key().address
+        aux_template = node.createauxblock(address)
+
+        generated = node.generateblock(address, [], False, invalid_call=False)
+        parent = from_hex(CBlock(), generated["hex"])
+        assert_equal(len(parent.vtx), 1)
+        assert_equal(parent.hashPrevBlock, int(aux_template["previousblockhash"], 16))
+        if parent_chain_id == 0:
+            parent.nVersion &= ~CHAIN_ID_MASK
+        assert_equal((parent.nVersion >> VERSION_START_BIT) & 0x1F, parent_chain_id)
+        assert_equal(parent.nVersion & VERSION_AUXPOW, 0)
+
+        merged_mining_tag = (
+            bytes.fromhex("fabe6d6d")
+            + bytes.fromhex(aux_template["hash"])
+            + struct.pack("<II", 1, 0)
+        )
+        old_script = bytes(parent.vtx[0].vin[0].scriptSig)
+        parent.vtx[0].vin[0].scriptSig = CScript(old_script + merged_mining_tag)
+        assert len(parent.vtx[0].vin[0].scriptSig) <= 100
+
+        # Post-Nexus AuxPoW requires this parent-coinbase output. It is also a
+        # valid zero-value OP_RETURN in the independently submitted parent.
+        parent.vtx[0].vout.append(
+            CTxOut(0, CScript(bytes.fromhex(aux_template["coinbasescript"])))
+        )
+
+        parent.vtx[0].rehash()
+        parent.hashMerkleRoot = parent.calc_merkle_root()
+        parent.nNonce = 0
+        parent.solve()
+
+        auxpow = CAuxPow()
+        auxpow.nVersion = parent.vtx[0].nVersion
+        auxpow.vin = copy.deepcopy(parent.vtx[0].vin)
+        auxpow.vout = copy.deepcopy(parent.vtx[0].vout)
+        auxpow.wit = copy.deepcopy(parent.vtx[0].wit)
+        auxpow.nLockTime = parent.vtx[0].nLockTime
+        auxpow.extraData = parent.vtx[0].extraData
+        auxpow.hashBlock = 0
+        auxpow.vMerkleBranch = []
+        auxpow.nIndex = 0
+        auxpow.vChainMerkleBranch = []
+        auxpow.nChainIndex = 0
+        auxpow.parentBlock = CBlockHeader(parent)
+
+        return aux_template, parent, auxpow
+
+    def run_test(self):
+        for node in self.nodes:
+            node.setnetworkactive(False)
+
+        self.log.info("Rejecting the direct parent at the Bridge V2 activation")
+        aux_template, parent, auxpow = self.build_pair(self.nodes[0])
+        assert_equal(
+            self.nodes[0].submitblock(parent.serialize().hex()),
+            "bad-direct-auxpow-parent",
+        )
+
+        self.log.info("Keeping the AuxPoW child valid")
+        assert_equal(
+            self.nodes[0].submitauxblock(aux_template["hash"], auxpow.serialize().hex()),
+            True,
+        )
+        aux_info = self.nodes[0].getblock(aux_template["hash"])
+        assert_equal(aux_info["height"], 1)
+        assert "auxpow" in aux_info
+
+        self.log.info("Keeping ordinary direct blocks valid after activation")
+        address = self.nodes[0].get_deterministic_priv_key().address
+        direct = self.nodes[0].generateblock(address, [], False, invalid_call=False)
+        assert_equal(self.nodes[0].submitblock(direct["hex"]), None)
+
+        self.log.info("Rejecting the same construction with parent Chain ID zero")
+        zero_template, zero_parent, zero_auxpow = self.build_pair(
+            self.nodes[0], parent_chain_id=0
+        )
+        assert_equal(
+            self.nodes[0].submitblock(zero_parent.serialize().hex()),
+            "bad-direct-auxpow-parent",
+        )
+        assert_equal(
+            self.nodes[0].submitauxblock(
+                zero_template["hash"], zero_auxpow.serialize().hex()
+            ),
+            True,
+        )
+
+        self.log.info("Preserving historical consensus before activation")
+        old_template, old_parent, old_auxpow = self.build_pair(self.nodes[1])
+        assert_equal(self.nodes[1].submitblock(old_parent.serialize().hex()), None)
+        assert_equal(
+            self.nodes[1].submitauxblock(old_template["hash"], old_auxpow.serialize().hex()),
+            True,
+        )
+        parent_info = self.nodes[1].getblock(old_parent.hash)
+        old_aux_info = self.nodes[1].getblock(old_template["hash"])
+        assert_equal(parent_info["height"], 1)
+        assert_equal(parent_info["height"], old_aux_info["height"])
+        assert_equal(parent_info["chainwork"], old_aux_info["chainwork"])
+
+
+if __name__ == "__main__":
+    AuxpowSelfParentTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -409,6 +409,7 @@ BASE_SCRIPTS = [
     'auxpow_mining.py',
     'auxpow_mining.py --segwit',
     'auxpow_invalidpow.py',
+    'auxpow_self_parent.py',
     'auxpow_zerohash.py',
 ]
 


### PR DESCRIPTION
## Summary

- reject non-AuxPoW blocks whose coinbase contains the merged-mining header at and after `nBridgeV2StartBlock`
- enforce the rule during contextual admission and `ConnectBlock`, including chainstate rebuilds
- default `nBridgeV2StartBlock` to `INT_MAX` so networks without an explicit assignment (including Signet) remain safely unactivated
- add functional coverage for the self-parent construction, Chain ID zero, valid AuxPoW children, normal direct blocks, and pre-activation compatibility

## Activation

This reuses the existing Bridge V2 consensus cutover; it does not add a new fork parameter or height. Testnet uses its existing `nBridgeV2StartBlock = 1786999` assignment, while mainnet activates the rule when the planned Bridge V2 height is assigned.

A fully synchronized local Syscoin testnet node was scanned from height 1,786,999 through 1,789,402 (tip hash `00000008852b807c6769c165b02a28be6f766d2e6947e38659ac1a39061d5fdc`). All 2,404 blocks were direct blocks and none of their coinbase scriptSigs contained `fabe6d6d`, so the existing testnet activation has no historical conflict through that tip.

## Rationale

The AuxPoW parent Chain ID collision check is only reached for a header carrying the AuxPoW version bit. A directly submitted parent can omit that bit while retaining a merged-mining commitment in its coinbase, then be reused as the parent of an AuxPoW child at the same height and work. Rejecting the merged-mining marker in activated direct blocks closes that ambiguity without changing Bitcoin parent Chain ID parsing.

## Testing

- `make -C src -j4 test/test_syscoin syscoind`
- `./src/test/test_syscoin --run_test=transaction_tests/syscoin_bridge_uses_clreceipt_activation --log_level=test_suite`
- `./src/test/test_syscoin --run_test=auxpow_tests --log_level=test_suite`
- `python3 test/functional/test_runner.py auxpow_self_parent.py auxpow_invalidpow.py auxpow_mining.py --jobs=3 --tmpdirprefix=/tmp/syscoin-auxpow-pr-tests`
- `python3 test/functional/test_runner.py auxpow_self_parent.py --jobs=1 --tmpdirprefix=/tmp/syscoin_pr606_final_`
- `git diff --check`