### PR TITLE
Schedule the mainnet Bridge V2 activation

### DIFF
--- a/doc/release-notes/release-notes-5.1.0.md
+++ b/doc/release-notes/release-notes-5.1.0.md
@@ -4,24 +4,48 @@ Syscoin Core version 5.1.0, codename **Liberty**, is available from:
 
 - <https://github.com/syscoin/syscoin/releases/tag/v5.1.0>
 
-Liberty is a consensus, bridge, ChainLock, and node-reliability release. It
-also includes the Syscoin geth 5.1.0 client used by managed NEVM nodes.
+Liberty is the cumulative consensus, bridge, ChainLock, and node-reliability
+upgrade from the 5.0.x release line. It also includes the matching Syscoin
+geth 5.1.0 client used by managed NEVM nodes.
 
 ## Network activation scope
 
-This release schedules **Bridge V2 on Tanenbaum testnet only**:
+### Mainnet — mandatory coordinated upgrade
+
+Liberty schedules the following consensus activation on mainnet:
+
+- Syscoin Core canonical-receipt and Bridge V2 manager cutover height:
+  **2,292,816**
+- Paired sysgeth Liberty and vault-migration block: **975,316**
+- Bridge V2 vault-manager proxy:
+  `0x28bD37C0926575f2568ea8f297c0745EF16174Ab`
+
+Mainnet Core operators must upgrade before Core height **2,292,816**. NEVM
+sequencers and operators of independently managed sysgeth instances must
+upgrade before NEVM block **975,316**. Activation is controlled by block
+height, not an estimated wall-clock time.
+
+The NEVM migration runs one Core block before the Core manager switch, making
+the migrated root available when Core height 2,292,816 is validated. The
+replacement vault is deployed paused and may remain paused for additional
+blocks after activation, but the pause does not remove the requirement to
+upgrade both consensus clients before their respective heights.
+
+### Tanenbaum testnet
+
+Liberty also schedules Bridge V2 on Tanenbaum:
 
 - Syscoin Core cutover height: **1,786,999**
 - Paired Tanenbaum NEVM migration block: **947,000**
 - Bridge V2 vault-manager proxy:
   `0x28bD37C0926575f2568ea8f297c0745EF16174Ab`
 
-Tanenbaum operators should upgrade before the Core cutover height.
+Tanenbaum operators must use matching Core and sysgeth versions at and after
+these activation heights.
 
-**No Bridge V2 or Bitcoin checkpoint (BTCC) activation height is assigned for
-mainnet in this release.** Those mainnet features remain inactive until a
-future coordinated release assigns their parameters. Installing 5.1.0 does
-not independently activate them on mainnet.
+**No Bitcoin checkpoint (BTCC) activation height is assigned for mainnet or
+Tanenbaum in this release.** BTCC remains inactive until a future coordinated
+release assigns its independent activation parameters.
 
 ## Upgrade instructions
 
@@ -64,6 +88,8 @@ remain supported.
 ### Managed sysgeth
 
 - Updates the bundled Linux x86-64 client to **sysgeth 5.1.0**.
+- Activates the Liberty EVM instruction set and Bridge V2 vault migration on
+  mainnet at NEVM block 975,316.
 - Improves managed-client startup, bootstrap, shutdown, and ZMQ request
   handling.
 - Keeps optional NEVM configurations available to nodes that do not require a
@@ -103,8 +129,9 @@ Syscoin Core is supported and tested on current Linux, macOS, and Windows
 systems. It should also work on other Unix-like systems, although those
 environments receive less testing.
 
-This release includes consensus and bridge hardening. Operators should avoid
-mixing 5.1.0 binaries with older bundled sysgeth artifacts.
+This release includes consensus and bridge hardening. Core and sysgeth must be
+upgraded as a matched pair; operators must not combine an activation-enabled
+Core binary with an older sysgeth artifact.
 
 ## Reporting issues
 

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -200,17 +200,18 @@ public:
         consensus.nSYSXAsset = 123456;
         consensus.nNEVMChainID = 57;
         consensus.vchSyscoinVaultManagerLegacy = ParseHex("7904299b3D3dC1b03d1DdEb45E9fDF3576aCBd5f");
-        // Bridge V2 stub — replace with deployed vault proxy before setting nBridgeV2StartBlock.
-        consensus.vchSyscoinVaultManager = ParseHex("1111111111111111111111111111111111111111");
+        consensus.vchSyscoinVaultManager = ParseHex("28bD37C0926575f2568ea8f297c0745EF16174Ab");
         consensus.vchTokenFreezeMethod = ParseHex("0b8914e27c9a6c88836bc5547f82ccf331142c761f84e9f1d36934a6a31eefad");
         consensus.nBridgeStartBlock = 348000;
         consensus.nNEVMStartBlock = 1317500;
-        // ChainLock receipt activation height (set on deployment to avoid invalidating historical blocks)
-        consensus.nCLReceiptStartBlock = std::numeric_limits<int>::max();
+        // Activate canonical receipts with Bridge V2 so legacy parsing cannot
+        // remain enabled after the vault-manager cutover.
+        consensus.nCLReceiptStartBlock = 2292816;
         // Deferred until the post-quantum BTCC format and validation path are defined.
         consensus.nBTCCStartBlock = std::numeric_limits<int>::max();
-        // Independent of nCLReceiptStartBlock; set to Core cutover H when V2 proxy is live.
-        consensus.nBridgeV2StartBlock = std::numeric_limits<int>::max();
+        // NEVM F=975316 is committed one Core block earlier, making its roots
+        // available when manager validation switches at H=2292816.
+        consensus.nBridgeV2StartBlock = 2292816;
         consensus.nNEVMStartTime = 1638791667;
         consensus.nPODAStartBlock = 1586000;
         consensus.nV19StartBlock = 1586000;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -977,12 +977,21 @@ BOOST_AUTO_TEST_CASE(syscoin_bridge_uses_clreceipt_activation)
     const auto main = CreateChainParams(*m_node.args, ChainType::MAIN);
     const auto testnet = CreateChainParams(*m_node.args, ChainType::TESTNET);
     const auto signet = CreateChainParams(*m_node.args, ChainType::SIGNET);
-    BOOST_CHECK_EQUAL(main->GetConsensus().nCLReceiptStartBlock, std::numeric_limits<int>::max());
+    BOOST_CHECK_EQUAL(main->GetConsensus().nCLReceiptStartBlock, 2292816);
     BOOST_CHECK_EQUAL(testnet->GetConsensus().nCLReceiptStartBlock, 1746000);
-    // Manager cutover is independent: mainnet is deferred, testnet is scheduled.
-    BOOST_CHECK_EQUAL(main->GetConsensus().nBridgeV2StartBlock, std::numeric_limits<int>::max());
+    // Manager cutover is independently scheduled per network.
+    BOOST_CHECK_EQUAL(main->GetConsensus().nBridgeV2StartBlock, 2292816);
     BOOST_CHECK_EQUAL(testnet->GetConsensus().nBridgeV2StartBlock, 1786999);
     BOOST_CHECK_EQUAL(signet->GetConsensus().nBridgeV2StartBlock, std::numeric_limits<int>::max());
+    BOOST_CHECK(
+        main->GetConsensus().vchSyscoinVaultManager ==
+        ParseHex("28bD37C0926575f2568ea8f297c0745EF16174Ab"));
+    // The NEVM migration runs one Core block before H so its roots are readable
+    // when manager validation switches at H.
+    BOOST_CHECK_EQUAL(
+        main->GetConsensus().nBridgeV2StartBlock -
+            main->GetConsensus().nNEVMStartBlock,
+        975316);
     BOOST_CHECK(
         testnet->GetConsensus().vchSyscoinVaultManager ==
         ParseHex("28bD37C0926575f2568ea8f297c0745EF16174Ab"));


### PR DESCRIPTION
## Summary

- schedule mainnet canonical receipt validation and Bridge V2 manager validation at Core height `2292816`
- set the deployed V2 vault-manager proxy to `0x28bD37C0926575f2568ea8f297c0745EF16174Ab`
- add consensus-parameter regressions for the activation pair and manager address
- update the bundled linux/amd64 sysgeth to the verified static build from `syscoin/go-ethereum@f3194bdf4af0b1284540770d8adfa9affc85ac85`

The paired sysgeth migration and Liberty fork run at NEVM block `975316`, one Core block before the manager validation switch, so the migrated root is available at activation.

## Validation

- `test_syscoin --run_test=transaction_tests/syscoin_bridge_uses_clreceipt_activation`
- `test_syscoin --run_test=transaction_tests/syscoin_mint_manager_switches_at_bridge_v2_height`
- bundled binary: static, stripped linux/amd64, version `5.1.0-stable`, embedded commit `f3194bdf4af0b1284540770d8adfa9affc85ac85`
- bundled binary SHA-256: `204e8cceef9699c9ea7455bde085882ee2872ef85d0a9ddc37ce6825e9f68448`
- `git diff --check`