### PR TITLE
fix(governance): validate legacy sync bloom filters

### DIFF
--- a/src/governance/governance.cpp
+++ b/src/governance/governance.cpp
@@ -136,6 +136,14 @@ void CGovernanceManager::ProcessMessage(CNode* pfrom, const std::string& strComm
 
         vRecv >> filter;
 
+        if (!filter.IsWithinSizeConstraints()) {
+            const PeerRef peer{peerman.GetPeerRef(pfrom->GetId())};
+            if (peer) {
+                peerman.Misbehaving(*peer, 100, "too-large bloom filter");
+            }
+            return;
+        }
+
         LogPrint(BCLog::GOBJECT, "MNGOVERNANCESYNC -- syncing governance objects to our peer %s\n", pfrom->addr.ToStringAddr());
         if (nProp == uint256()) {
             SyncObjects(pfrom, connman, peerman);

--- a/src/test/validation_chainstate_tests.cpp
+++ b/src/test/validation_chainstate_tests.cpp
@@ -10,6 +10,9 @@
 #include <governance/governancevote.h>
 #include <masternode/masternodepayments.h>
 #include <masternode/masternodesync.h>
+#include <net.h>
+#include <net_processing.h>
+#include <protocol.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <random.h>
@@ -24,6 +27,7 @@
 #include <util/time.h>
 #include <validation.h>
 
+#include <limits>
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
@@ -96,6 +100,46 @@ public:
 } // namespace governance_tests
 
 BOOST_FIXTURE_TEST_SUITE(validation_chainstate_tests, ChainTestingSetup)
+
+BOOST_FIXTURE_TEST_CASE(
+    legacy_governance_sync_rejects_oversized_bloom_filter,
+    TestChain100Setup)
+{
+    BOOST_REQUIRE(governance != nullptr);
+    BOOST_REQUIRE(governance->LoadCache(/*load_cache=*/false));
+    BOOST_REQUIRE(governance->IsValid());
+    struct SyncModeGuard {
+        const int old_mode;
+        ~SyncModeGuard() { masternodeSync.SetSyncMode(old_mode); }
+    } sync_mode_guard{masternodeSync.GetAssetID()};
+    masternodeSync.SetSyncMode(MASTERNODE_SYNC_FINISHED);
+    BOOST_REQUIRE(masternodeSync.IsSynced());
+
+    in_addr ipv4_addr;
+    ipv4_addr.s_addr = 0xa0b0c006;
+    const CAddress address{CService{ipv4_addr, 7782}, NODE_NETWORK};
+    CNode node{
+        /*id=*/7, /*sock=*/nullptr, address,
+        /*nKeyedNetGroupIn=*/6, /*nLocalHostNonceIn=*/7, CAddress{},
+        /*addrNameIn=*/std::string{}, ConnectionType::INBOUND,
+        /*inbound_onion=*/false};
+    m_node.peerman->InitializeNode(node, NODE_NETWORK);
+
+    CDataStream request{SER_NETWORK, PROTOCOL_VERSION};
+    request << uint256::ONEV;
+    request << std::vector<unsigned char>{0xff};
+    request << std::numeric_limits<unsigned int>::max();
+    request << static_cast<unsigned int>(0);
+    request << static_cast<unsigned char>(0);
+
+    governance->ProcessMessage(
+        &node, NetMsgType::MNGOVERNANCESYNC, request,
+        *m_node.connman, *m_node.peerman);
+
+    BOOST_CHECK(request.empty());
+    BOOST_CHECK(m_node.peerman->IsBanned(node.GetId()));
+    m_node.peerman->FinalizeNode(node);
+}
 
 //! Test resizing coins-related Chainstate caches during runtime.
 //!


### PR DESCRIPTION
## Summary

- validate legacy governance-sync Bloom filters at the deserialization boundary
- discourage peers that exceed the existing protocol limits
- add a regression for malformed legacy requests

## Testing

- `make -C src -j4 test/test_syscoin`
- `./src/test/test_syscoin --run_test=validation_chainstate_tests/legacy_governance_sync_rejects_oversized_bloom_filter --log_level=error`
- `./src/test/test_syscoin --run_test=validation_chainstate_tests --log_level=error`
