### PR TITLE
fix: recover cleanly from slow geth bootstrap

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -273,6 +273,7 @@ SYSCOIN_CORE_H = \
   node/context.h \
   node/database_args.h \
   node/eviction.h \
+  node/geth_startup.h \
   node/interface_ui.h \
   node/kernel_notifications.h \
   node/mempool_args.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -109,6 +109,7 @@ SYSCOIN_TESTS =\
   test/evodb_tests.cpp \
   test/flatfile_tests.cpp \
   test/fs_tests.cpp \
+  test/geth_startup_tests.cpp \
   test/getarg_tests.cpp \
   test/governance_validators_tests.cpp \
   test/hash_tests.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1970,8 +1970,8 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                 if (active_timeout == 0) {
                     LogPrintf("Waiting for sysgeth startup to complete before NEVM attach (%s%s)\n", stateStr, bootstrap_msg);
                 } else {
-                    const auto waited = std::chrono::duration_cast<std::chrono::seconds>(now - wait_start).count();
-                    LogPrintf("Waiting for sysgeth startup to complete before NEVM attach (%s%s), elapsed=%d timeout=%d seconds\n", stateStr, bootstrap_msg, waited, active_timeout);
+                    const auto phase_elapsed = geth_wait.ActiveElapsed(now).count();
+                    LogPrintf("Waiting for sysgeth startup to complete before NEVM attach (%s%s), phase_elapsed=%d timeout=%d seconds\n", stateStr, bootstrap_msg, phase_elapsed, active_timeout);
                 }
                 next_wait_log = now + std::chrono::seconds{DEFAULT_GETH_STARTUP_LOG_INTERVAL};
             }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -47,6 +47,7 @@
 #include <node/chainstate.h>
 #include <node/chainstatemanager_args.h>
 #include <node/context.h>
+#include <node/geth_startup.h>
 #include <node/interface_ui.h>
 #include <node/kernel_notifications.h>
 #include <node/mempool_args.h>
@@ -1942,9 +1943,10 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         const int64_t geth_startup_timeout = std::max<int64_t>(0, args.GetIntArg("-gethstartuptimeout", DEFAULT_GETH_STARTUP_TIMEOUT));
         const int64_t geth_bootstrap_startup_timeout = std::max<int64_t>(0, args.GetIntArg("-gethbootstrapstartuptimeout", DEFAULT_GETH_BOOTSTRAP_STARTUP_TIMEOUT));
         const auto wait_start = std::chrono::steady_clock::now();
-        auto wait_deadline = wait_start + std::chrono::seconds{geth_startup_timeout};
-        auto bootstrap_wait_deadline = wait_start + std::chrono::seconds{geth_bootstrap_startup_timeout};
-        bool bootstrap_wait_started{false};
+        node::GethStartupWaitState geth_wait{
+            wait_start,
+            std::chrono::seconds{geth_startup_timeout},
+            std::chrono::seconds{geth_bootstrap_startup_timeout}};
         auto next_wait_log = wait_start;
         uint64_t nHeightFromGeth{0};
         std::string stateStr;
@@ -1959,14 +1961,12 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
             const auto now = std::chrono::steady_clock::now();
             const std::string bootstrap_status = ReadGethStateBootstrapStatus(args.GetDataDirNet());
-            const bool bootstrap_active = !bootstrap_status.empty() && node.chainman->ActiveChainstate().IsGethNodeRunning();
-            if (bootstrap_active && !bootstrap_wait_started) {
-                bootstrap_wait_started = true;
-                bootstrap_wait_deadline = now + std::chrono::seconds{geth_bootstrap_startup_timeout};
-            }
+            const bool geth_running = node.chainman->ActiveChainstate().IsGethNodeRunning();
+            geth_wait.Observe(!bootstrap_status.empty(), geth_running, now);
+            const bool bootstrap_active = geth_wait.BootstrapActive();
             if (now >= next_wait_log) {
                 const std::string bootstrap_msg = bootstrap_active ? strprintf(", state bootstrap=%s", bootstrap_status) : "";
-                const int64_t active_timeout = bootstrap_active ? geth_bootstrap_startup_timeout : geth_startup_timeout;
+                const int64_t active_timeout = geth_wait.ActiveTimeout().count();
                 if (active_timeout == 0) {
                     LogPrintf("Waiting for sysgeth startup to complete before NEVM attach (%s%s)\n", stateStr, bootstrap_msg);
                 } else {
@@ -1976,10 +1976,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
                 next_wait_log = now + std::chrono::seconds{DEFAULT_GETH_STARTUP_LOG_INTERVAL};
             }
 
-            if (!bootstrap_active && geth_startup_timeout != 0 && now >= wait_deadline) {
-                break;
-            }
-            if (bootstrap_active && geth_bootstrap_startup_timeout != 0 && bootstrap_wait_started && now >= bootstrap_wait_deadline) {
+            if (geth_wait.Expired(now)) {
                 break;
             }
             for (int64_t slept_ms{0}; slept_ms < DEFAULT_GETH_STARTUP_RETRY_INTERVAL_MS && !ShutdownRequested(); slept_ms += 200) {

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -365,23 +365,45 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
 
     LOCK(cs_main);
 
+    ChainstateLoadOptions effective_options{options};
+    if (!effective_options.reindex && !effective_options.block_tree_db_in_memory) {
+        auto& pblocktree{chainman.m_blockman.m_block_tree_db};
+        pblocktree.reset();
+        pblocktree = std::make_unique<BlockTreeDB>(DBParams{
+            .path = chainman.m_options.datadir / "blocks" / "index",
+            .cache_bytes = static_cast<size_t>(cache_sizes.block_tree_db),
+            .memory_only = false,
+            .wipe_data = false,
+            .options = chainman.m_options.block_tree_db});
+        bool persisted_reindex{false};
+        pblocktree->ReadReindexing(persisted_reindex);
+        pblocktree.reset();
+        if (persisted_reindex) {
+            LogPrintf("Persisted reindex marker found before chainstate load; starting full block-file reindex.\n");
+            effective_options.reindex = true;
+            effective_options.fReindexGeth = true;
+            fReindex = true;
+            fReindexGeth = true;
+        }
+    }
+
     chainman.m_total_coinstip_cache = cache_sizes.coins;
     chainman.m_total_coinsdb_cache = cache_sizes.coins_db;
 
     // Load the fully validated chainstate.
-    chainman.InitializeChainstate(options.mempool);
+    chainman.InitializeChainstate(effective_options.mempool);
 
     // Load a chain created from a UTXO snapshot, if any exist.
     bool has_snapshot = chainman.DetectSnapshotChainstate();
 
-    if (has_snapshot && (options.reindex || options.reindex_chainstate)) {
+    if (has_snapshot && (effective_options.reindex || effective_options.reindex_chainstate)) {
         LogPrintf("[snapshot] deleting snapshot chainstate due to reindexing\n");
         if (!chainman.DeleteSnapshotChainstate()) {
             return {ChainstateLoadStatus::FAILURE_FATAL, Untranslated("Couldn't remove snapshot chainstate.")};
         }
     }
 
-    auto [init_status, init_error] = CompleteChainstateInitialization(chainman, cache_sizes, options);
+    auto [init_status, init_error] = CompleteChainstateInitialization(chainman, cache_sizes, effective_options);
     if (init_status != ChainstateLoadStatus::SUCCESS) {
         return {init_status, init_error};
     }
@@ -411,13 +433,13 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
         assert(!chainman.IsSnapshotActive());
         assert(!chainman.IsSnapshotValidated());
 
-        chainman.InitializeChainstate(options.mempool);
+        chainman.InitializeChainstate(effective_options.mempool);
 
         // A reload of the block index is required to recompute setBlockIndexCandidates
         // for the fully validated chainstate.
         chainman.ActiveChainstate().ClearBlockIndexCandidates();
 
-        auto [init_status, init_error] = CompleteChainstateInitialization(chainman, cache_sizes, options);
+        auto [init_status, init_error] = CompleteChainstateInitialization(chainman, cache_sizes, effective_options);
         if (init_status != ChainstateLoadStatus::SUCCESS) {
             return {init_status, init_error};
         }

--- a/src/node/geth_startup.h
+++ b/src/node/geth_startup.h
@@ -18,6 +18,8 @@ public:
     GethStartupWaitState(Clock::time_point start, Seconds normal_timeout, Seconds bootstrap_timeout)
         : m_normal_timeout{normal_timeout},
           m_bootstrap_timeout{bootstrap_timeout},
+          m_normal_start{start},
+          m_bootstrap_start{start},
           m_normal_deadline{start + normal_timeout},
           m_bootstrap_deadline{start + bootstrap_timeout}
     {
@@ -28,9 +30,11 @@ public:
         m_bootstrap_active = bootstrap_status_present && geth_running;
         if (m_bootstrap_active && !m_bootstrap_started) {
             m_bootstrap_started = true;
+            m_bootstrap_start = now;
             m_bootstrap_deadline = now + m_bootstrap_timeout;
         } else if (!bootstrap_status_present && geth_running && m_bootstrap_started && !m_bootstrap_completed) {
             m_bootstrap_completed = true;
+            m_normal_start = now;
             m_normal_deadline = now + m_normal_timeout;
         }
     }
@@ -40,6 +44,11 @@ public:
     Seconds ActiveTimeout() const
     {
         return m_bootstrap_active ? m_bootstrap_timeout : m_normal_timeout;
+    }
+
+    Seconds ActiveElapsed(Clock::time_point now) const
+    {
+        return std::chrono::duration_cast<Seconds>(now - (m_bootstrap_active ? m_bootstrap_start : m_normal_start));
     }
 
     bool Expired(Clock::time_point now) const
@@ -52,6 +61,8 @@ public:
 private:
     const Seconds m_normal_timeout;
     const Seconds m_bootstrap_timeout;
+    Clock::time_point m_normal_start;
+    Clock::time_point m_bootstrap_start;
     Clock::time_point m_normal_deadline;
     Clock::time_point m_bootstrap_deadline;
     bool m_bootstrap_started{false};

--- a/src/node/geth_startup.h
+++ b/src/node/geth_startup.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 The Syscoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef SYSCOIN_NODE_GETH_STARTUP_H
+#define SYSCOIN_NODE_GETH_STARTUP_H
+
+#include <chrono>
+
+namespace node {
+
+class GethStartupWaitState
+{
+public:
+    using Clock = std::chrono::steady_clock;
+    using Seconds = std::chrono::seconds;
+
+    GethStartupWaitState(Clock::time_point start, Seconds normal_timeout, Seconds bootstrap_timeout)
+        : m_normal_timeout{normal_timeout},
+          m_bootstrap_timeout{bootstrap_timeout},
+          m_normal_deadline{start + normal_timeout},
+          m_bootstrap_deadline{start + bootstrap_timeout}
+    {
+    }
+
+    void Observe(bool bootstrap_status_present, bool geth_running, Clock::time_point now)
+    {
+        m_bootstrap_active = bootstrap_status_present && geth_running;
+        if (m_bootstrap_active && !m_bootstrap_started) {
+            m_bootstrap_started = true;
+            m_bootstrap_deadline = now + m_bootstrap_timeout;
+        } else if (!bootstrap_status_present && geth_running && m_bootstrap_started && !m_bootstrap_completed) {
+            m_bootstrap_completed = true;
+            m_normal_deadline = now + m_normal_timeout;
+        }
+    }
+
+    bool BootstrapActive() const { return m_bootstrap_active; }
+
+    Seconds ActiveTimeout() const
+    {
+        return m_bootstrap_active ? m_bootstrap_timeout : m_normal_timeout;
+    }
+
+    bool Expired(Clock::time_point now) const
+    {
+        const Seconds timeout = ActiveTimeout();
+        if (timeout == Seconds::zero()) return false;
+        return now >= (m_bootstrap_active ? m_bootstrap_deadline : m_normal_deadline);
+    }
+
+private:
+    const Seconds m_normal_timeout;
+    const Seconds m_bootstrap_timeout;
+    Clock::time_point m_normal_deadline;
+    Clock::time_point m_bootstrap_deadline;
+    bool m_bootstrap_started{false};
+    bool m_bootstrap_completed{false};
+    bool m_bootstrap_active{false};
+};
+
+} // namespace node
+
+#endif // SYSCOIN_NODE_GETH_STARTUP_H

--- a/src/test/geth_startup_tests.cpp
+++ b/src/test/geth_startup_tests.cpp
@@ -18,10 +18,12 @@ BOOST_AUTO_TEST_CASE(bootstrap_completion_starts_fresh_normal_timeout)
 
     wait.Observe(/*bootstrap_status_present=*/true, /*geth_running=*/true, start + Seconds{2});
     BOOST_CHECK(wait.BootstrapActive());
+    BOOST_CHECK_EQUAL(wait.ActiveElapsed(start + Seconds{66}).count(), 64);
     BOOST_CHECK(!wait.Expired(start + Seconds{66}));
 
     wait.Observe(/*bootstrap_status_present=*/false, /*geth_running=*/true, start + Seconds{72});
     BOOST_CHECK(!wait.BootstrapActive());
+    BOOST_CHECK_EQUAL(wait.ActiveElapsed(start + Seconds{101}).count(), 29);
     BOOST_CHECK(!wait.Expired(start + Seconds{101}));
     BOOST_CHECK(wait.Expired(start + Seconds{102}));
 }

--- a/src/test/geth_startup_tests.cpp
+++ b/src/test/geth_startup_tests.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2026 The Syscoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <node/geth_startup.h>
+
+#include <boost/test/unit_test.hpp>
+
+using node::GethStartupWaitState;
+
+BOOST_AUTO_TEST_SUITE(geth_startup_tests)
+
+BOOST_AUTO_TEST_CASE(bootstrap_completion_starts_fresh_normal_timeout)
+{
+    using Seconds = GethStartupWaitState::Seconds;
+    const GethStartupWaitState::Clock::time_point start{};
+    GethStartupWaitState wait{start, Seconds{30}, Seconds{7200}};
+
+    wait.Observe(/*bootstrap_status_present=*/true, /*geth_running=*/true, start + Seconds{2});
+    BOOST_CHECK(wait.BootstrapActive());
+    BOOST_CHECK(!wait.Expired(start + Seconds{66}));
+
+    wait.Observe(/*bootstrap_status_present=*/false, /*geth_running=*/true, start + Seconds{72});
+    BOOST_CHECK(!wait.BootstrapActive());
+    BOOST_CHECK(!wait.Expired(start + Seconds{101}));
+    BOOST_CHECK(wait.Expired(start + Seconds{102}));
+}
+
+BOOST_AUTO_TEST_CASE(dead_geth_does_not_gain_post_bootstrap_grace)
+{
+    using Seconds = GethStartupWaitState::Seconds;
+    const GethStartupWaitState::Clock::time_point start{};
+    GethStartupWaitState wait{start, Seconds{30}, Seconds{7200}};
+
+    wait.Observe(/*bootstrap_status_present=*/true, /*geth_running=*/true, start + Seconds{2});
+    wait.Observe(/*bootstrap_status_present=*/true, /*geth_running=*/false, start + Seconds{20});
+    BOOST_CHECK(!wait.BootstrapActive());
+    BOOST_CHECK(wait.Expired(start + Seconds{30}));
+}
+
+BOOST_AUTO_TEST_CASE(zero_timeout_remains_unbounded)
+{
+    using Seconds = GethStartupWaitState::Seconds;
+    const GethStartupWaitState::Clock::time_point start{};
+    GethStartupWaitState wait{start, Seconds::zero(), Seconds::zero()};
+
+    wait.Observe(/*bootstrap_status_present=*/true, /*geth_running=*/true, start + Seconds{2});
+    BOOST_CHECK(!wait.Expired(start + Seconds{100000}));
+    wait.Observe(/*bootstrap_status_present=*/false, /*geth_running=*/true, start + Seconds{100001});
+    BOOST_CHECK(!wait.Expired(start + Seconds{200000}));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -5,6 +5,8 @@
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <kernel/disconnected_transactions.h>
+#include <node/blockstorage.h>
+#include <node/chainstate.h>
 #include <node/kernel_notifications.h>
 #include <node/utxo_snapshot.h>
 #include <random.h>
@@ -29,6 +31,59 @@
 using node::BlockManager;
 using node::KernelNotifications;
 using node::SnapshotMetadata;
+
+BOOST_FIXTURE_TEST_CASE(persisted_reindex_marker_forces_clean_block_index, ChainTestingSetup)
+{
+    struct ReindexFlagsGuard {
+        const bool reindex{node::fReindex.load()};
+        const bool reindex_geth{fReindexGeth.load()};
+        ~ReindexFlagsGuard()
+        {
+            node::fReindex = reindex;
+            fReindexGeth = reindex_geth;
+        }
+    } flags_guard;
+
+    ChainstateManager& chainman = *Assert(m_node.chainman);
+    const fs::path block_index_path = m_args.GetDataDirNet() / "blocks" / "index";
+    {
+        LOCK(::cs_main);
+        chainman.m_blockman.m_block_tree_db.reset();
+    }
+    {
+        kernel::BlockTreeDB block_tree{DBParams{
+            .path = block_index_path,
+            .cache_bytes = static_cast<size_t>(m_cache_sizes.block_tree_db),
+            .memory_only = false,
+            .wipe_data = true}};
+        BOOST_REQUIRE(block_tree.WriteFlag("reindex-sentinel", true));
+        BOOST_REQUIRE(block_tree.WriteReindexing(true));
+    }
+
+    node::fReindex = false;
+    fReindexGeth = false;
+    node::ChainstateLoadOptions options;
+    options.mempool = Assert(m_node.mempool.get());
+    options.block_tree_db_in_memory = false;
+    options.coins_db_in_memory = true;
+    options.connman = Assert(m_node.connman.get());
+    options.banman = Assert(m_node.banman.get());
+    options.peerman = Assert(m_node.peerman.get());
+
+    const auto [status, error] = node::LoadChainstate(chainman, m_cache_sizes, options);
+    BOOST_REQUIRE_MESSAGE(status == node::ChainstateLoadStatus::SUCCESS, error.original);
+    BOOST_CHECK(node::fReindex.load());
+    BOOST_CHECK(fReindexGeth.load());
+
+    {
+        LOCK(::cs_main);
+        bool sentinel{false};
+        BOOST_CHECK(!chainman.m_blockman.m_block_tree_db->ReadFlag("reindex-sentinel", sentinel));
+        bool reindexing{false};
+        chainman.m_blockman.m_block_tree_db->ReadReindexing(reindexing);
+        BOOST_CHECK(reindexing);
+    }
+}
 
 BOOST_FIXTURE_TEST_SUITE(validation_chainstatemanager_tests, TestingSetup)
 


### PR DESCRIPTION
## Summary

- keep the extended sysgeth startup allowance while state bootstrap is active
- start a fresh normal readiness window after bootstrap installation completes
- promote a persisted deep-lag recovery marker to a full block-file/NEVM reindex before loading stale chainstate
- add focused regressions for both startup recovery paths

## Verification

- `make -C src -j16 test/test_syscoin`
- `./src/test/test_syscoin --run_test=geth_startup_tests`
- `./src/test/test_syscoin --run_test=persisted_reindex_marker_forces_clean_block_index`
- `./src/test/test_syscoin --run_test=validation_chainstatemanager_tests`
- `./src/test/test_syscoin` (626 test cases)
- `git diff --check`
