### PR TITLE
fix(llmq): reject invalid DKG signatures

### DIFF
--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -204,6 +204,11 @@ bool CDKGSession::PreVerifyMessage(const CDKGContribution& qc, bool& retBan) con
         retBan = true;
         return false;
     }
+    if (!qc.sig.IsValid()) {
+        logger.Batch("invalid membersSig");
+        retBan = true;
+        return false;
+    }
 
     if (qc.contributions->blobs.size() != members.size()) {
         logger.Batch("invalid contributions count");
@@ -508,6 +513,11 @@ bool CDKGSession::PreVerifyMessage(const CDKGComplaint& qc, bool& retBan) const
         retBan = true;
         return false;
     }
+    if (!qc.sig.IsValid()) {
+        logger.Batch("invalid membersSig");
+        retBan = true;
+        return false;
+    }
     const auto& params = Params().GetConsensus().llmqTypeChainLocks;
     if (qc.badMembers.size() != (size_t)params.size) {
         logger.Batch("invalid badMembers bitset size");
@@ -696,6 +706,11 @@ bool CDKGSession::PreVerifyMessage(const CDKGJustification& qj, bool& retBan) co
     auto* member = GetMember(qj.proTxHash);
     if (member == nullptr) {
         logger.Batch("justifier not a member of this quorum, rejecting justification");
+        retBan = true;
+        return false;
+    }
+    if (!qj.sig.IsValid()) {
+        logger.Batch("invalid membersSig");
         retBan = true;
         return false;
     }

--- a/src/llmq/quorums_dkgsessionhandler.cpp
+++ b/src/llmq/quorums_dkgsessionhandler.cpp
@@ -344,6 +344,11 @@ std::set<NodeId> BatchVerifyMessageSigs(CDKGSession& session, const std::vector<
             ret.emplace(p.first);
             continue;
         }
+        if (!msg.sig.IsValid()) {
+            ret.emplace(p.first);
+            revertToSingleVerification = true;
+            continue;
+        }
 
         if (first) {
             aggSig = msg.sig;

--- a/src/test/llmq_dkg_tests.cpp
+++ b/src/test/llmq_dkg_tests.cpp
@@ -2,10 +2,39 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <chainparams.h>
+#include <evo/deterministicmns.h>
 #include <llmq/quorums_dkgsession.h>
+#include <llmq/quorums_dkgsessionmgr.h>
+#include <protocol.h>
+#include <test/util/setup_common.h>
+#include <validation.h>
+
 #include <boost/test/unit_test.hpp>
 
+#include <algorithm>
+#include <limits>
+#include <stdexcept>
+
 BOOST_AUTO_TEST_SUITE(llmq_dkg_tests)
+
+namespace {
+
+template <typename Message>
+Message WireRoundTrip(const Message& message)
+{
+    CDataStream stream{SER_NETWORK, PROTOCOL_VERSION};
+    stream << message;
+
+    Message decoded;
+    stream >> decoded;
+    if (!stream.empty()) {
+        throw std::runtime_error{"DKG message wire round-trip left trailing data"};
+    }
+    return decoded;
+}
+
+} // namespace
 
 BOOST_AUTO_TEST_CASE(llmq_dkgerror)
 {
@@ -18,6 +47,92 @@ BOOST_AUTO_TEST_CASE(llmq_dkgerror)
     BOOST_ASSERT(GetSimulatedErrorRate(llmq::DKGError::type::_COUNT) == 0.0);
     SetSimulatedDKGErrorRate(llmq::DKGError::type::_COUNT, 1.0);
     BOOST_ASSERT(GetSimulatedErrorRate(llmq::DKGError::type::_COUNT) == 0.0);
+}
+
+BOOST_FIXTURE_TEST_CASE(preverify_rejects_invalid_member_signatures, TestChain100Setup)
+{
+    using namespace llmq;
+
+    BOOST_REQUIRE(quorumDKGSessionManager != nullptr);
+    const CBlockIndex* quorum_base_block{WITH_LOCK(
+        cs_main, return m_node.chainman->ActiveChain().Tip())};
+    BOOST_REQUIRE(quorum_base_block != nullptr);
+
+    const auto& params{Params().GetConsensus().llmqTypeChainLocks};
+    BOOST_REQUIRE(params.size <= std::numeric_limits<uint8_t>::max());
+    CBLSSecretKey signing_key;
+    signing_key.MakeNewKey();
+    const bool use_legacy_bls{bls::bls_legacy_scheme.load()};
+
+    std::vector<CDeterministicMNCPtr> members;
+    members.reserve(params.size);
+    for (int i = 0; i < params.size; ++i) {
+        auto member{std::make_shared<CDeterministicMN>(i + 1)};
+        member->proTxHash = uint256{static_cast<uint8_t>(i + 1)};
+        auto state{std::make_shared<CDeterministicMNState>()};
+        if (i == 0) {
+            state->pubKeyOperator.Set(signing_key.GetPublicKey(), use_legacy_bls);
+        }
+        member->pdmnState = std::move(state);
+        members.emplace_back(std::move(member));
+    }
+
+    CBLSWorker bls_worker;
+    CDKGSession session{bls_worker, *quorumDKGSessionManager};
+    BOOST_REQUIRE(session.Init(quorum_base_block, members, uint256{}));
+
+    const auto sign = [&](auto& message) {
+        message.sig = signing_key.Sign(message.GetSignHash(), use_legacy_bls);
+        BOOST_REQUIRE(message.sig.IsValid());
+    };
+    const auto check_preverification = [&](const auto& message) {
+        static_assert(CBLSSignature::SerSize == 96);
+        const auto invalid_signature_bytes{message.sig.ToBytes(use_legacy_bls)};
+        BOOST_REQUIRE(std::all_of(
+            invalid_signature_bytes.begin(), invalid_signature_bytes.end(),
+            [](uint8_t byte) { return byte == 0; }));
+        const auto invalid_message{WireRoundTrip(message)};
+        BOOST_REQUIRE(!invalid_message.sig.IsValid());
+        bool ban{false};
+        BOOST_CHECK(!session.PreVerifyMessage(invalid_message, ban));
+        BOOST_CHECK(ban);
+
+        auto valid_message{message};
+        sign(valid_message);
+        valid_message = WireRoundTrip(valid_message);
+        BOOST_REQUIRE(valid_message.sig.IsValid());
+        BOOST_REQUIRE(valid_message.sig.VerifyInsecure(
+            members.front()->pdmnState->pubKeyOperator.Get(),
+            valid_message.GetSignHash(), use_legacy_bls));
+        ban = false;
+        BOOST_CHECK(session.PreVerifyMessage(valid_message, ban));
+        BOOST_CHECK(!ban);
+    };
+
+    CDKGContribution contribution;
+    contribution.quorumHash = quorum_base_block->GetBlockHash();
+    contribution.proTxHash = members.front()->proTxHash;
+    contribution.vvec = std::make_shared<std::vector<CBLSPublicKey>>();
+    for (int i = 0; i < params.threshold; ++i) {
+        CBLSSecretKey key;
+        key.MakeNewKey();
+        contribution.vvec->emplace_back(key.GetPublicKey());
+    }
+    contribution.contributions =
+        std::make_shared<CBLSIESMultiRecipientObjects<CBLSSecretKey>>();
+    contribution.contributions->blobs.resize(params.size);
+    check_preverification(contribution);
+
+    CDKGComplaint complaint{static_cast<size_t>(params.size)};
+    complaint.quorumHash = quorum_base_block->GetBlockHash();
+    complaint.proTxHash = members.front()->proTxHash;
+    check_preverification(complaint);
+
+    CDKGJustification justification;
+    justification.quorumHash = quorum_base_block->GetBlockHash();
+    justification.proTxHash = members.front()->proTxHash;
+    justification.contributions.push_back({0, signing_key});
+    check_preverification(justification);
 }
 
 


### PR DESCRIPTION
## Motivation

Legacy DKG contribution, complaint, and justification messages can deserialize an invalid member signature without throwing. Those messages currently pass preverification and reach batch aggregation, whose internal validity assertion can terminate the node.

## Changes

- reject and discourage invalid member signatures during DKG preverification
- keep a DKG-local validity guard immediately before batch aggregation
- retain the asserted BLS aggregation API as an internal invariant
- add wire-round-trip coverage for all three affected message types and cryptographically valid controls

This does not change consensus, storage, or wire formats.

## Testing

- `make -C src -j4 test/test_syscoin`
- `./src/test/test_syscoin --run_test=llmq_dkg_tests/preverify_rejects_invalid_member_signatures --log_level=error`
- `./src/test/test_syscoin --run_test=llmq_dkg_tests,bls_tests,llmq_sigshare_cache_tests --log_level=error`
- `./src/test/test_syscoin --log_level=error` (680 test cases)
