### PR TITLE
fix(llmq): validate DKG justification indices

### DIFF
--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -723,7 +723,7 @@ bool CDKGSession::PreVerifyMessage(const CDKGJustification& qj, bool& retBan) co
 
     std::set<size_t> contributionsSet;
     for (const auto& p : qj.contributions) {
-        if (p.index > members.size()) {
+        if (p.index >= members.size()) {
             logger.Batch("invalid contribution index");
             retBan = true;
             return false;

--- a/src/test/llmq_dkg_tests.cpp
+++ b/src/test/llmq_dkg_tests.cpp
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(llmq_dkgerror)
     BOOST_ASSERT(GetSimulatedErrorRate(llmq::DKGError::type::_COUNT) == 0.0);
 }
 
-BOOST_FIXTURE_TEST_CASE(preverify_rejects_invalid_member_signatures, TestChain100Setup)
+BOOST_FIXTURE_TEST_CASE(preverify_rejects_invalid_member_messages, TestChain100Setup)
 {
     using namespace llmq;
 
@@ -133,6 +133,22 @@ BOOST_FIXTURE_TEST_CASE(preverify_rejects_invalid_member_signatures, TestChain10
     justification.proTxHash = members.front()->proTxHash;
     justification.contributions.push_back({0, signing_key});
     check_preverification(justification);
+
+    justification.contributions.front().index =
+        static_cast<uint32_t>(members.size() - 1);
+    sign(justification);
+    auto decoded_justification{WireRoundTrip(justification)};
+    bool ban{true};
+    BOOST_CHECK(session.PreVerifyMessage(decoded_justification, ban));
+    BOOST_CHECK(!ban);
+
+    justification.contributions.front().index =
+        static_cast<uint32_t>(members.size());
+    sign(justification);
+    decoded_justification = WireRoundTrip(justification);
+    ban = false;
+    BOOST_CHECK(!session.PreVerifyMessage(decoded_justification, ban));
+    BOOST_CHECK(ban);
 }
 
 


### PR DESCRIPTION
## Motivation

A DKG justification contribution index equal to the quorum member count passes preverification because the upper-bound check is off by one. The verified message is later used with unchecked vector indexing, allowing a single selected malicious quorum member to trigger undefined behavior in peers processing the justification.

## Changes

- reject justification contribution indices greater than or equal to the member count
- retain the existing punishment behavior for malformed member messages
- add signed, wire-round-tripped coverage for the final valid index and the one-past boundary

This does not change consensus, storage, or wire formats. Honest justification generation already emits only indices below the member count.

This PR is stacked on #612 so the shared DKG test fixture is not duplicated. It can be retargeted to `master` after #612 merges.

## Testing

- pre-fix regression: failed because `index == members.size()` was accepted and not punished
- `./test/test_syscoin --run_test=llmq_dkg_tests/preverify_rejects_invalid_member_messages --log_level=error`
- `./test/test_syscoin --run_test=llmq_dkg_tests,bls_tests,llmq_sigshare_cache_tests --log_level=error` (35 test cases)
- `./test/test_syscoin --log_level=error` (680 test cases)
- `git diff --check`
