### PR TITLE
fix(llmq): bound bitset message decoding

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -118,6 +118,7 @@ SYSCOIN_TESTS =\
   test/interfaces_tests.cpp \
   test/key_tests.cpp \
   test/llmq_dkg_tests.cpp \
+  test/llmq_signing_shares_tests.cpp \
   test/llmq_sigshare_cache_tests.cpp \
   test/logging_tests.cpp \
   test/mempool_tests.cpp \

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -80,6 +80,8 @@ enum
 
 };
 
+static constexpr int MAX_LLMQ_SIZE{400};
+
 // Configures a LLMQ and its DKG
 // See https://github.com/dashpay/dips/blob/master/dip-0006.md for more details
 struct LLMQParams {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1198,7 +1198,8 @@ bool AppInitParameterInteraction(const ArgsManager& args)
             std::string s = args.GetArg("-llmqtestparams", "");
             std::vector<std::string> v = SplitString(s, ':');
             int size, threshold;
-            if (v.size() != 2 || !ParseInt32(v[0], &size) || !ParseInt32(v[1], &threshold)) {
+            if (v.size() != 2 || !ParseInt32(v[0], &size) || !ParseInt32(v[1], &threshold) ||
+                size <= 0 || size > Consensus::MAX_LLMQ_SIZE || threshold <= 0 || threshold > size) {
                 return InitError(Untranslated("Invalid -llmqtestparams specified"));
             }
             UpdateLLMQTestParams(size, threshold);

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -90,6 +90,8 @@ static CBlock CreateGenesisBlock(uint32_t nTime, uint32_t nNonce, uint32_t nBits
     return CreateGenesisBlock(pszTimestamp, genesisOutputScript, nTime, nNonce, nBits, nVersion, genesisReward);
 }
 void CChainParams::UpdateLLMQTestParams(int size, int threshold) {
+    assert(size > 0 && size <= Consensus::MAX_LLMQ_SIZE);
+    assert(threshold > 0 && threshold <= size);
     auto& params = consensus.llmqTypeChainLocks;
     params.size = size;
     params.minSize = threshold;

--- a/src/llmq/quorums_btccheckpoints.h
+++ b/src/llmq/quorums_btccheckpoints.h
@@ -6,6 +6,7 @@
 #define SYSCOIN_LLMQ_QUORUMS_BTCCHECKPOINTS_H
 
 #include <bls/bls.h>
+#include <consensus/params.h>
 #include <llmq/quorums_signing.h>
 #include <uint256.h>
 
@@ -58,7 +59,7 @@ public:
 
     SERIALIZE_METHODS(CBTCCheckpointSig, obj) {
         READWRITE(obj.nHeight, obj.sysHash, obj.sig);
-        READWRITE(DYNBITSET(obj.signers));
+        READWRITE(DYNBITSET(obj.signers, Consensus::MAX_LLMQ_SIZE));
     }
 
     bool IsNull() const;
@@ -185,4 +186,3 @@ extern CBTCCheckpointsHandler* btcCheckpointsHandler;
 } // namespace llmq
 
 #endif // SYSCOIN_LLMQ_QUORUMS_BTCCHECKPOINTS_H
-

--- a/src/llmq/quorums_chainlocks.h
+++ b/src/llmq/quorums_chainlocks.h
@@ -5,6 +5,7 @@
 #ifndef SYSCOIN_LLMQ_QUORUMS_CHAINLOCKS_H
 #define SYSCOIN_LLMQ_QUORUMS_CHAINLOCKS_H
 
+#include <consensus/params.h>
 #include <kernel/cs_main.h>
 #include <llmq/quorums_signing.h>
 #include <atomic>
@@ -42,7 +43,7 @@ public:
     CChainLockSig() = default;
     SERIALIZE_METHODS(CChainLockSig, obj) {
         READWRITE(obj.nHeight, obj.blockHash, obj.sig);
-        READWRITE(DYNBITSET(obj.signers));
+        READWRITE(DYNBITSET(obj.signers, Consensus::MAX_LLMQ_SIZE));
     }
     // Equality operator
     bool operator==(const CChainLockSig& other) const

--- a/src/llmq/quorums_commitment.cpp
+++ b/src/llmq/quorums_commitment.cpp
@@ -152,7 +152,7 @@ uint256 BuildCommitmentHash(const uint256& blockHash, const std::vector<bool>& v
 {
     CHashWriter hw(SER_GETHASH, 0);
     hw << blockHash;
-    hw << DYNBITSET(validMembers);
+    hw << DYNBITSET(validMembers, Consensus::MAX_LLMQ_SIZE);
     hw << pubKey;
     hw << vvecHash;
     return hw.GetHash();

--- a/src/llmq/quorums_commitment.h
+++ b/src/llmq/quorums_commitment.h
@@ -5,6 +5,7 @@
 #ifndef SYSCOIN_LLMQ_QUORUMS_COMMITMENT_H
 #define SYSCOIN_LLMQ_QUORUMS_COMMITMENT_H
 
+#include <consensus/params.h>
 #include <llmq/quorums_utils.h>
 #include <primitives/transaction.h>
 #include <bls/bls.h>
@@ -67,8 +68,8 @@ public:
                 obj.quorumHash
         );
         READWRITE(
-                DYNBITSET(obj.signers),
-                DYNBITSET(obj.validMembers),
+                DYNBITSET(obj.signers, Consensus::MAX_LLMQ_SIZE),
+                DYNBITSET(obj.validMembers, Consensus::MAX_LLMQ_SIZE),
                 CBLSPublicKeyVersionWrapper(const_cast<CBLSPublicKey&>(obj.quorumPublicKey), (obj.nVersion == LEGACY_BLS_NON_INDEXED_QUORUM_VERSION)),
                 obj.quorumVvecHash,
                 CBLSSignatureVersionWrapper(const_cast<CBLSSignature&>(obj.quorumSig), (obj.nVersion == LEGACY_BLS_NON_INDEXED_QUORUM_VERSION)),

--- a/src/llmq/quorums_dkgsession.h
+++ b/src/llmq/quorums_dkgsession.h
@@ -98,8 +98,8 @@ public:
         READWRITE(
                 obj.quorumHash,
                 obj.proTxHash,
-                DYNBITSET(obj.badMembers),
-                DYNBITSET(obj.complainForMembers),
+                DYNBITSET(obj.badMembers, Consensus::MAX_LLMQ_SIZE),
+                DYNBITSET(obj.complainForMembers, Consensus::MAX_LLMQ_SIZE),
                 obj.sig
                 );
     }
@@ -175,7 +175,7 @@ public:
         READWRITE(
                 obj.quorumHash,
                 obj.proTxHash,
-                DYNBITSET(obj.validMembers),
+                DYNBITSET(obj.validMembers, Consensus::MAX_LLMQ_SIZE),
                 obj.quorumPublicKey,
                 obj.quorumVvecHash,
                 obj.quorumSig,

--- a/src/llmq/quorums_signing_shares.cpp
+++ b/src/llmq/quorums_signing_shares.cpp
@@ -218,10 +218,8 @@ void CSigSharesManager::ProcessMessage(const CNode* pfrom, const std::string& st
 
     if (sporkManager->IsSporkActive(SPORK_21_QUORUM_ALL_CONNECTED) && strCommand == NetMsgType::QSIGSHARE) {
         std::vector<CSigShare> receivedSigShares;
-        vRecv >> receivedSigShares;
-
-        if (receivedSigShares.size() > MAX_MSGS_SIG_SHARES) {
-            LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- too many sigs in QSIGSHARE message. cnt=%d, max=%d, node=%d\n", __func__, receivedSigShares.size(), MAX_MSGS_SIG_SHARES, pfrom->GetId());
+        if (!UnserializeVectorWithMaxSize(vRecv, receivedSigShares, MAX_MSGS_SIG_SHARES)) {
+            LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- too many sigs in QSIGSHARE message. max=%d, node=%d\n", __func__, MAX_MSGS_SIG_SHARES, pfrom->GetId());
             BanNode(pfrom->GetId());
             return;
         }
@@ -233,9 +231,8 @@ void CSigSharesManager::ProcessMessage(const CNode* pfrom, const std::string& st
 
     if (strCommand == NetMsgType::QSIGSESANN) {
         std::vector<CSigSesAnn> msgs;
-        vRecv >> msgs;
-        if (msgs.size() > MAX_MSGS_CNT_QSIGSESANN) {
-            LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- too many announcements in QSIGSESANN message. cnt=%d, max=%d, node=%d\n", __func__, msgs.size(), MAX_MSGS_CNT_QSIGSESANN, pfrom->GetId());
+        if (!UnserializeVectorWithMaxSize(vRecv, msgs, MAX_MSGS_CNT_QSIGSESANN)) {
+            LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- too many announcements in QSIGSESANN message. max=%d, node=%d\n", __func__, MAX_MSGS_CNT_QSIGSESANN, pfrom->GetId());
             BanNode(pfrom->GetId());
             return;
         }
@@ -246,9 +243,8 @@ void CSigSharesManager::ProcessMessage(const CNode* pfrom, const std::string& st
         }
     } else if (strCommand == NetMsgType::QSIGSHARESINV) {
         std::vector<CSigSharesInv> msgs;
-        vRecv >> msgs;
-        if (msgs.size() > MAX_MSGS_CNT_QSIGSHARESINV) {
-            LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- too many invs in QSIGSHARESINV message. cnt=%d, max=%d, node=%d\n", __func__, msgs.size(), MAX_MSGS_CNT_QSIGSHARESINV, pfrom->GetId());
+        if (!UnserializeVectorWithMaxSize(vRecv, msgs, MAX_MSGS_CNT_QSIGSHARESINV)) {
+            LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- too many invs in QSIGSHARESINV message. max=%d, node=%d\n", __func__, MAX_MSGS_CNT_QSIGSHARESINV, pfrom->GetId());
             BanNode(pfrom->GetId());
             return;
         }
@@ -259,9 +255,8 @@ void CSigSharesManager::ProcessMessage(const CNode* pfrom, const std::string& st
         }
     } else if (strCommand == NetMsgType::QGETSIGSHARES) {
         std::vector<CSigSharesInv> msgs;
-        vRecv >> msgs;
-        if (msgs.size() > MAX_MSGS_CNT_QGETSIGSHARES) {
-            LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- too many invs in QGETSIGSHARES message. cnt=%d, max=%d, node=%d\n", __func__, msgs.size(), MAX_MSGS_CNT_QGETSIGSHARES, pfrom->GetId());
+        if (!UnserializeVectorWithMaxSize(vRecv, msgs, MAX_MSGS_CNT_QGETSIGSHARES)) {
+            LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- too many invs in QGETSIGSHARES message. max=%d, node=%d\n", __func__, MAX_MSGS_CNT_QGETSIGSHARES, pfrom->GetId());
             BanNode(pfrom->GetId());
             return;
         }
@@ -272,7 +267,11 @@ void CSigSharesManager::ProcessMessage(const CNode* pfrom, const std::string& st
         }
     } else if (strCommand == NetMsgType::QBSIGSHARES) {
         std::vector<CBatchedSigShares> msgs;
-        vRecv >> msgs;
+        if (!UnserializeVectorWithMaxSize(vRecv, msgs, MAX_MSGS_TOTAL_BATCHED_SIGS)) {
+            LogPrint(BCLog::LLMQ_SIGS, "CSigSharesManager::%s -- too many batches in QBSIGSHARES message. max=%d, node=%d\n", __func__, MAX_MSGS_TOTAL_BATCHED_SIGS, pfrom->GetId());
+            BanNode(pfrom->GetId());
+            return;
+        }
         size_t totalSigsCount = 0;
         for (const auto& bs : msgs) {
             totalSigsCount += bs.sigShares.size();

--- a/src/llmq/quorums_signing_shares.h
+++ b/src/llmq/quorums_signing_shares.h
@@ -5,6 +5,7 @@
 #ifndef SYSCOIN_LLMQ_QUORUMS_SIGNING_SHARES_H
 #define SYSCOIN_LLMQ_QUORUMS_SIGNING_SHARES_H
 
+#include <consensus/params.h>
 #include <llmq/quorums_signing.h>
 
 #include <serialize.h>
@@ -117,7 +118,7 @@ public:
         uint64_t invSize = obj.inv.size();
         READWRITE(VARINT(obj.sessionId), COMPACTSIZE(invSize));
         autobitset_t bitset = std::make_pair(obj.inv, (size_t)invSize);
-        READWRITE(AUTOBITSET(bitset));
+        READWRITE(AUTOBITSET(bitset, Consensus::MAX_LLMQ_SIZE));
         SER_READ(obj, obj.inv = bitset.first);
     }
 
@@ -140,7 +141,14 @@ public:
 public:
     SERIALIZE_METHODS(CBatchedSigShares, obj)
     {
-        READWRITE(VARINT(obj.sessionId), obj.sigShares);
+        READWRITE(VARINT(obj.sessionId));
+        if constexpr (Operation::ForRead()) {
+            if (!UnserializeVectorWithMaxSize(s, obj.sigShares, Consensus::MAX_LLMQ_SIZE)) {
+                throw std::ios_base::failure("batched sig shares size exceeds maximum quorum size");
+            }
+        } else {
+            READWRITE(obj.sigShares);
+        }
     }
 
     [[nodiscard]] std::string ToInvString() const;
@@ -360,8 +368,7 @@ private:
     static constexpr size_t MAX_MSGS_CNT_QSIGSESANN{100};
     static constexpr size_t MAX_MSGS_CNT_QGETSIGSHARES{200};
     static constexpr size_t MAX_MSGS_CNT_QSIGSHARESINV{200};
-    // 400 is the maximum quorum size, so this is also the maximum number of sigs we need to support
-    static constexpr size_t MAX_MSGS_TOTAL_BATCHED_SIGS{400};
+    static constexpr size_t MAX_MSGS_TOTAL_BATCHED_SIGS{Consensus::MAX_LLMQ_SIZE};
 
     static constexpr int64_t EXP_SEND_FOR_RECOVERY_TIMEOUT{2000};
     static constexpr int64_t MAX_SEND_FOR_RECOVERY_TIMEOUT{10000};

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -10,6 +10,7 @@
 #include <compat/endian.h>
 
 #include <algorithm>
+#include <concepts>
 #include <cstdint>
 #include <cstring>
 #include <ios>
@@ -528,12 +529,24 @@ void WriteFixedBitSet(Stream& s, const std::vector<bool>& vec, size_t size)
     s.write(MakeByteSpan(vBytes));
 }
 
-template<typename Stream>
+/** A stream that reports how many bytes remain available to read. */
+template<typename S>
+concept SizedStream = requires(const S& s) { { s.size() } -> std::convertible_to<size_t>; };
+
+template<SizedStream Stream>
 void ReadFixedBitSet(Stream& s, std::vector<bool>& vec, size_t size)
 {
+    const size_t nbytes = (size + 7) / 8;
+    // Dense bitsets require exactly ceil(size / 8) payload bytes. Check that invariant before
+    // allocating from a wire-declared size so truncated messages cannot amplify a few bytes into
+    // multi-megabyte temporary allocations.
+    if (nbytes > s.size()) {
+        throw std::ios_base::failure("ReadFixedBitSet(): declared size exceeds remaining bytes");
+    }
+
     vec.resize(size);
 
-    std::vector<unsigned char> vBytes((size + 7) / 8);
+    std::vector<unsigned char> vBytes(nbytes);
     s.read(MakeWritableByteSpan(vBytes));
     for (size_t p = 0; p < size; p++)
         vec[p] = (vBytes[p / 8] & (1 << (p % 8))) != 0;
@@ -568,21 +581,17 @@ void ReadFixedVarIntsBitSet(Stream& s, std::vector<bool>& vec, size_t size)
 {
     vec.assign(size, false);
 
-    int32_t last = -1;
+    size_t index_plus_one{0};
     while(true) {
         uint32_t offset = ReadVarInt<Stream, VarIntMode::DEFAULT, uint32_t>(s);
         if (offset == 0) {
             break;
         }
-        int32_t idx = last + offset;
-        if (idx >= (int32_t)size) {
+        if (offset > size - index_plus_one) {
             throw std::ios_base::failure("out of bounds index");
         }
-        if (last != -1 && idx <= last) {
-            throw std::ios_base::failure("offset overflow");
-        }
-        vec[idx] = true;
-        last = idx;
+        index_plus_one += offset;
+        vec[index_plus_one - 1] = true;
     }
 }
 
@@ -681,10 +690,11 @@ static inline Wrapper<Formatter, T&> Using(T&& t) { return Wrapper<Formatter, T&
 #define LIMITED_STRING(obj,n) Using<LimitedStringFormatter<n>>(obj)
 
 // SYSCOIN
-#define DYNBITSET(obj) Using<DynamicBitSetFormatter>(obj)
-#define AUTOBITSET(obj) Using<AutoBitSetFormatter>(obj)
+#define DYNBITSET(obj, limit) Using<DynamicBitSetFormatter<limit>>(obj)
+#define AUTOBITSET(obj, limit) Using<AutoBitSetFormatter<limit>>(obj)
 
 /** TODO: describe DynamicBitSet */
+template<size_t Limit>
 struct DynamicBitSetFormatter
 {
     template<typename Stream>
@@ -697,13 +707,18 @@ struct DynamicBitSetFormatter
     template<typename Stream>
     void Unser(Stream& s, std::vector<bool>& vec)
     {
-        ReadFixedBitSet(s, vec, ReadCompactSize(s));
+        const size_t size = ReadCompactSize(s);
+        if (size > Limit) {
+            throw std::ios_base::failure("DynamicBitSetFormatter: size exceeds limit");
+        }
+        ReadFixedBitSet(s, vec, size);
     }
 };
 
 /**
  * Serializes either as a CFixedBitSet or CFixedVarIntsBitSet, depending on which would give a smaller size
  */
+template<size_t Limit>
 struct AutoBitSetFormatter
 {
     template<typename Stream>
@@ -715,6 +730,9 @@ struct AutoBitSetFormatter
     template<typename Stream>
     void Unser(Stream& s, autobitset_t& item)
     {
+        if (item.second > Limit) {
+            throw std::ios_base::failure("AutoBitSetFormatter: size exceeds limit");
+        }
         ReadAutoBitSet(s, item);
     }
 };
@@ -859,6 +877,27 @@ struct LimitedStringFormatter
     }
 };
 
+namespace detail {
+template<class Formatter, typename Stream, typename V>
+void UnserializeVectorContents(Stream& s, V& v, size_t size)
+{
+    Formatter formatter;
+    size_t allocated{0};
+    while (allocated < size) {
+        // For DoS prevention, do not blindly allocate as much as the stream claims to contain.
+        // Instead, allocate in 5MiB batches, so that an attacker actually needs to provide
+        // X MiB of data to make us allocate X+5 Mib.
+        static_assert(sizeof(typename V::value_type) <= MAX_VECTOR_ALLOCATE, "Vector element size too large");
+        allocated = std::min(size, allocated + MAX_VECTOR_ALLOCATE / sizeof(typename V::value_type));
+        v.reserve(allocated);
+        while (v.size() < allocated) {
+            v.emplace_back();
+            formatter.Unser(s, v.back());
+        }
+    }
+}
+} // namespace detail
+
 /** Formatter to serialize/deserialize vector elements using another formatter
  *
  * Example:
@@ -888,22 +927,8 @@ struct VectorFormatter
     template<typename Stream, typename V>
     void Unser(Stream& s, V& v)
     {
-        Formatter formatter;
         v.clear();
-        size_t size = ReadCompactSize(s);
-        size_t allocated = 0;
-        while (allocated < size) {
-            // For DoS prevention, do not blindly allocate as much as the stream claims to contain.
-            // Instead, allocate in 5MiB batches, so that an attacker actually needs to provide
-            // X MiB of data to make us allocate X+5 Mib.
-            static_assert(sizeof(typename V::value_type) <= MAX_VECTOR_ALLOCATE, "Vector element size too large");
-            allocated = std::min(size, allocated + MAX_VECTOR_ALLOCATE / sizeof(typename V::value_type));
-            v.reserve(allocated);
-            while (v.size() < allocated) {
-                v.emplace_back();
-                formatter.Unser(s, v.back());
-            }
-        }
+        detail::UnserializeVectorContents<Formatter>(s, v, ReadCompactSize(s));
     };
 };
 
@@ -1011,6 +1036,23 @@ struct DefaultFormatter
     template<typename Stream, typename T>
     static void Unser(Stream& s, T& t) { Unserialize(s, t); }
 };
+
+/**
+ * Deserialize a vector only when its declared element count is within the
+ * caller's protocol limit. Returns false without reading any elements when
+ * the limit is exceeded.
+ */
+template<class Formatter = DefaultFormatter, typename Stream, typename V>
+[[nodiscard]] bool UnserializeVectorWithMaxSize(Stream& s, V& v, size_t max_size)
+{
+    v.clear();
+    const size_t size = ReadCompactSize(s);
+    if (size > max_size) {
+        return false;
+    }
+    detail::UnserializeVectorContents<Formatter>(s, v, size);
+    return true;
+}
 
 
 

--- a/src/test/llmq_signing_shares_tests.cpp
+++ b/src/test/llmq_signing_shares_tests.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2026 The Syscoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <consensus/params.h>
+#include <evo/deterministicmns.h>
+#include <llmq/quorums_signing_shares.h>
+
+#include <protocol.h>
+#include <serialize.h>
+#include <streams.h>
+#include <util/strencodings.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <vector>
+
+BOOST_AUTO_TEST_SUITE(llmq_signing_shares_tests)
+
+BOOST_AUTO_TEST_CASE(inventory_size_is_bounded_before_allocation)
+{
+    {
+        CDataStream stream{ParseHex("00fd90010100"), SER_NETWORK, PROTOCOL_VERSION};
+        llmq::CSigSharesInv inventory;
+        BOOST_REQUIRE_NO_THROW(stream >> inventory);
+        BOOST_CHECK(stream.empty());
+        BOOST_CHECK_EQUAL(inventory.inv.size(), Consensus::MAX_LLMQ_SIZE);
+        BOOST_CHECK_EQUAL(inventory.CountSet(), 0U);
+    }
+
+    for (const auto& wire : {"00fd91010100", "00fe000000020100"}) {
+        CDataStream stream{ParseHex(wire), SER_NETWORK, PROTOCOL_VERSION};
+        llmq::CSigSharesInv inventory;
+        BOOST_CHECK_THROW(stream >> inventory, std::ios_base::failure);
+        BOOST_CHECK(inventory.inv.empty());
+        BOOST_CHECK_EQUAL(stream.size(), 2U);
+    }
+
+    llmq::CSigSharesInv dense;
+    dense.sessionId = 7;
+    dense.inv.assign(Consensus::MAX_LLMQ_SIZE, true);
+    CDataStream stream{SER_NETWORK, PROTOCOL_VERSION};
+    stream << dense;
+    llmq::CSigSharesInv decoded;
+    BOOST_REQUIRE_NO_THROW(stream >> decoded);
+    BOOST_CHECK(stream.empty());
+    BOOST_CHECK_EQUAL(decoded.sessionId, dense.sessionId);
+    BOOST_CHECK(decoded.inv == dense.inv);
+}
+
+BOOST_AUTO_TEST_CASE(inventory_vector_count_is_bounded_before_elements)
+{
+    const std::vector<uint8_t> element{ParseHex("00fd90010100")};
+
+    std::vector<uint8_t> accepted_wire{0xc8};
+    for (size_t i = 0; i < 200; ++i) {
+        accepted_wire.insert(accepted_wire.end(), element.begin(), element.end());
+    }
+    CDataStream accepted_stream{accepted_wire, SER_NETWORK, PROTOCOL_VERSION};
+    std::vector<llmq::CSigSharesInv> accepted;
+    BOOST_REQUIRE(UnserializeVectorWithMaxSize(accepted_stream, accepted, 200));
+    BOOST_CHECK(accepted_stream.empty());
+    BOOST_CHECK_EQUAL(accepted.size(), 200U);
+
+    std::vector<uint8_t> rejected_wire{0xc9};
+    rejected_wire.insert(rejected_wire.end(), element.begin(), element.end());
+    CDataStream rejected_stream{rejected_wire, SER_NETWORK, PROTOCOL_VERSION};
+    std::vector<llmq::CSigSharesInv> rejected;
+    BOOST_CHECK(!UnserializeVectorWithMaxSize(rejected_stream, rejected, 200));
+    BOOST_CHECK(rejected.empty());
+    BOOST_CHECK_EQUAL(rejected_stream.size(), element.size());
+}
+
+BOOST_AUTO_TEST_CASE(batched_share_count_is_bounded_before_allocation)
+{
+    CDataStream stream{ParseHex("00fd91010000ff"), SER_NETWORK, PROTOCOL_VERSION};
+    llmq::CBatchedSigShares batch;
+    BOOST_CHECK_THROW(stream >> batch, std::ios_base::failure);
+    BOOST_CHECK(batch.sigShares.empty());
+    BOOST_CHECK_EQUAL(stream.size(), 3U);
+}
+
+BOOST_AUTO_TEST_CASE(sparse_inventory_offsets_are_checked_before_indexing)
+{
+    {
+        CDataStream stream{ParseHex("01010186fefeff0100"), SER_NETWORK, PROTOCOL_VERSION};
+        llmq::CSigSharesInv inventory;
+        BOOST_CHECK_THROW(stream >> inventory, std::ios_base::failure);
+        BOOST_CHECK_EQUAL(stream.size(), 1U);
+    }
+
+    {
+        CDataStream stream{ParseHex("0103010300"), SER_NETWORK, PROTOCOL_VERSION};
+        llmq::CSigSharesInv inventory;
+        BOOST_REQUIRE_NO_THROW(stream >> inventory);
+        BOOST_CHECK(stream.empty());
+        BOOST_REQUIRE_EQUAL(inventory.inv.size(), 3U);
+        BOOST_CHECK(!inventory.inv[0]);
+        BOOST_CHECK(!inventory.inv[1]);
+        BOOST_CHECK(inventory.inv[2]);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -6,6 +6,7 @@
 #include <evo/specialtx.h>
 #include <hash.h>
 #include <llmq/quorums_btccheckpoints.h>
+#include <llmq/quorums_commitment.h>
 #include <primitives/block.h>
 #include <serialize.h>
 #include <script/script.h>
@@ -188,6 +189,56 @@ BOOST_AUTO_TEST_CASE(vector_bool)
 
     BOOST_CHECK(vec1 == std::vector<uint8_t>(vec2.begin(), vec2.end()));
     BOOST_CHECK((HashWriter{} << vec1).GetHash() == (HashWriter{} << vec2).GetHash());
+}
+
+static bool isBitSetSizeException(const std::ios_base::failure& ex)
+{
+    const std::ios_base::failure expected("ReadFixedBitSet(): declared size exceeds remaining bytes");
+    return strcmp(expected.what(), ex.what()) == 0;
+}
+
+static bool isBitSetLimitException(const std::ios_base::failure& ex)
+{
+    const std::ios_base::failure expected("DynamicBitSetFormatter: size exceeds limit");
+    return strcmp(expected.what(), ex.what()) == 0;
+}
+
+BOOST_AUTO_TEST_CASE(dynbitset_rejects_underfilled_payload_before_allocation)
+{
+    CDataStream stream{SER_NETWORK, PROTOCOL_VERSION};
+    const std::vector<bool> original{true, false, true};
+    std::vector<bool> decoded{original};
+    BOOST_CHECK_EXCEPTION(ReadFixedBitSet(stream, decoded, 1'000'000), std::ios_base::failure, isBitSetSizeException);
+    BOOST_CHECK(decoded == original);
+}
+
+BOOST_AUTO_TEST_CASE(dynbitset_maximum_quorum_size_roundtrip)
+{
+    std::vector<bool> original(Consensus::MAX_LLMQ_SIZE, false);
+    original.front() = true;
+    original.back() = true;
+
+    CDataStream stream{SER_NETWORK, PROTOCOL_VERSION};
+    stream << DYNBITSET(original, Consensus::MAX_LLMQ_SIZE);
+
+    std::vector<bool> decoded;
+    BOOST_REQUIRE_NO_THROW(stream >> DYNBITSET(decoded, Consensus::MAX_LLMQ_SIZE));
+    BOOST_CHECK(stream.empty());
+    BOOST_CHECK(decoded == original);
+}
+
+BOOST_AUTO_TEST_CASE(qfcommitment_rejects_underfilled_signers_before_allocation)
+{
+    CDataStream stream{SER_NETWORK, PROTOCOL_VERSION};
+    stream << static_cast<uint16_t>(llmq::CFinalCommitment::LEGACY_BLS_NON_INDEXED_QUORUM_VERSION);
+    stream << uint256{};
+    WriteCompactSize(stream, MAX_SIZE);
+    stream << uint8_t{0xaa};
+
+    llmq::CFinalCommitment commitment;
+    BOOST_CHECK_EXCEPTION(stream >> commitment, std::ios_base::failure, isBitSetLimitException);
+    BOOST_CHECK(commitment.signers.empty());
+    BOOST_CHECK_EQUAL(stream.size(), 1U);
 }
 
 BOOST_AUTO_TEST_CASE(noncanonical)


### PR DESCRIPTION
## Motivation

LLMQ bitset and sigshare message decoders trusted wire-declared sizes until after allocation or element decoding. This allowed:

- sparse sigshare inventories to retain roughly 800 MiB from a roughly 1.6 KiB message;
- an overflowing sparse offset to reach an out-of-bounds `vector<bool>` write;
- truncated dense LLMQ bitsets (including `qfcommit`) to trigger repeatable multi-megabyte allocations.

## Changes

- require an explicit shared 400-member ceiling for every LLMQ `DYNBITSET` and `AUTOBITSET` field;
- check dense payload availability before allocating;
- use overflow-safe sparse-offset arithmetic;
- enforce sigshare outer and inner vector limits before decoding elements;
- reject inconsistent `-llmqtestparams` overrides;
- add canonical valid and malicious wire regressions.

The dense pre-allocation invariant follows the same approach as [Dash Core #7532](https://github.com/dashpay/dash/pull/7532).

## Compatibility

Valid wire serialization, hashes, and consensus behavior are unchanged. All shipped quorum profiles are at or below 400 members, and the exact 400-member boundary is covered by round-trip tests.

## Testing

- `make -C src -j4 test/test_syscoin`
- `./src/test/test_syscoin --run_test=serialize_tests,llmq_signing_shares_tests,llmq_sigshare_cache_tests --log_level=error` (37 cases)
- `./src/test/test_syscoin --log_level=error` (686 cases)
- `make -C src -j4 syscoind`
- invalid `-llmqtestparams=401:300` startup rejection
