### PR TITLE
fix(llmq): validate DKG justification indices

### DIFF
--- a/src/llmq/quorums_dkgsession.cpp
+++ b/src/llmq/quorums_dkgsession.cpp
@@ -723,7 +723,7 @@ bool CDKGSession::PreVerifyMessage(const CDKGJustification& qj, bool& retBan) co
 
     std::set<size_t> contributionsSet;
     for (const auto& p : qj.contributions) {
-        if (p.index > members.size()) {
+        if (p.index >= members.size()) {
             logger.Batch("invalid contribution index");
             retBan = true;
             return false;

--- a/src/test/llmq_dkg_tests.cpp
+++ b/src/test/llmq_dkg_tests.cpp
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(llmq_dkgerror)
     BOOST_ASSERT(GetSimulatedErrorRate(llmq::DKGError::type::_COUNT) == 0.0);
 }
 
-BOOST_FIXTURE_TEST_CASE(preverify_rejects_invalid_member_signatures, TestChain100Setup)
+BOOST_FIXTURE_TEST_CASE(preverify_rejects_invalid_member_messages, TestChain100Setup)
 {
     using namespace llmq;
 
@@ -133,6 +133,22 @@ BOOST_FIXTURE_TEST_CASE(preverify_rejects_invalid_member_signatures, TestChain10
     justification.proTxHash = members.front()->proTxHash;
     justification.contributions.push_back({0, signing_key});
     check_preverification(justification);
+
+    justification.contributions.front().index =
+        static_cast<uint32_t>(members.size() - 1);
+    sign(justification);
+    auto decoded_justification{WireRoundTrip(justification)};
+    bool ban{true};
+    BOOST_CHECK(session.PreVerifyMessage(decoded_justification, ban));
+    BOOST_CHECK(!ban);
+
+    justification.contributions.front().index =
+        static_cast<uint32_t>(members.size());
+    sign(justification);
+    decoded_justification = WireRoundTrip(justification);
+    ban = false;
+    BOOST_CHECK(!session.PreVerifyMessage(decoded_justification, ban));
+    BOOST_CHECK(ban);
 }
 
 


### PR DESCRIPTION
## Motivation

PR #613 was merged into its stacked base branch `codex/fix-dkg-invalid-signatures` after #612 had already landed in `master`. Its merge commit is therefore not an ancestor of `master`, and current `master` still accepts a DKG justification contribution index equal to the quorum member count.

That one-past index is later used for unchecked vector indexing. A single selected malicious DKG member can sign such a justification and trigger undefined behavior in peers processing it.

This replacement PR reapplies the already-reviewed #613 patch directly onto current `master`.

## Changes

- reject justification contribution indices greater than or equal to the member count
- retain the existing punishment behavior for malformed member messages
- cover the final valid index and the one-past boundary with signed, wire-round-tripped tests

This does not change consensus, storage, or wire formats. Honest justification generation already emits only indices below the member count.

## Testing

- `make -j4 test/test_syscoin`
- `./test/test_syscoin --run_test=llmq_dkg_tests/preverify_rejects_invalid_member_messages --log_level=error`
- `./test/test_syscoin --run_test=llmq_dkg_tests,bls_tests,llmq_sigshare_cache_tests --log_level=error` (35 test cases)
- `./test/test_syscoin --log_level=error` (691 test cases)
- `git diff --check origin/master...HEAD`
