### PR TITLE
fix(init): preserve post-bootstrap startup grace

### DIFF
--- a/src/node/geth_startup.h
+++ b/src/node/geth_startup.h
@@ -28,10 +28,13 @@ public:
     void Observe(bool bootstrap_status_present, bool geth_running, Clock::time_point now)
     {
         m_bootstrap_active = bootstrap_status_present && geth_running;
-        if (m_bootstrap_active && !m_bootstrap_started) {
-            m_bootstrap_started = true;
-            m_bootstrap_start = now;
-            m_bootstrap_deadline = now + m_bootstrap_timeout;
+        if (m_bootstrap_active) {
+            if (!m_bootstrap_started) {
+                m_bootstrap_started = true;
+                m_bootstrap_start = now;
+                m_bootstrap_deadline = now + m_bootstrap_timeout;
+            }
+            m_bootstrap_completed = false;
         } else if (!bootstrap_status_present && geth_running && m_bootstrap_started && !m_bootstrap_completed) {
             m_bootstrap_completed = true;
             m_normal_start = now;

--- a/src/test/geth_startup_tests.cpp
+++ b/src/test/geth_startup_tests.cpp
@@ -28,6 +28,24 @@ BOOST_AUTO_TEST_CASE(bootstrap_completion_starts_fresh_normal_timeout)
     BOOST_CHECK(wait.Expired(start + Seconds{102}));
 }
 
+BOOST_AUTO_TEST_CASE(bootstrap_status_flicker_does_not_consume_final_completion_grace)
+{
+    using Seconds = GethStartupWaitState::Seconds;
+    const GethStartupWaitState::Clock::time_point start{};
+    GethStartupWaitState wait{start, Seconds{30}, Seconds{7200}};
+
+    wait.Observe(/*bootstrap_status_present=*/true, /*geth_running=*/true, start + Seconds{2});
+    wait.Observe(/*bootstrap_status_present=*/false, /*geth_running=*/true, start + Seconds{72});
+    wait.Observe(/*bootstrap_status_present=*/true, /*geth_running=*/true, start + Seconds{73});
+    BOOST_CHECK(wait.BootstrapActive());
+
+    wait.Observe(/*bootstrap_status_present=*/false, /*geth_running=*/true, start + Seconds{200});
+    BOOST_CHECK(!wait.BootstrapActive());
+    BOOST_CHECK_EQUAL(wait.ActiveElapsed(start + Seconds{229}).count(), 29);
+    BOOST_CHECK(!wait.Expired(start + Seconds{229}));
+    BOOST_CHECK(wait.Expired(start + Seconds{230}));
+}
+
 BOOST_AUTO_TEST_CASE(dead_geth_does_not_gain_post_bootstrap_grace)
 {
     using Seconds = GethStartupWaitState::Seconds;


### PR DESCRIPTION
## Summary\n\n- treat a reappearing non-empty sysgeth state-bootstrap status as evidence that bootstrap is still active\n- clear provisional completion without resetting the original bootstrap deadline\n- start the normal startup grace period from the final observed disappearance\n- preserve dead-process behavior and explicit zero-timeout semantics\n\n## Why\n\nThe status file can disappear transiently while bootstrap is still in progress. The previous state machine marked bootstrap complete on the first missing observation and never reconsidered that decision, so the normal timeout could be consumed before the actual final completion.\n\n## Validation\n\n- exact-branch full unit suite: 692 test cases passed\n- geth_startup_tests: 4 test cases passed\n- syscoind and test_syscoin linked successfully\n- git diff --check and repository whitespace lint passed\n- independent state-machine review found no actionable issues\n- Codex Security exact-diff review completed with zero reportable findings