### PR TITLE
fix(nevm): maintain auxiliary data and cache lifecycles

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -262,6 +262,7 @@ SYSCOIN_CORE_H = \
   netgroup.h \
   netmessagemaker.h \
   node/abort.h \
+  node/blockconnection.h \
   node/blockmanager_args.h \
   node/blockstorage.h \
   node/caches.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -104,6 +104,9 @@ SYSCOIN_TESTS =\
   test/dbwrapper_tests.cpp \
   test/denialofservice_tests.cpp \
   test/descriptor_tests.cpp \
+  test/nevm_auxiliary_tests.cpp \
+  test/nevm_cache_writeback_tests.cpp \
+  test/nevm_ownership_tests.cpp \
   test/nevm_tests.cpp \
   test/evo_deterministicmns_tests.cpp \
   test/evodb_tests.cpp \

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -226,8 +226,11 @@ ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<
         // but that is expensive, and CheckBlock caches a block's
         // "checked-status" (in the CBlock?). CBlock should be able to
         // check its own merkle root and cache that check.
-        if (state.GetResult() == BlockValidationResult::BLOCK_MUTATED)
-            return READ_STATUS_FAILED; // Possible Short ID collision
+        // Failures in reconstructed or replaceable data must permit a full-block
+        // retry, since they do not establish that the block identity is invalid.
+        if (state.GetResult() == BlockValidationResult::BLOCK_MUTATED ||
+            state.GetResult() == BlockValidationResult::BLOCK_AUX_DATA_INVALID)
+            return READ_STATUS_FAILED;
         return READ_STATUS_CHECKBLOCK_FAILED;
     }
 

--- a/src/consensus/tx_check.cpp
+++ b/src/consensus/tx_check.cpp
@@ -17,7 +17,10 @@ bool CheckTransaction(const CTransaction& tx, TxValidationState& state)
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-vout-empty");
     // Size limits (this doesn't take the witness into account, as that hasn't been checked for malleability)
     if (::GetSerializeSize(tx, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT) {
-        return state.Invalid(HasNEVMAuxiliaryData(tx) ? TxValidationResult::TX_AUX_DATA_INVALID : TxValidationResult::TX_CONSENSUS,
+        // An unrelated or discounted sidecar cannot excuse an oversized committed form.
+        const bool committed_oversize = ::GetSerializeSize(tx, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS,
+                                                          SER_SIZE | SER_NO_PODA) * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT;
+        return state.Invalid(committed_oversize ? TxValidationResult::TX_CONSENSUS : TxValidationResult::TX_AUX_DATA_INVALID,
                              "bad-txns-oversize");
     }
 

--- a/src/consensus/tx_check.cpp
+++ b/src/consensus/tx_check.cpp
@@ -16,8 +16,10 @@ bool CheckTransaction(const CTransaction& tx, TxValidationState& state)
     if (tx.vout.empty())
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-vout-empty");
     // Size limits (this doesn't take the witness into account, as that hasn't been checked for malleability)
-    if (::GetSerializeSize(tx, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT)
-        return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-oversize");
+    if (::GetSerializeSize(tx, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT) {
+        return state.Invalid(HasNEVMAuxiliaryData(tx) ? TxValidationResult::TX_AUX_DATA_INVALID : TxValidationResult::TX_CONSENSUS,
+                             "bad-txns-oversize");
+    }
 
     // Check for negative or overflow output values (see CVE-2010-5139)
     CAmount nValueOut = 0;

--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -6,6 +6,7 @@
 #ifndef SYSCOIN_CONSENSUS_VALIDATION_H
 #define SYSCOIN_CONSENSUS_VALIDATION_H
 
+#include <algorithm>
 #include <string>
 #include <version.h>
 #include <consensus/consensus.h>
@@ -55,6 +56,7 @@ enum class TxValidationResult {
     TX_MEMPOOL_POLICY,        //!< violated mempool's fee/size/descendant/RBF/etc limits
     // SYSCOIN
     TX_MINT_DUPLICATE, //!< mempool's nevm mint tx hashexisting in mempool
+    TX_AUX_DATA_INVALID,      //!< auxiliary data failed validation independently of txid and wtxid
     TX_NO_MEMPOOL,            //!< this node does not have a mempool so can't validate the transaction
 };
 
@@ -77,6 +79,7 @@ enum class BlockValidationResult {
     BLOCK_CACHED_INVALID,    //!< this block was cached as being invalid and we didn't store the reason why
     BLOCK_INVALID_HEADER,    //!< invalid proof of work or time too old
     BLOCK_MUTATED,           //!< the block's data didn't match the data committed to by the PoW
+    BLOCK_AUX_DATA_INVALID,  //!< replaceable auxiliary data failed validation independently of block identity
     BLOCK_MISSING_PREV,      //!< We don't have the previous block the checked one is built on
     BLOCK_INVALID_PREV,      //!< A block this one builds on is invalid
     BLOCK_TIME_FUTURE,       //!< block timestamp was > 2 hours in the future (or our clock is bad)
@@ -144,6 +147,37 @@ public:
 
 class TxValidationState : public ValidationState<TxValidationResult> {};
 class BlockValidationState : public ValidationState<BlockValidationResult> {};
+
+/** Whether a rejection can be retained under the transaction's witness identity. */
+inline bool IsTxRejectionCacheable(TxValidationResult result, const CTransaction& tx)
+{
+    // Even valid optional sidecars affect size and fee policy without changing
+    // either transaction identity. Do not retain their policy failures by hash.
+    return !tx.IsNEVMData() && result != TxValidationResult::TX_RESULT_UNSET &&
+           result != TxValidationResult::TX_WITNESS_STRIPPED &&
+           result != TxValidationResult::TX_AUX_DATA_INVALID;
+}
+
+inline bool IsBlockRejectionCacheable(BlockValidationResult result)
+{
+    return result != BlockValidationResult::BLOCK_RESULT_UNSET &&
+           result != BlockValidationResult::BLOCK_MUTATED &&
+           result != BlockValidationResult::BLOCK_AUX_DATA_INVALID;
+}
+
+inline bool HasNEVMAuxiliaryData(const CTransaction& tx)
+{
+    return tx.IsNEVMData() && std::any_of(tx.vout.begin(), tx.vout.end(), [](const auto& out) {
+        return !out.vchNEVMData.empty();
+    });
+}
+
+inline bool HasNEVMAuxiliaryData(const CBlock& block)
+{
+    return std::any_of(block.vtx.begin(), block.vtx.end(), [](const auto& tx) {
+        return HasNEVMAuxiliaryData(*tx);
+    });
+}
 
 // These implement the weight = (stripped_size * 4) + witness_size formula,
 // using only serialization with and without witness data. As witness_size

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1680,6 +1680,7 @@ bool PeerManagerImpl::MaybePunishNodeForBlock(NodeId nodeid, const BlockValidati
         return true;
     case BlockValidationResult::BLOCK_RECENT_CONSENSUS_CHANGE:
     case BlockValidationResult::BLOCK_TIME_FUTURE:
+    case BlockValidationResult::BLOCK_AUX_DATA_INVALID:
         break;
     }
     if (message != "") {
@@ -1708,6 +1709,7 @@ bool PeerManagerImpl::MaybePunishNodeForTx(NodeId nodeid, const TxValidationStat
     case TxValidationResult::TX_PREMATURE_SPEND:
     case TxValidationResult::TX_WITNESS_MUTATED:
     case TxValidationResult::TX_WITNESS_STRIPPED:
+    case TxValidationResult::TX_AUX_DATA_INVALID:
     case TxValidationResult::TX_CONFLICT:
     case TxValidationResult::TX_MEMPOOL_POLICY:
     case TxValidationResult::TX_NO_MEMPOOL:
@@ -3171,7 +3173,7 @@ bool PeerManagerImpl::ProcessOrphanTx(Peer& peer)
             // Has inputs but not accepted to mempool
             // Probably non-standard or insufficient fee
             LogPrint(BCLog::TXPACKAGES, "   removed orphan tx %s (wtxid=%s)\n", orphanHash.ToString(), orphan_wtxid.ToString());
-            if (state.GetResult() != TxValidationResult::TX_WITNESS_STRIPPED) {
+            if (IsTxRejectionCacheable(state.GetResult(), *porphanTx)) {
                 // We can add the wtxid of this transaction to our reject filter.
                 // Do not add txids of witness transactions or witness-stripped
                 // transactions to the filter, as they can have been malleated;
@@ -4543,7 +4545,7 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
                 m_txrequest.ForgetTxHash(tx.GetWitnessHash());
             }
         } else {
-            if (state.GetResult() != TxValidationResult::TX_WITNESS_STRIPPED) {
+            if (IsTxRejectionCacheable(state.GetResult(), tx)) {
                 // We can add the wtxid of this transaction to our reject filter.
                 // Do not add txids of witness transactions or witness-stripped
                 // transactions to the filter, as they can have been malleated;

--- a/src/node/blockconnection.h
+++ b/src/node/blockconnection.h
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 The Syscoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef SYSCOIN_NODE_BLOCKCONNECTION_H
+#define SYSCOIN_NODE_BLOCKCONNECTION_H
+
+#include <coins.h>
+#include <consensus/validation.h>
+#include <kernel/cs_main.h>
+#include <node/blockstorage.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <util/hasher.h>
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace node {
+
+struct BlockConnectionState {
+    NEVMMintTxSet mint_txs;
+    NEVMTxRootMap nevm_tx_roots;
+    PoDAMAPMemory poda;
+    std::vector<std::pair<uint256, uint32_t>> txid_pairs;
+    std::unique_ptr<CCoinsViewCache> view;
+
+    explicit BlockConnectionState(CCoinsViewCache& coins_tip)
+        : view{std::make_unique<CCoinsViewCache>(&coins_tip)} {}
+
+    void Reset(CCoinsViewCache& coins_tip, BlockValidationState& state)
+    {
+        view = std::make_unique<CCoinsViewCache>(&coins_tip);
+        state = BlockValidationState{};
+        mint_txs.clear();
+        nevm_tx_roots.clear();
+        poda.clear();
+        txid_pairs.clear();
+    }
+};
+
+enum class BlockConnectionResult {
+    SUCCESS,
+    FAILED,
+    DISK_READ_FAILED,
+};
+
+// Auxiliary rejection must precede other stateful validation: this retry resets
+// only the child coins view and the outputs staged by the connection attempt.
+template <typename Connect>
+BlockConnectionResult ConnectBlockWithAuxiliaryRetry(
+    const BlockManager& blockman, const CBlockIndex& index, bool loaded_from_disk,
+    std::shared_ptr<const CBlock>& block, BlockValidationState& state,
+    CCoinsViewCache& coins_tip, BlockConnectionState& connection, Connect&& connect)
+    EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    bool connected = connect();
+    if (!connected && loaded_from_disk && state.GetResult() == BlockValidationResult::BLOCK_AUX_DATA_INVALID &&
+        HasNEVMAuxiliaryData(*block)) {
+        // Disk blocks omit sidecars. Reread that representation rather than
+        // treating the first in-memory representation as trusted block data.
+        auto committed = std::make_shared<CBlock>();
+        if (!blockman.ReadBlockFromDisk(*committed, index, /*load_auxiliary_data=*/false)) {
+            return BlockConnectionResult::DISK_READ_FAILED;
+        }
+        connection.Reset(coins_tip, state);
+        block = std::move(committed);
+        connected = connect();
+    }
+    return connected ? BlockConnectionResult::SUCCESS : BlockConnectionResult::FAILED;
+}
+
+} // namespace node
+
+#endif // SYSCOIN_NODE_BLOCKCONNECTION_H

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -1103,11 +1103,11 @@ bool BlockManager::ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos) cons
     return res;
 }
 
-bool BlockManager::ReadBlockFromDisk(CBlock& block, const CBlockIndex& index) const
+bool BlockManager::ReadBlockFromDisk(CBlock& block, const CBlockIndex& index, bool load_auxiliary_data) const
 {
     auto res = ReadBlockOrHeader(block, index);
     // SYSCOIN
-    if(!FillNEVMData(block)) {
+    if(load_auxiliary_data && !FillNEVMData(block)) {
         return error("ReadBlockFromDisk(): FillNEVMData() failed for %s",
         index.GetBlockHash().GetHex());
     }

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -374,7 +374,8 @@ public:
 
     /** Functions for disk access for blocks */
     bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos) const;
-    bool ReadBlockFromDisk(CBlock& block, const CBlockIndex& index) const;
+    /** Auxiliary loading may be disabled when revalidating the committed disk representation. */
+    bool ReadBlockFromDisk(CBlock& block, const CBlockIndex& index, bool load_auxiliary_data = true) const;
     bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos) const;
 
     bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex& index) const;

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -762,10 +762,6 @@ bool CNEVMData::UnserializeFromTx(const CTransaction &tx, const int nVersion) {
 	}
     if(!tx.vout[nOut].vchNEVMData.empty()) {
         vchNEVMData = std::make_shared<const std::vector<uint8_t>>(tx.vout[nOut].vchNEVMData);
-        if(vchNEVMData->size() > MAX_NEVM_DATA_BLOB) {
-            SetNull();
-            return false;
-        }
     }
     txid = tx.GetHash();
     return true;

--- a/src/services/assetconsensus.cpp
+++ b/src/services/assetconsensus.cpp
@@ -338,19 +338,8 @@ bool CheckSyscoinMintInternal(
     if (nAssetFromLog == 0 || outputAmount == 0 || witnessAddress.empty()) {
         return FormatSyscoinErrorMessage(state, "mint-missing-freeze-log", fJustCheck);
     }
-    // sanity check is set in mempool during m_test_accept and when miner validates block
-    // we care to ensure unique bridge id's in the mempool, not to emplace on test_accept
-    if(fJustCheck) {
-        if(setMintTxs.find(mintSyscoin.nTxHash) != setMintTxs.end()) {
-            return state.Invalid(TxValidationResult::TX_MINT_DUPLICATE, "mint-duplicate-transfer");
-        }
-    }
-    else {
-        // ensure eth tx not already spent in current processing block or mempool(mapMintKeysMempool passed in)
-        auto itMap = setMintTxs.insert(mintSyscoin.nTxHash);
-        if(!itMap.second) {
-            return state.Invalid(TxValidationResult::TX_MINT_DUPLICATE, "mint-duplicate-transfer");
-        }
+    if (setMintTxs.count(mintSyscoin.nTxHash)) {
+        return state.Invalid(TxValidationResult::TX_MINT_DUPLICATE, "mint-duplicate-transfer");
     }
     
     if (!rlpTxValue.isList()) {
@@ -489,6 +478,9 @@ bool CheckSyscoinMint(
     if (outputAmount != nTotalMinted) {
         return FormatSyscoinErrorMessage(state, "mint-output-mismatch", fJustCheck);
     }
+    // The caller owns this block/package-local set, including for check-only validation.
+    // Do not reserve a mint before its proof and outputs have both passed validation.
+    setMintTxs.insert(mintSyscoin.nTxHash);
     if (!fJustCheck) {
         if (nHeight > 0) {
             LogPrint(BCLog::SYS,"CONNECTED ASSET MINT: asset=%llu tx=%s height=%d fJustCheck=%s\n",
@@ -648,27 +640,11 @@ bool CNEVMTxRootsDB::FlushCacheToDisk(std::size_t CHUNK_ITEMS, bool fSync)
     LOCK(cs_cache);
     if (mapCache.empty()) return true;
 
-    CDBBatch batch(*this);
-    std::size_t items = 0;
-    std::size_t count = 0;
-    auto flush = [&]() {
-        if (batch.SizeEstimate() == 0) return true;
-        if (!WriteBatch(batch, fSync)) return false;
-        batch.Clear();
-        items = 0;
-        return true;
-    };
-
-    for (auto it = mapCache.begin(); it != mapCache.end(); ) {
-        batch.Write(it->first, it->second);
-        count++;
-        if (++items == CHUNK_ITEMS) {
-            if (!flush()) return false;
-        }
-        // entry is now durable → erase from cache
-        it = mapCache.erase(it);
-    }
-    if (!flush()) return false;       // last partial chunk
+    const std::size_t count = mapCache.size();
+    if (!nevm_cache_detail::FlushCache(
+            *this, mapCache, CHUNK_ITEMS, fSync,
+            [](CDBBatch& batch, const auto& entry) { batch.Write(entry.first, entry.second); },
+            [this](CDBBatch& batch, bool sync) { return WriteBatch(batch, sync); })) return false;
 
     LogPrint(BCLog::SYS,
              "Flushed NEVM-tx-roots cache, %zu items written in %zu-entry chunks\n",
@@ -712,27 +688,11 @@ bool CNEVMMintedTxDB::FlushCacheToDisk(std::size_t CHUNK_ITEMS, bool fSync)
     LOCK(cs_cache);
     if (mapCache.empty()) return true;
 
-    CDBBatch batch(*this);
-    std::size_t items = 0;
-    std::size_t count = 0;
-
-    auto flush = [&]() {
-        if (batch.SizeEstimate() == 0) return true;
-        if (!WriteBatch(batch, fSync)) return false;
-        batch.Clear();
-        items = 0;
-        return true;
-    };
-
-    for (auto it = mapCache.begin(); it != mapCache.end(); ) {
-        batch.Write(*it, true);       // value is a dummy bool
-        count++;
-        if (++items == CHUNK_ITEMS) {
-            if (!flush()) return false;
-        }
-        it = mapCache.erase(it);      // safe to purge now
-    }
-    if (!flush()) return false;
+    const std::size_t count = mapCache.size();
+    if (!nevm_cache_detail::FlushCache(
+            *this, mapCache, CHUNK_ITEMS, fSync,
+            [](CDBBatch& batch, const uint256& key) { batch.Write(key, true); },
+            [this](CDBBatch& batch, bool sync) { return WriteBatch(batch, sync); })) return false;
 
     LogPrint(BCLog::SYS,
              "Flushed NEVM-minted-tx cache, %zu items written in %zu-entry chunks\n",

--- a/src/services/assetconsensus.h
+++ b/src/services/assetconsensus.h
@@ -9,6 +9,36 @@
 #include <consensus/params.h>
 #include <util/hasher.h>
 #include <sync.h>
+
+#include <cstddef>
+
+namespace nevm_cache_detail {
+/** The caller must hold the cache lock; callbacks must not modify the cache. */
+template <typename Cache, typename AddToBatch, typename WriteBatch>
+bool FlushCache(CDBWrapper& db, Cache& cache, std::size_t chunk_items, bool sync,
+                AddToBatch add_to_batch, WriteBatch write_batch)
+{
+    CDBBatch batch(db);
+    auto first = cache.begin();
+    while (first != cache.end()) {
+        auto last = first;
+        std::size_t items{0};
+        do {
+            add_to_batch(batch, *last);
+            ++last;
+            ++items;
+        } while (last != cache.end() && items != chunk_items);
+
+        // A zero chunk limit preserves the unbounded-batch behavior. Keep the
+        // entire pending range visible if writing returns false or throws.
+        if (!write_batch(batch, sync)) return false;
+        first = cache.erase(first, last);
+        batch.Clear();
+    }
+    return true;
+}
+} // namespace nevm_cache_detail
+
 class TxValidationState;
 class CTxUndo;
 class CBlock;

--- a/src/services/nevmconsensus.cpp
+++ b/src/services/nevmconsensus.cpp
@@ -17,6 +17,9 @@
 #include <timedata.h>
 #include <key_io.h>
 #include <logging.h>
+
+#include <algorithm>
+
 std::unique_ptr<CBlockIndexDB> pblockindexdb;
 std::unique_ptr<CNEVMDataDB> pnevmdatadb;
 std::unique_ptr<CNEVMDataBlobDB> pnevmdatablobdb;
@@ -33,119 +36,142 @@ bool DisconnectSyscoinTransaction(const CTransaction& tx, NEVMMintTxSet &setMint
     return true;       
 }
 
-void CNEVMDataDB::FlushDataToCache(const PoDAMAPMemory &mapPoDA, PoDAFlushSource source) {
+void CNEVMDataDB::FlushDataToCache(const PoDAMAPMemory& mapPoDA, PoDAFlushSource source)
+{
     LOCK(cs_cache);
-    if(mapPoDA.empty()) {
-        return;
-    }
-    CDBBatch batchblob(*pnevmdatablobdb);  
-    for (auto const& [key, val] : mapPoDA) {
-        if(!val.vchNEVMData) {
-            continue;
-        }
+    if (mapPoDA.empty()) return;
+
+    PoDAMAPMemory cache_updates;
+    std::map<std::vector<uint8_t>, uint256> owner_updates;
+    NEVMDataVec retained_keys;
+    CDBBatch batchblob(*pnevmdatablobdb);
+    for (const auto& [key, val] : mapPoDA) {
+        const bool have_payload = val.vchNEVMData && !val.vchNEVMData->empty();
         MapPoDAPayloadMeta meta;
-        if(Read(key, meta)) {
-            if(source == PoDAFlushSource::Block && meta.nSize == val.nSize) {
-                auto inserted = mapCache.try_emplace(key, val.txid, meta.nSize, val.nMedianTime);
-                if(!inserted.second) {
-                    inserted.first->second.nMedianTime = val.nMedianTime;
-                    inserted.first->second.txid = val.txid;
-                }
-            }
-            continue;
+        const auto cached = mapCache.find(key);
+        bool have_metadata = cached != mapCache.end();
+        if (have_metadata) {
+            meta = cached->second;
+        } else {
+            have_metadata = Read(key, meta);
+            // An unreadable existing row is not evidence of a new mempool blob.
+            if (!have_metadata && Exists(key)) continue;
         }
-        auto inserted = mapCache.try_emplace(key, val.txid, val.nSize, val.nMedianTime);
-        if(!inserted.second) {
-            if(source == PoDAFlushSource::Block && inserted.first->second.nSize == val.nSize) {
-                inserted.first->second.nMedianTime = val.nMedianTime;
-                inserted.first->second.txid = val.txid;
-            }
-            continue;
-        }
-        if(!pnevmdatablobdb->Exists(key)) {
+        // Optional sidecar omissions still identify retained references, but do
+        // not provide a size or enough information to create a new blob record.
+        if (!have_metadata && !have_payload) continue;
+        if (have_metadata && have_payload && meta.nSize != val.nSize) continue;
+
+        const bool have_blob = have_payload && pnevmdatablobdb->Exists(key);
+        if (have_payload && !have_blob) {
             batchblob.Write(key, val.vchNEVMData);
         }
-    }
-    if(batchblob.SizeEstimate() > 0) {
-        pnevmdatablobdb->WriteBatch(batchblob);
-    }
-}
-bool CNEVMDataDB::FlushCacheToDisk(const int64_t nMedianTime, bool fSync) {
-    bool cacheEmpty = false;
-    {
-        LOCK(cs_cache);
-        cacheEmpty = mapCache.empty();
-    }
-    if(cacheEmpty) {
-        if(fTestNet) {
-            return PruneStandalone(nMedianTime, fSync);
+        if (have_metadata && source == PoDAFlushSource::Mempool) {
+            if (meta.txid != val.txid) retained_keys.push_back(key);
+            continue;
         }
-        return true;
+
+        // Blocks can arrive out of order; the shared blob must keep the newest
+        // observed retention deadline even when its metadata txid is refreshed.
+        const int64_t median_time = source == PoDAFlushSource::Block && have_metadata ?
+            std::max(meta.nMedianTime, val.nMedianTime) : val.nMedianTime;
+        cache_updates.try_emplace(key, val.txid, have_metadata ? meta.nSize : val.nSize, median_time);
+        if (source == PoDAFlushSource::Block) {
+            retained_keys.push_back(key);
+        } else if (!have_blob) {
+            owner_updates.emplace(key, val.txid);
+        }
     }
+    if (batchblob.SizeEstimate() > 0 && !pnevmdatablobdb->WriteBatch(batchblob)) {
+        throw dbwrapper_error("Failed to write NEVM blob data");
+    }
+    for (const auto& [key, meta] : cache_updates) {
+        const auto cached = mapCache.find(key);
+        if (cached != mapCache.end()) cached->second = meta;
+    }
+    for (const auto& key : retained_keys) m_mempool_owners.erase(key);
+    mapCache.merge(cache_updates);
+    m_mempool_owners.merge(owner_updates);
+}
+bool CNEVMDataDB::FlushCacheToDisk(const int64_t nMedianTime, bool fSync)
+{
     LOCK(cs_cache);
+    if (mapCache.empty() && !fTestNet) return true;
+
     CDBBatch batch(*this);
+    CDBBatch batchblob(*pnevmdatablobdb);
+    NEVMDataVec pruned_keys;
     // only prune on testnet flush, mainnet relies only on CL
-    if(fTestNet) {
-        CDBBatch batchblob(*pnevmdatablobdb);
-        if (!PruneToBatch(batch, batchblob, nMedianTime)) {
+    if (fTestNet) {
+        if (!PruneToBatch(batch, batchblob, nMedianTime, pruned_keys)) {
             LogPrint(BCLog::SYS, "Error: Could not prune nevm blobs\n");
             return false;
         }
-        pnevmdatablobdb->WriteBatch(batchblob);
     }
-    for (auto const& [key, val] : mapCache) {
+    for (const auto& [key, val] : mapCache) {
+        if (fTestNet && nMedianTime > val.nMedianTime + NEVM_DATA_EXPIRE_TIME) continue;
         batch.Write(key, val);
     }
-    if(mapCache.size() > 0)
+    if (!mapCache.empty()) {
         LogPrint(BCLog::SYS, "Flushing cache to disk, storing %d nevm blobs\n", mapCache.size());
-    bool res = WriteBatch(batch, fSync);
-    if(res) {
-        mapCache.clear();
     }
-    return res;
+    // Keep metadata indexed until payload deletion succeeds, so interrupted
+    // cleanup can be retried without an unindexed payload leak.
+    if (batchblob.SizeEstimate() > 0 && !pnevmdatablobdb->WriteBatch(batchblob, fSync)) return false;
+    if (!WriteBatch(batch, fSync)) return false;
+    mapCache.clear();
+    for (const auto& key : pruned_keys) m_mempool_owners.erase(key);
+    return true;
 }
-bool CNEVMDataDB::FlushErase(const NEVMDataVec &vecDataKeys) {
+bool CNEVMDataDB::FlushErase(const NEVMDataVec& vecDataKeys)
+{
     LOCK(cs_cache);
-    if(vecDataKeys.empty())
-        return true;
-    CDBBatch batch(*this);    
-    for (const auto &key : vecDataKeys) {
+    if (vecDataKeys.empty()) return true;
+
+    CDBBatch batch(*this);
+    for (const auto& key : vecDataKeys) {
         batch.Erase(key);
-        // remove from cache as well
-        auto it = mapCache.find(key);
-        if(it != mapCache.end())
-            mapCache.erase(it);
     }
-    if(vecDataKeys.size() > 0)
-        LogPrint(BCLog::SYS, "Flushing, erasing %d nevm blob keys\n", vecDataKeys.size());
-    return WriteBatch(batch, true) && pnevmdatablobdb->FlushErase(vecDataKeys);
+    if (!pnevmdatablobdb->FlushErase(vecDataKeys)) return false;
+    if (!WriteBatch(batch, true)) return false;
+    for (const auto& key : vecDataKeys) {
+        mapCache.erase(key);
+        m_mempool_owners.erase(key);
+    }
+    LogPrint(BCLog::SYS, "Flushing, erasing %d nevm blob keys\n", vecDataKeys.size());
+    return true;
 }
-bool CNEVMDataDB::FlushMempoolErase(const std::vector<uint8_t>& vchVersionHash, const uint256& txid) {
+bool CNEVMDataDB::FlushMempoolErase(const std::vector<uint8_t>& vchVersionHash, const uint256& txid)
+{
     LOCK(cs_cache);
+    const auto owner = m_mempool_owners.find(vchVersionHash);
+    if (owner == m_mempool_owners.end() || owner->second != txid) return true;
+
     MapPoDAPayloadMeta meta;
-    if(Read(vchVersionHash, meta)) {
-        if(meta.txid == txid) {
-            CDBBatch batch(*this);
-            auto it = mapCache.find(vchVersionHash);
-            if(it != mapCache.end()) {
-                if(it->second.txid != txid) {
-                    batch.Write(vchVersionHash, it->second);
-                    return WriteBatch(batch, true);
-                }
-                mapCache.erase(it);
-            }
-            batch.Erase(vchVersionHash);
-            return WriteBatch(batch, true) && pnevmdatablobdb->FlushErase({vchVersionHash});
-        }
+    const auto cached = mapCache.find(vchVersionHash);
+    if (cached != mapCache.end()) {
+        meta = cached->second;
+    } else if (!Read(vchVersionHash, meta)) {
         return true;
     }
-    auto it = mapCache.find(vchVersionHash);
-    if(it == mapCache.end() || it->second.txid != txid) {
-        return true;
-    }
-    mapCache.erase(it);
-    return pnevmdatablobdb->FlushErase({vchVersionHash});
+    if (meta.txid != txid) return true;
+
+    CDBBatch batch(*this);
+    batch.Erase(vchVersionHash);
+    if (!pnevmdatablobdb->FlushErase({vchVersionHash})) return false;
+    if (!WriteBatch(batch, true)) return false;
+    mapCache.erase(vchVersionHash);
+    m_mempool_owners.erase(vchVersionHash);
+    return true;
 }
+
+void CNEVMDataDB::ReleaseMempoolOwner(const std::vector<uint8_t>& version_hash, const uint256& txid)
+{
+    LOCK(cs_cache);
+    const auto owner = m_mempool_owners.find(version_hash);
+    if (owner != m_mempool_owners.end() && owner->second == txid) m_mempool_owners.erase(owner);
+}
+
 bool CNEVMDataBlobDB::FlushErase(const NEVMDataVec &vecDataKeys) {
     CDBBatch batch(*this);    
     for (const auto &key : vecDataKeys) {
@@ -173,20 +199,17 @@ const PoDAMAPMemory& CNEVMDataDB::GetCache() const {
 bool CNEVMDataDB::PruneToBatch(
     CDBBatch& batch,
     CDBBatch& batchblob,
-    const int64_t nMedianTime)
+    const int64_t nMedianTime,
+    NEVMDataVec& pruned_keys)
 {
     AssertLockHeld(cs_cache);
     int nCount = 0;
-    auto it = mapCache.begin();
-    while (it != mapCache.end()) {
-        const int64_t entryTime = it->second.nMedianTime;
-        bool isExpired = nMedianTime > (entryTime + NEVM_DATA_EXPIRE_TIME);
-        if (isExpired) {
-            batchblob.Erase(it->first);
-            it = mapCache.erase(it);
+    for (const auto& [key, meta] : mapCache) {
+        if (nMedianTime > meta.nMedianTime + NEVM_DATA_EXPIRE_TIME) {
+            batch.Erase(key);
+            batchblob.Erase(key);
+            pruned_keys.push_back(key);
             ++nCount;
-        } else {
-            ++it;
         }
     }
     
@@ -200,11 +223,17 @@ bool CNEVMDataDB::PruneToBatch(
                 pcursor->Next();
                 continue;
             }
+            // Cached block refreshes supersede older persisted retention times.
+            if (mapCache.count(vchVersionHash) != 0) {
+                pcursor->Next();
+                continue;
+            }
             if (pcursor->GetValue(meta)) {
                 bool isExpired = nMedianTime > (meta.nMedianTime + NEVM_DATA_EXPIRE_TIME);
                 if (isExpired) {
                     batch.Erase(vchVersionHash);
                     batchblob.Erase(vchVersionHash);
+                    pruned_keys.push_back(vchVersionHash);
                     ++nCount;
                 }
             }
@@ -224,8 +253,15 @@ bool CNEVMDataDB::PruneStandalone(const int64_t nMedianTime, bool fSync)
     LOCK(cs_cache);
     CDBBatch batch(*this);
     CDBBatch batchblob(*pnevmdatablobdb);
-    if (!PruneToBatch(batch, batchblob, nMedianTime)) {
+    NEVMDataVec pruned_keys;
+    if (!PruneToBatch(batch, batchblob, nMedianTime, pruned_keys)) {
         return false;
     }
-    return WriteBatch(batch, fSync) && pnevmdatablobdb->WriteBatch(batchblob, fSync);
+    if (!pnevmdatablobdb->WriteBatch(batchblob, fSync)) return false;
+    if (!WriteBatch(batch, fSync)) return false;
+    for (const auto& key : pruned_keys) {
+        mapCache.erase(key);
+        m_mempool_owners.erase(key);
+    }
+    return true;
 }

--- a/src/services/nevmconsensus.h
+++ b/src/services/nevmconsensus.h
@@ -9,6 +9,9 @@
 #include <consensus/params.h>
 #include <util/hasher.h>
 #include <sync.h>
+
+#include <map>
+
 class TxValidationState;
 class CCoinsViewCache;
 class CTxUndo;
@@ -31,14 +34,18 @@ public:
     mutable Mutex cs_cache; // Mutex to protect cache operations
 private:
     PoDAMAPMemory mapCache GUARDED_BY(cs_cache);
+    // Deletion authority belongs only to this session's exclusively mempool-owned
+    // blobs. It survives metadata flushes, but reopened/legacy rows are retained.
+    std::map<std::vector<uint8_t>, uint256> m_mempool_owners GUARDED_BY(cs_cache);
+    bool PruneToBatch(CDBBatch& batch, CDBBatch& batchblob, int64_t nMedianTime, NEVMDataVec& pruned_keys) EXCLUSIVE_LOCKS_REQUIRED(cs_cache);
 public:
     using CDBWrapper::CDBWrapper;
     bool FlushErase(const NEVMDataVec &vecDataKeys) EXCLUSIVE_LOCKS_REQUIRED(!cs_cache);
     bool FlushMempoolErase(const std::vector<uint8_t>& vchVersionHash, const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(!cs_cache);
+    void ReleaseMempoolOwner(const std::vector<uint8_t>& version_hash, const uint256& txid) EXCLUSIVE_LOCKS_REQUIRED(!cs_cache);
     bool FlushCacheToDisk(const int64_t nMedianTime, bool fSync = true) EXCLUSIVE_LOCKS_REQUIRED(!cs_cache);
     void FlushDataToCache(const PoDAMAPMemory &mapPoDA, PoDAFlushSource source) EXCLUSIVE_LOCKS_REQUIRED(!cs_cache);
     bool PruneStandalone(const int64_t nMedianTime, bool fSync = true) EXCLUSIVE_LOCKS_REQUIRED(!cs_cache);
-    bool PruneToBatch(CDBBatch& batch,CDBBatch& batchblob,  const int64_t nMedianTime) EXCLUSIVE_LOCKS_REQUIRED(cs_cache);
     bool GetBlobMetaData(const std::vector<uint8_t>& vchVersionhash, MapPoDAPayloadMeta& meta) EXCLUSIVE_LOCKS_REQUIRED(!cs_cache);
     bool BlobExists(const std::vector<uint8_t>& vchVersionhash) EXCLUSIVE_LOCKS_REQUIRED(!cs_cache);
     const PoDAMAPMemory& GetCache() const EXCLUSIVE_LOCKS_REQUIRED(cs_cache);

--- a/src/syscoin-chainstate.cpp
+++ b/src/syscoin-chainstate.cpp
@@ -285,6 +285,9 @@ int main(int argc, char* argv[])
         case BlockValidationResult::BLOCK_MUTATED:
             std::cerr << "the block's data didn't match the data committed to by the PoW" << std::endl;
             break;
+        case BlockValidationResult::BLOCK_AUX_DATA_INVALID:
+            std::cerr << "replaceable auxiliary block data failed validation" << std::endl;
+            break;
         case BlockValidationResult::BLOCK_MISSING_PREV:
             std::cerr << "We don't have the previous block the checked one is built on" << std::endl;
             break;

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -5,6 +5,7 @@
 #include <blockencodings.h>
 #include <chainparams.h>
 #include <consensus/merkle.h>
+#include <consensus/validation.h>
 #include <pow.h>
 #include <streams.h>
 #include <test/util/random.h>
@@ -13,6 +14,8 @@
 #include <test/util/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
+
+#include <optional>
 
 std::vector<std::pair<uint256, CTransactionRef>> extra_txn;
 
@@ -111,6 +114,37 @@ BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
         BOOST_CHECK_EQUAL(block.hashMerkleRoot.ToString(), BlockMerkleRoot(block3, &mutated).ToString());
         BOOST_CHECK(!mutated);
     }
+}
+
+BOOST_AUTO_TEST_CASE(FillBlockValidationResultTest)
+{
+    CTxMemPool pool{MemPoolOptionsForTest(m_node)};
+    const CBlock block{BuildBlockTestCase()};
+
+    const auto check_status = [&](std::optional<BlockValidationResult> result, ReadStatus expected_status) {
+        CBlockHeaderAndShortTxIDs short_ids{block};
+        PartiallyDownloadedBlock partial_block{&pool};
+        BOOST_REQUIRE(partial_block.InitData(short_ids, {}) == READ_STATUS_OK);
+
+        bool check_block_called{false};
+        partial_block.m_check_block_mock = [result, &check_block_called](const CBlock&, BlockValidationState& state, const Consensus::Params&, bool check_pow, bool check_merkle_root) {
+            check_block_called = true;
+            BOOST_CHECK(check_pow);
+            BOOST_CHECK(check_merkle_root);
+            return result ? state.Invalid(*result) : true;
+        };
+
+        CBlock reconstructed_block;
+        BOOST_CHECK(partial_block.FillBlock(reconstructed_block, {block.vtx[1], block.vtx[2]}) == expected_status);
+        BOOST_CHECK(check_block_called);
+        BOOST_CHECK_EQUAL(reconstructed_block.GetHash().ToString(), block.GetHash().ToString());
+        BOOST_CHECK(reconstructed_block.vtx == block.vtx);
+    };
+
+    check_status(BlockValidationResult::BLOCK_MUTATED, READ_STATUS_FAILED);
+    check_status(BlockValidationResult::BLOCK_AUX_DATA_INVALID, READ_STATUS_FAILED);
+    check_status(BlockValidationResult::BLOCK_CONSENSUS, READ_STATUS_CHECKBLOCK_FAILED);
+    check_status(std::nullopt, READ_STATUS_OK);
 }
 
 class TestHeaderAndShortIDs {

--- a/src/test/fuzz/partially_downloaded_block.cpp
+++ b/src/test/fuzz/partially_downloaded_block.cpp
@@ -114,6 +114,7 @@ FUZZ_TARGET(partially_downloaded_block, .init = initialize_pdb)
              BlockValidationResult::BLOCK_CACHED_INVALID,
              BlockValidationResult::BLOCK_INVALID_HEADER,
              BlockValidationResult::BLOCK_MUTATED,
+             BlockValidationResult::BLOCK_AUX_DATA_INVALID,
              BlockValidationResult::BLOCK_MISSING_PREV,
              BlockValidationResult::BLOCK_INVALID_PREV,
              BlockValidationResult::BLOCK_TIME_FUTURE,

--- a/src/test/nevm_auxiliary_tests.cpp
+++ b/src/test/nevm_auxiliary_tests.cpp
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 The Syscoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <consensus/tx_check.h>
+#include <consensus/validation.h>
+#include <nevm/sha3.h>
+#include <primitives/block.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <streams.h>
+#include <sync.h>
+#include <test/util/setup_common.h>
+#include <validation.h>
+
+#include <cstdint>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+CMutableTransaction MakeAuxiliaryTransaction(uint8_t hash_type, const std::vector<uint8_t>& data)
+{
+    CNEVMData payload;
+    payload.nVersionHashType = hash_type;
+    payload.vchVersionHash = hash_type == NEVM_DATA_LEGACY_VERSION_BYTE ?
+        dev::sha3(data).asBytes() : dev::blake2s(dev::bytesConstRef(data.data(), data.size())).asBytes();
+    std::vector<unsigned char> commitment;
+    payload.SerializeData(commitment);
+
+    CMutableTransaction tx;
+    tx.nVersion = SYSCOIN_TX_VERSION_NEVM_DATA_SHA3;
+    tx.vout.emplace_back(0, CScript() << OP_RETURN << commitment);
+    tx.vout.back().vchNEVMData = data;
+    return tx;
+}
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(nevm_auxiliary_tests, RegTestingSetup)
+
+BOOST_AUTO_TEST_CASE(commitments_and_auxiliary_limits_are_independent)
+{
+    const std::vector<uint8_t> data{'d', 'a', 't', 'a'};
+    for (const uint8_t type : {NEVM_DATA_LEGACY_VERSION_BYTE, NEVM_DATA_BLAKE2S_VERSION_BYTE}) {
+        const CMutableTransaction original = MakeAuxiliaryTransaction(type, data);
+        const CTransaction valid{original};
+        PoDAMAPMemory metadata;
+        BOOST_CHECK_EQUAL(ProcessNEVMData(m_node.chainman->m_blockman, valid, 100, 100, metadata),
+                          ProcessNEVMDataResult::VALID);
+        BOOST_REQUIRE_EQUAL(metadata.size(), 1U);
+
+        CMutableTransaction varied{original};
+        varied.vout.front().vchNEVMData.resize(MAX_NEVM_DATA_BLOB + 1);
+        const CTransaction bounded{varied};
+        const CNEVMData parsed{bounded};
+        BOOST_CHECK(!parsed.IsNull());
+        BOOST_CHECK(parsed.vchVersionHash == CNEVMData(valid).vchVersionHash);
+        BOOST_CHECK(bounded.GetHash() == valid.GetHash());
+        BOOST_CHECK(bounded.GetWitnessHash() == valid.GetWitnessHash());
+        metadata.clear();
+        BOOST_CHECK_EQUAL(ProcessNEVMData(m_node.chainman->m_blockman, bounded, 100, 100, metadata),
+                          ProcessNEVMDataResult::AUX_DATA_INVALID);
+        BOOST_CHECK(metadata.empty());
+
+        CBlock block;
+        block.vtx = {MakeTransactionRef(bounded)};
+        BOOST_CHECK_EQUAL(ProcessNEVMData(m_node.chainman->m_blockman, block, 100, 100, metadata),
+                          ProcessNEVMDataResult::AUX_DATA_INVALID);
+        BOOST_CHECK(metadata.empty());
+
+        varied.vout.front().vchNEVMData.clear();
+        BOOST_CHECK_EQUAL(ProcessNEVMData(m_node.chainman->m_blockman, CTransaction{varied}, 100, 100, metadata),
+                          ProcessNEVMDataResult::AUX_DATA_INVALID);
+        BOOST_CHECK(metadata.empty());
+        BOOST_CHECK_EQUAL(ProcessNEVMData(m_node.chainman->m_blockman, valid, 100, 100, metadata),
+                          ProcessNEVMDataResult::VALID);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(auxiliary_output_placement_is_checked)
+{
+    CMutableTransaction tx = MakeAuxiliaryTransaction(NEVM_DATA_LEGACY_VERSION_BYTE, {'o', 'k'});
+    tx.vout.emplace_back(0, CScript() << OP_RETURN);
+    PoDAMAPMemory metadata;
+    BOOST_CHECK_EQUAL(ProcessNEVMData(m_node.chainman->m_blockman, CTransaction{tx}, 100, 100, metadata),
+                      ProcessNEVMDataResult::VALID);
+    metadata.clear();
+    tx.vout.back().vchNEVMData = {'x'};
+    BOOST_CHECK_EQUAL(ProcessNEVMData(m_node.chainman->m_blockman, CTransaction{tx}, 100, 100, metadata),
+                      ProcessNEVMDataResult::AUX_DATA_INVALID);
+    BOOST_CHECK(metadata.empty());
+}
+
+BOOST_AUTO_TEST_CASE(committed_format_and_embedded_payload_checks_remain)
+{
+    CMutableTransaction tx = MakeAuxiliaryTransaction(NEVM_DATA_LEGACY_VERSION_BYTE, {'o', 'k'});
+    tx.vout.front().scriptPubKey = CScript() << OP_RETURN << std::vector<uint8_t>{1};
+    PoDAMAPMemory metadata;
+    BOOST_CHECK_EQUAL(ProcessNEVMData(m_node.chainman->m_blockman, CTransaction{tx}, 100, 100, metadata),
+                      ProcessNEVMDataResult::CONSENSUS_INVALID);
+    BOOST_CHECK(metadata.empty());
+
+    CNEVMData payload{CTransaction{MakeAuxiliaryTransaction(NEVM_DATA_LEGACY_VERSION_BYTE, {'o', 'k'})}};
+    std::vector<unsigned char> embedded;
+    payload.SerializeData(embedded);
+    CDataStream stream(embedded, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_PODA);
+    stream << std::vector<uint8_t>(MAX_NEVM_DATA_BLOB + 1);
+    const auto bytes = MakeUCharSpan(stream);
+    const std::vector<unsigned char> serialized{bytes.begin(), bytes.end()};
+    BOOST_CHECK_LT(payload.UnserializeFromData(serialized, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_PODA), 0);
+    BOOST_CHECK(payload.IsNull());
+}
+
+BOOST_AUTO_TEST_CASE(rejection_cache_uses_only_stable_results)
+{
+    const CTransaction ordinary{CMutableTransaction{}};
+    BOOST_CHECK(!IsTxRejectionCacheable(TxValidationResult::TX_RESULT_UNSET, ordinary));
+    BOOST_CHECK(!IsTxRejectionCacheable(TxValidationResult::TX_AUX_DATA_INVALID, ordinary));
+    BOOST_CHECK(!IsTxRejectionCacheable(TxValidationResult::TX_WITNESS_STRIPPED, ordinary));
+    BOOST_CHECK(IsTxRejectionCacheable(TxValidationResult::TX_CONSENSUS, ordinary));
+    BOOST_CHECK(IsTxRejectionCacheable(TxValidationResult::TX_NOT_STANDARD, ordinary));
+    BOOST_CHECK(IsTxRejectionCacheable(TxValidationResult::TX_INPUTS_NOT_STANDARD, ordinary));
+    BOOST_CHECK(IsTxRejectionCacheable(TxValidationResult::TX_WITNESS_MUTATED, ordinary));
+    BOOST_CHECK(IsBlockRejectionCacheable(BlockValidationResult::BLOCK_CONSENSUS));
+    BOOST_CHECK(!IsBlockRejectionCacheable(BlockValidationResult::BLOCK_RESULT_UNSET));
+    BOOST_CHECK(!IsBlockRejectionCacheable(BlockValidationResult::BLOCK_MUTATED));
+    BOOST_CHECK(!IsBlockRejectionCacheable(BlockValidationResult::BLOCK_AUX_DATA_INVALID));
+}
+
+BOOST_AUTO_TEST_CASE(optional_auxiliary_data_does_not_enable_identity_rejection_caching)
+{
+    CMutableTransaction tx = MakeAuxiliaryTransaction(NEVM_DATA_LEGACY_VERSION_BYTE, {'o', 'k'});
+    const int64_t now = 100 + NEVM_DATA_ENFORCE_TIME_HAVE_DATA + 1;
+    for (const bool include_data : {true, false}) {
+        if (!include_data) tx.vout.front().vchNEVMData.clear();
+        const CTransaction optional{tx};
+        PoDAMAPMemory metadata;
+        BOOST_CHECK_EQUAL(ProcessNEVMData(m_node.chainman->m_blockman, optional, 100, now, metadata),
+                          ProcessNEVMDataResult::VALID);
+        BOOST_CHECK_EQUAL(HasNEVMAuxiliaryData(optional), include_data);
+        CBlock block;
+        block.vtx = {MakeTransactionRef(optional)};
+        BOOST_CHECK_EQUAL(HasNEVMAuxiliaryData(block), include_data);
+        for (const auto result : {TxValidationResult::TX_CONSENSUS, TxValidationResult::TX_NOT_STANDARD,
+                                  TxValidationResult::TX_MEMPOOL_POLICY, TxValidationResult::TX_CONFLICT}) {
+            BOOST_CHECK(!IsTxRejectionCacheable(result, optional));
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(size_failure_classification_accounts_for_auxiliary_data)
+{
+    CMutableTransaction tx;
+    tx.vin.emplace_back(COutPoint{uint256S("01"), 0});
+    tx.vout.emplace_back(0, CScript{});
+    tx.vout.front().scriptPubKey.resize(MAX_BLOCK_WEIGHT / WITNESS_SCALE_FACTOR);
+    TxValidationState ordinary;
+    BOOST_CHECK(!CheckTransaction(CTransaction{tx}, ordinary));
+    BOOST_CHECK_EQUAL(ordinary.GetResult(), TxValidationResult::TX_CONSENSUS);
+    BOOST_CHECK_EQUAL(ordinary.GetRejectReason(), "bad-txns-oversize");
+
+    tx.nVersion = SYSCOIN_TX_VERSION_NEVM_DATA_SHA3;
+    tx.vout.front().vchNEVMData = {'x'};
+    TxValidationState auxiliary;
+    BOOST_CHECK(!CheckTransaction(CTransaction{tx}, auxiliary));
+    BOOST_CHECK_EQUAL(auxiliary.GetResult(), TxValidationResult::TX_AUX_DATA_INVALID);
+    BOOST_CHECK_EQUAL(auxiliary.GetRejectReason(), "bad-txns-oversize");
+}
+
+BOOST_AUTO_TEST_CASE(committed_disk_reads_preserve_ordinary_blocks)
+{
+    LOCK(cs_main);
+    const CBlockIndex* index = m_node.chainman->ActiveChain().Tip();
+    BOOST_REQUIRE(index);
+    CBlock with_auxiliary;
+    CBlock committed;
+    BOOST_REQUIRE(m_node.chainman->m_blockman.ReadBlockFromDisk(with_auxiliary, *index));
+    BOOST_REQUIRE(m_node.chainman->m_blockman.ReadBlockFromDisk(committed, *index, /*load_auxiliary_data=*/false));
+    BOOST_CHECK(with_auxiliary.GetHash() == committed.GetHash());
+    BOOST_REQUIRE_EQUAL(with_auxiliary.vtx.size(), committed.vtx.size());
+    for (size_t i = 0; i < committed.vtx.size(); ++i) {
+        BOOST_CHECK(with_auxiliary.vtx[i]->GetHash() == committed.vtx[i]->GetHash());
+        BOOST_CHECK(with_auxiliary.vtx[i]->GetWitnessHash() == committed.vtx[i]->GetWitnessHash());
+    }
+    BlockValidationState state;
+    BOOST_CHECK(CheckBlock(committed, state, Params().GetConsensus()));
+}
+
+BOOST_AUTO_TEST_CASE(admission_checks_auxiliary_data_before_orphan_eligibility)
+{
+    CMutableTransaction original = MakeAuxiliaryTransaction(NEVM_DATA_LEGACY_VERSION_BYTE, {'o', 'k'});
+    original.vin.emplace_back(COutPoint{uint256S("01"), 0});
+    CMutableTransaction varied{original};
+    varied.vout.front().vchNEVMData.resize(MAX_NEVM_DATA_BLOB + 1);
+    LOCK(cs_main);
+    const auto auxiliary = m_node.chainman->ProcessTransaction(MakeTransactionRef(varied), /*test_accept=*/true);
+    BOOST_CHECK(auxiliary.m_result_type == MempoolAcceptResult::ResultType::INVALID);
+    BOOST_CHECK_EQUAL(auxiliary.m_state.GetResult(), TxValidationResult::TX_AUX_DATA_INVALID);
+    BOOST_CHECK(!IsTxRejectionCacheable(auxiliary.m_state.GetResult(), CTransaction{varied}));
+
+    // Valid auxiliary data must still reach the ordinary missing-input checks.
+    const auto missing = m_node.chainman->ProcessTransaction(MakeTransactionRef(original), /*test_accept=*/true);
+    BOOST_CHECK(missing.m_result_type == MempoolAcceptResult::ResultType::INVALID);
+    BOOST_CHECK_EQUAL(missing.m_state.GetResult(), TxValidationResult::TX_MISSING_INPUTS);
+    BOOST_CHECK(!IsTxRejectionCacheable(missing.m_state.GetResult(), CTransaction{original}));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/nevm_auxiliary_tests.cpp
+++ b/src/test/nevm_auxiliary_tests.cpp
@@ -6,15 +6,22 @@
 #include <consensus/tx_check.h>
 #include <consensus/validation.h>
 #include <nevm/sha3.h>
+#include <node/blockconnection.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
+#include <script/sign.h>
+#include <script/signingprovider.h>
 #include <streams.h>
 #include <sync.h>
+#include <test/util/coins.h>
 #include <test/util/setup_common.h>
+#include <util/time.h>
 #include <validation.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
@@ -35,6 +42,147 @@ CMutableTransaction MakeAuxiliaryTransaction(uint8_t hash_type, const std::vecto
     tx.vout.back().vchNEVMData = data;
     return tx;
 }
+
+struct AuxiliaryRetrySetup : TestChain100Setup {
+    CBlockIndex* index{nullptr};
+    COutPoint input;
+    COutPoint output;
+
+    AuxiliaryRetrySetup()
+    {
+        const CTransaction& funding = *m_coinbase_txns.front();
+        CMutableTransaction tx = MakeAuxiliaryTransaction(NEVM_DATA_LEGACY_VERSION_BYTE, {'r', 'e', 't', 'r', 'y'});
+        input = COutPoint{funding.GetHash(), 0};
+        tx.vin.emplace_back(input);
+        tx.vout.emplace_back(funding.vout.front().nValue - 1000, CScript() << OP_TRUE);
+        FillableSigningProvider provider;
+        provider.AddKey(coinbaseKey);
+        SignatureData signature;
+        BOOST_REQUIRE(SignSignature(provider, funding, tx, 0, SIGHASH_ALL, signature));
+        output = COutPoint{tx.GetHash(), 1};
+
+        const auto block = std::make_shared<const CBlock>(
+            CreateBlock({tx}, CScript() << OP_TRUE, m_node.chainman->ActiveChainstate()));
+        LOCK(cs_main);
+        BlockValidationState state;
+        bool new_block{false};
+        BOOST_REQUIRE(m_node.chainman->AcceptBlock(block, state, &index, /*fRequested=*/true,
+                                                  /*dbp=*/nullptr, &new_block, /*min_pow_checked=*/true));
+        BOOST_REQUIRE(new_block);
+        BOOST_REQUIRE(index);
+        BOOST_REQUIRE(m_node.chainman->ActiveTip() == index->pprev);
+    }
+
+    std::shared_ptr<const CBlock> ReadCandidate(bool load_auxiliary_data = true)
+        EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+    {
+        auto block = std::make_shared<CBlock>();
+        BOOST_REQUIRE(m_node.chainman->m_blockman.ReadBlockFromDisk(*block, *index, load_auxiliary_data));
+        BOOST_REQUIRE_EQUAL(block->vtx.size(), 2U);
+        BOOST_REQUIRE_EQUAL(HasNEVMAuxiliaryData(*block), load_auxiliary_data);
+        return block;
+    }
+
+    void CheckRetry(bool require_data)
+    {
+        LOCK(cs_main);
+        auto& chainstate = m_node.chainman->ActiveChainstate();
+        auto& coins_tip = chainstate.CoinsTip();
+        const uint256 tip_hash = coins_tip.GetBestBlock();
+        SetMockTime(index->GetMedianTimePast() + (require_data ? 0 : NEVM_DATA_ENFORCE_TIME_HAVE_DATA + 1));
+        auto block = ReadCandidate();
+        const auto original = block;
+
+        // The first failure is injected, not caused by invalid transaction or
+        // blob bytes. Establish the ordinary attached representation as a control.
+        BlockValidationState control_state;
+        node::BlockConnectionState control{coins_tip};
+        BOOST_REQUIRE(chainstate.ConnectBlock(*block, control_state, index, *control.view, /*fJustCheck=*/true,
+                                              control.mint_txs, control.nevm_tx_roots, control.poda, control.txid_pairs));
+        BOOST_REQUIRE_EQUAL(control.poda.size(), 1U);
+
+        CCoinsViewCache parent{&coins_tip};
+        node::BlockConnectionState connection{parent};
+        BlockValidationState state;
+        const uint256 marker{uint256S("01")};
+        const std::vector<uint8_t> marker_key(32, 0x42);
+        COutPoint staged_coin;
+        unsigned int attempts{0};
+        const auto result = node::ConnectBlockWithAuxiliaryRetry(
+            m_node.chainman->m_blockman, *index, /*loaded_from_disk=*/true, block, state, parent, connection,
+            [&]() EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
+                ++attempts;
+                BOOST_REQUIRE(state.IsValid());
+                BOOST_CHECK(state.GetRejectReason().empty());
+                BOOST_CHECK(state.GetDebugMessage().empty());
+                if (attempts == 1) {
+                    BOOST_REQUIRE(HasNEVMAuxiliaryData(*block));
+                    staged_coin = AddTestCoin(*connection.view);
+                    connection.view->SetBestBlock(marker);
+                    connection.mint_txs.insert(marker);
+                    connection.nevm_tx_roots.emplace(marker, NEVMTxRoot{});
+                    connection.poda.emplace(marker_key, MapPoDAPayloadMeta{marker, 0, 0});
+                    connection.txid_pairs.emplace_back(marker, 0);
+                    return state.Invalid(BlockValidationResult::BLOCK_AUX_DATA_INVALID,
+                                         "injected-auxiliary-result", "first-attempt state");
+                }
+                BOOST_REQUIRE_EQUAL(attempts, 2U);
+                BOOST_REQUIRE(!HasNEVMAuxiliaryData(*block));
+                BOOST_REQUIRE(block->GetHash() == original->GetHash());
+                BOOST_REQUIRE(block->vtx[1]->GetWitnessHash() == original->vtx[1]->GetWitnessHash());
+                BOOST_REQUIRE_EQUAL(connection.view->GetCacheSize(), 0U);
+                BOOST_REQUIRE(connection.view->GetBestBlock() == tip_hash);
+                BOOST_REQUIRE(!connection.view->HaveCoin(staged_coin));
+                BOOST_REQUIRE(connection.mint_txs.empty());
+                BOOST_REQUIRE(connection.nevm_tx_roots.empty());
+                BOOST_REQUIRE(connection.poda.empty());
+                BOOST_REQUIRE(connection.txid_pairs.empty());
+                return chainstate.ConnectBlock(*block, state, index, *connection.view, /*fJustCheck=*/false,
+                                               connection.mint_txs, connection.nevm_tx_roots,
+                                               connection.poda, connection.txid_pairs);
+            });
+
+        BOOST_CHECK_EQUAL(attempts, 2U);
+        BOOST_CHECK(block != original);
+        BOOST_CHECK(HasNEVMAuxiliaryData(*original));
+        BOOST_CHECK(!HasNEVMAuxiliaryData(*block));
+        BOOST_CHECK(!parent.HaveCoin(staged_coin));
+        BOOST_CHECK(parent.HaveCoin(input));
+        BOOST_CHECK(!parent.HaveCoin(output));
+        BOOST_CHECK(parent.GetBestBlock() == tip_hash);
+        BOOST_CHECK_EQUAL(connection.mint_txs.count(marker), 0U);
+        BOOST_CHECK_EQUAL(connection.nevm_tx_roots.count(marker), 0U);
+        BOOST_CHECK_EQUAL(connection.poda.count(marker_key), 0U);
+        BOOST_CHECK(std::none_of(connection.txid_pairs.begin(), connection.txid_pairs.end(),
+                                 [&](const auto& entry) { return entry.first == marker; }));
+
+        if (require_data) {
+            BOOST_CHECK(result == node::BlockConnectionResult::FAILED);
+            BOOST_CHECK(state.IsInvalid());
+            BOOST_CHECK_EQUAL(state.GetResult(), BlockValidationResult::BLOCK_AUX_DATA_INVALID);
+            BOOST_CHECK_EQUAL(state.GetRejectReason(), "poda-aux-data-invalid");
+            BOOST_CHECK(!IsBlockRejectionCacheable(state.GetResult()));
+            BOOST_CHECK(connection.poda.empty());
+            BOOST_CHECK(connection.view->HaveCoin(input));
+            BOOST_CHECK(!connection.view->HaveCoin(output));
+        } else {
+            BOOST_CHECK(result == node::BlockConnectionResult::SUCCESS);
+            BOOST_CHECK(state.IsValid());
+            BOOST_CHECK_EQUAL(connection.poda.size(), 1U);
+            BOOST_CHECK(!connection.view->HaveCoin(input));
+            BOOST_CHECK(connection.view->HaveCoin(output));
+            BOOST_REQUIRE(connection.view->Flush());
+            BOOST_CHECK(!parent.HaveCoin(staged_coin));
+            BOOST_CHECK(!parent.HaveCoin(input));
+            BOOST_CHECK(parent.HaveCoin(output));
+            BOOST_CHECK(parent.GetBestBlock() == index->GetBlockHash());
+        }
+        BOOST_CHECK(coins_tip.GetBestBlock() == tip_hash);
+        BOOST_CHECK(coins_tip.HaveCoin(input));
+        BOOST_CHECK(!coins_tip.HaveCoin(output));
+        BOOST_CHECK(m_node.chainman->ActiveTip() == index->pprev);
+    }
+};
 } // namespace
 
 BOOST_FIXTURE_TEST_SUITE(nevm_auxiliary_tests, RegTestingSetup)
@@ -236,6 +384,88 @@ BOOST_AUTO_TEST_CASE(committed_disk_reads_preserve_ordinary_blocks)
     }
     BlockValidationState state;
     BOOST_CHECK(CheckBlock(committed, state, Params().GetConsensus()));
+}
+
+BOOST_FIXTURE_TEST_CASE(disk_auxiliary_retry_reconnects_with_fresh_state, AuxiliaryRetrySetup)
+{
+    CheckRetry(/*require_data=*/false);
+}
+
+BOOST_FIXTURE_TEST_CASE(disk_auxiliary_retry_preserves_required_data_checks, AuxiliaryRetrySetup)
+{
+    CheckRetry(/*require_data=*/true);
+}
+
+BOOST_FIXTURE_TEST_CASE(disk_auxiliary_retry_is_limited_to_eligible_failures, AuxiliaryRetrySetup)
+{
+    LOCK(cs_main);
+    struct Case {
+        bool loaded_from_disk;
+        bool with_auxiliary;
+        bool success;
+        BlockValidationResult failure;
+    };
+    for (const auto& test : {
+             Case{true, true, true, BlockValidationResult::BLOCK_RESULT_UNSET},
+             Case{false, true, false, BlockValidationResult::BLOCK_AUX_DATA_INVALID},
+             Case{true, false, false, BlockValidationResult::BLOCK_AUX_DATA_INVALID},
+             Case{true, true, false, BlockValidationResult::BLOCK_CONSENSUS},
+             Case{true, true, false, BlockValidationResult::BLOCK_MUTATED}}) {
+        auto block = ReadCandidate(test.with_auxiliary);
+        const auto original = block;
+        CCoinsViewCache parent{&m_node.chainman->ActiveChainstate().CoinsTip()};
+        node::BlockConnectionState connection{parent};
+        BlockValidationState state;
+        unsigned int attempts{0};
+        const uint256 marker{uint256S("01")};
+        const auto result = node::ConnectBlockWithAuxiliaryRetry(
+            m_node.chainman->m_blockman, *index, test.loaded_from_disk, block, state, parent, connection,
+            [&] {
+                ++attempts;
+                connection.mint_txs.insert(marker);
+                return test.success || state.Invalid(test.failure, "injected-result");
+            });
+        BOOST_CHECK_EQUAL(attempts, 1U);
+        BOOST_CHECK(block == original);
+        BOOST_CHECK_EQUAL(connection.mint_txs.count(marker), 1U);
+        BOOST_CHECK(result == (test.success ? node::BlockConnectionResult::SUCCESS : node::BlockConnectionResult::FAILED));
+        BOOST_CHECK_EQUAL(state.GetResult(), test.failure);
+    }
+}
+
+BOOST_FIXTURE_TEST_CASE(disk_auxiliary_retry_preserves_reread_errors, AuxiliaryRetrySetup)
+{
+    LOCK(cs_main);
+    auto block = ReadCandidate();
+    const auto original = block;
+    CCoinsViewCache parent{&m_node.chainman->ActiveChainstate().CoinsTip()};
+    node::BlockConnectionState connection{parent};
+    BlockValidationState state;
+    unsigned int attempts{0};
+    const uint256 marker{uint256S("01")};
+    CBlockIndex mismatched_index;
+    mismatched_index.nStatus = BLOCK_HAVE_DATA;
+    mismatched_index.nFile = index->nFile;
+    mismatched_index.nDataPos = index->nDataPos;
+    // Exercise the real indexed-read failure without changing stored block bytes.
+    mismatched_index.phashBlock = &marker;
+    const auto result = node::ConnectBlockWithAuxiliaryRetry(
+        m_node.chainman->m_blockman, mismatched_index, /*loaded_from_disk=*/true, block, state, parent, connection,
+        [&] {
+            ++attempts;
+            connection.mint_txs.insert(marker);
+            connection.view->SetBestBlock(marker);
+            return state.Invalid(BlockValidationResult::BLOCK_AUX_DATA_INVALID, "injected-result");
+        });
+    BOOST_CHECK(result == node::BlockConnectionResult::DISK_READ_FAILED);
+    BOOST_CHECK_EQUAL(attempts, 1U);
+    BOOST_CHECK(block == original);
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK_EQUAL(state.GetResult(), BlockValidationResult::BLOCK_AUX_DATA_INVALID);
+    BOOST_CHECK_EQUAL(state.GetRejectReason(), "injected-result");
+    BOOST_CHECK_EQUAL(connection.mint_txs.count(marker), 1U);
+    BOOST_CHECK(connection.view->GetBestBlock() == marker);
+    BOOST_CHECK(parent.GetBestBlock() == index->pprev->GetBlockHash());
 }
 
 BOOST_AUTO_TEST_CASE(admission_checks_auxiliary_data_before_orphan_eligibility)

--- a/src/test/nevm_auxiliary_tests.cpp
+++ b/src/test/nevm_auxiliary_tests.cpp
@@ -164,8 +164,59 @@ BOOST_AUTO_TEST_CASE(size_failure_classification_accounts_for_auxiliary_data)
     tx.vout.front().vchNEVMData = {'x'};
     TxValidationState auxiliary;
     BOOST_CHECK(!CheckTransaction(CTransaction{tx}, auxiliary));
-    BOOST_CHECK_EQUAL(auxiliary.GetResult(), TxValidationResult::TX_AUX_DATA_INVALID);
+    BOOST_CHECK_EQUAL(auxiliary.GetResult(), TxValidationResult::TX_CONSENSUS);
     BOOST_CHECK_EQUAL(auxiliary.GetRejectReason(), "bad-txns-oversize");
+
+    tx.vout.front().scriptPubKey.front() = OP_RETURN;
+    TxValidationState unspendable;
+    BOOST_CHECK(!CheckTransaction(CTransaction{tx}, unspendable));
+    BOOST_CHECK_EQUAL(unspendable.GetResult(), TxValidationResult::TX_CONSENSUS);
+    BOOST_CHECK_EQUAL(unspendable.GetRejectReason(), "bad-txns-oversize");
+}
+
+BOOST_AUTO_TEST_CASE(committed_size_omits_only_auxiliary_contributions)
+{
+    for (const size_t data_size : {0U, 1U, 99U, 100U, 101U, 200U}) {
+        CMutableTransaction tx = MakeAuxiliaryTransaction(NEVM_DATA_LEGACY_VERSION_BYTE,
+                                                        std::vector<uint8_t>(data_size, 'x'));
+        tx.vin.emplace_back(COutPoint{uint256S("01"), 0});
+        tx.vout.emplace_back(0, CScript() << OP_TRUE);
+        tx.vout.back().vchNEVMData.assign(200, 'y');
+        for (const bool with_witness : {false, true}) {
+            if (with_witness) tx.vin.front().scriptWitness.stack = {{1, 2, 3}};
+            CMutableTransaction cleared{tx};
+            for (auto& output : cleared.vout) output.vchNEVMData.clear();
+            const CTransaction attached{tx};
+            const CTransaction committed{cleared};
+            CBlock attached_block;
+            attached_block.SetNEVMVersion();
+            attached_block.vtx = {MakeTransactionRef(attached)};
+            CBlock committed_block;
+            committed_block.SetNEVMVersion();
+            committed_block.vtx = {MakeTransactionRef(committed)};
+
+            for (const int version : {PROTOCOL_VERSION, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS}) {
+                const auto committed_size = ::GetSerializeSize(attached, version, SER_SIZE | SER_NO_PODA);
+                BOOST_CHECK_EQUAL(committed_size, ::GetSerializeSize(committed, version));
+                BOOST_CHECK_EQUAL(::GetSerializeSize(attached, version) - committed_size,
+                                  static_cast<size_t>(data_size * NEVM_DATA_SCALE_FACTOR));
+                BOOST_CHECK_EQUAL(::GetSerializeSize(attached_block, version, SER_SIZE | SER_NO_PODA),
+                                  ::GetSerializeSize(committed_block, version));
+                attached_block.vchNEVMBlockData.assign(200, 'z');
+                BOOST_CHECK_EQUAL(::GetSerializeSize(attached_block, version, SER_SIZE | SER_NO_PODA),
+                                  ::GetSerializeSize(committed_block, version));
+
+                CMutableTransaction ordinary{tx};
+                ordinary.nVersion = CTransaction::CURRENT_VERSION;
+                BOOST_CHECK_EQUAL(::GetSerializeSize(ordinary, version, SER_SIZE | SER_NO_PODA),
+                                  ::GetSerializeSize(ordinary, version));
+            }
+            const auto committed_weight =
+                ::GetSerializeSize(attached_block, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS, SER_SIZE | SER_NO_PODA) * (WITNESS_SCALE_FACTOR - 1) +
+                ::GetSerializeSize(attached_block, PROTOCOL_VERSION, SER_SIZE | SER_NO_PODA);
+            BOOST_CHECK_EQUAL(committed_weight, GetBlockWeight(committed_block));
+        }
+    }
 }
 
 BOOST_AUTO_TEST_CASE(committed_disk_reads_preserve_ordinary_blocks)

--- a/src/test/nevm_cache_writeback_tests.cpp
+++ b/src/test/nevm_cache_writeback_tests.cpp
@@ -1,0 +1,227 @@
+// Copyright (c) 2026 The Syscoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <arith_uint256.h>
+#include <dbwrapper.h>
+#include <primitives/transaction.h>
+#include <services/assetconsensus.h>
+#include <test/util/setup_common.h>
+#include <uint256.h>
+#include <util/fs.h>
+#include <util/hasher.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+
+namespace {
+uint256 TestHash(uint64_t value)
+{
+    return ArithToUint256(arith_uint256{value});
+}
+
+const uint256& CacheKey(const uint256& key)
+{
+    return key;
+}
+
+const uint256& CacheKey(const NEVMTxRootMap::value_type& entry)
+{
+    return entry.first;
+}
+
+void AddCacheEntry(CDBBatch& batch, const uint256& key)
+{
+    batch.Write(key, true);
+}
+
+void AddCacheEntry(CDBBatch& batch, const NEVMTxRootMap::value_type& entry)
+{
+    batch.Write(entry.first, entry.second);
+}
+
+void CheckStoredEntry(CDBWrapper& db, const uint256& key)
+{
+    bool marker{false};
+    BOOST_REQUIRE(db.Read(key, marker));
+    BOOST_CHECK(marker);
+}
+
+void CheckStoredEntry(CDBWrapper& db, const NEVMTxRootMap::value_type& entry)
+{
+    NEVMTxRoot roots;
+    BOOST_REQUIRE(db.Read(entry.first, roots));
+    BOOST_CHECK(roots.nTxRoot == entry.second.nTxRoot);
+    BOOST_CHECK(roots.nReceiptRoot == entry.second.nReceiptRoot);
+}
+
+template <typename Cache>
+void CheckFailedChunk(const fs::path& path, Cache cache, std::size_t chunk_items,
+                      std::size_t failed_chunk, bool throw_error, bool sync)
+{
+    CDBWrapper db({.path = path, .cache_bytes = 1 << 20, .memory_only = true});
+    // Snapshot this container's order; salted hash iteration is not key order.
+    const std::vector<typename Cache::value_type> entries(cache.begin(), cache.end());
+    std::size_t staged_items{0};
+    std::vector<std::size_t> batch_sizes;
+    const auto add_entry = [&](CDBBatch& batch, const auto& entry) {
+        AddCacheEntry(batch, entry);
+        ++staged_items;
+    };
+    const auto fail_writer = [&](CDBBatch& batch, bool actual_sync) {
+        BOOST_CHECK_EQUAL(actual_sync, sync);
+        batch_sizes.push_back(staged_items);
+        staged_items = 0;
+        if (batch_sizes.size() == failed_chunk) {
+            if (throw_error) throw dbwrapper_error("local writeback test failure");
+            return false;
+        }
+        return db.WriteBatch(batch, actual_sync);
+    };
+    const auto flush = [&] {
+        return nevm_cache_detail::FlushCache(db, cache, chunk_items, sync, add_entry, fail_writer);
+    };
+    if (throw_error) {
+        BOOST_CHECK_THROW(flush(), dbwrapper_error);
+    } else {
+        BOOST_CHECK(!flush());
+    }
+
+    BOOST_REQUIRE_EQUAL(batch_sizes.size(), failed_chunk);
+    const std::size_t written_items = chunk_items * (failed_chunk - 1);
+    BOOST_REQUIRE(written_items < entries.size());
+    const std::size_t limit = chunk_items == 0 ? entries.size() : chunk_items;
+    BOOST_CHECK_EQUAL(batch_sizes.back(), std::min(limit, entries.size() - written_items));
+    BOOST_CHECK_EQUAL(cache.size(), entries.size() - written_items);
+    for (std::size_t i = 0; i < entries.size(); ++i) {
+        const auto& key = CacheKey(entries[i]);
+        BOOST_CHECK_EQUAL(cache.count(key), i >= written_items ? 1U : 0U);
+        BOOST_CHECK_EQUAL(db.Exists(key), i < written_items);
+        if (i < written_items) CheckStoredEntry(db, entries[i]);
+    }
+
+    std::size_t retry_items{0};
+    const auto retry_entry = [&](CDBBatch& batch, const auto& entry) {
+        AddCacheEntry(batch, entry);
+        ++retry_items;
+    };
+    const auto retry_writer = [&](CDBBatch& batch, bool actual_sync) {
+        BOOST_CHECK_EQUAL(actual_sync, sync);
+        return db.WriteBatch(batch, actual_sync);
+    };
+    BOOST_REQUIRE(nevm_cache_detail::FlushCache(db, cache, chunk_items, sync, retry_entry, retry_writer));
+    BOOST_CHECK(cache.empty());
+    BOOST_CHECK_EQUAL(retry_items, entries.size() - written_items);
+    for (const auto& entry : entries) CheckStoredEntry(db, entry);
+}
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(nevm_cache_writeback_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(failed_batches_preserve_pending_entries)
+{
+    for (const bool sync : {false, true}) {
+        for (const bool throw_error : {false, true}) {
+            for (const std::size_t chunk_items : {0U, 1U, 2U, 256U}) {
+                const std::size_t entry_count = chunk_items == 0 ? 5 : 2 * chunk_items + 1;
+                NEVMMintTxSet mints;
+                NEVMTxRootMap roots;
+                for (std::size_t i = 0; i < entry_count; ++i) {
+                    const uint256 key = TestHash(i + 1);
+                    mints.insert(key);
+                    roots.emplace(key, NEVMTxRoot{TestHash(i + 1000), TestHash(i + 2000)});
+                }
+                const std::size_t chunk_count = chunk_items == 0 ? 1 : (entry_count + chunk_items - 1) / chunk_items;
+                for (std::size_t failed_chunk = 1; failed_chunk <= chunk_count; ++failed_chunk) {
+                    BOOST_TEST_CONTEXT("chunk_items=" << chunk_items << ", failed_chunk=" << failed_chunk
+                                                     << ", throw=" << throw_error << ", sync=" << sync) {
+                        CheckFailedChunk(m_args.GetDataDirBase() / "mint_writeback", mints,
+                                         chunk_items, failed_chunk, throw_error, sync);
+                        CheckFailedChunk(m_args.GetDataDirBase() / "root_writeback", roots,
+                                         chunk_items, failed_chunk, throw_error, sync);
+                    }
+                }
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(empty_cache_does_not_write)
+{
+    CDBWrapper db({.path = m_args.GetDataDirBase() / "empty_writeback", .cache_bytes = 1 << 20, .memory_only = true});
+    NEVMMintTxSet mints;
+    NEVMTxRootMap roots;
+    const auto unexpected_entry = [](CDBBatch&, const auto&) { BOOST_FAIL("empty cache staged an entry"); };
+    const auto unexpected_writer = [](CDBBatch&, bool) {
+        BOOST_FAIL("empty cache submitted a batch");
+        return false;
+    };
+    for (const std::size_t chunk_items : {0U, 1U, 256U}) {
+        BOOST_CHECK(nevm_cache_detail::FlushCache(db, mints, chunk_items, true, unexpected_entry, unexpected_writer));
+        BOOST_CHECK(nevm_cache_detail::FlushCache(db, roots, chunk_items, false, unexpected_entry, unexpected_writer));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(public_cache_flush_preserves_serialization_and_persistence)
+{
+    const fs::path mint_path = m_args.GetDataDirBase() / "mint_writeback_persistence";
+    const fs::path root_path = m_args.GetDataDirBase() / "root_writeback_persistence";
+    for (const bool sync : {false, true}) {
+        for (const std::size_t chunk_items : {0U, 1U, 2U, 256U}) {
+            const std::size_t full_chunk = chunk_items == 0 ? 5 : chunk_items;
+            for (const std::size_t entry_count : {std::size_t{0}, std::size_t{1}, full_chunk, full_chunk + 1}) {
+                NEVMMintTxSet mints;
+                NEVMTxRootMap roots;
+                for (std::size_t i = 0; i < entry_count; ++i) {
+                    const uint256 key = TestHash(i + 1);
+                    mints.insert(key);
+                    roots.emplace(key, NEVMTxRoot{TestHash(i + 1000), TestHash(i + 2000)});
+                }
+                {
+                    CNEVMMintedTxDB mint_db({.path = mint_path, .cache_bytes = 1 << 20, .wipe_data = true});
+                    CNEVMTxRootsDB root_db({.path = root_path, .cache_bytes = 1 << 20, .wipe_data = true});
+                    mint_db.FlushDataToCache(mints);
+                    root_db.FlushDataToCache(roots);
+                    for (const auto& key : mints) {
+                        BOOST_CHECK(mint_db.ExistsTx(key));
+                        BOOST_CHECK(!mint_db.Exists(key));
+                    }
+                    for (const auto& entry : roots) {
+                        NEVMTxRoot value;
+                        BOOST_REQUIRE(root_db.ReadTxRoots(entry.first, value));
+                        BOOST_CHECK(value.nTxRoot == entry.second.nTxRoot);
+                        BOOST_CHECK(value.nReceiptRoot == entry.second.nReceiptRoot);
+                        BOOST_CHECK(!root_db.Exists(entry.first));
+                    }
+                    BOOST_REQUIRE(mint_db.FlushCacheToDisk(chunk_items, sync));
+                    BOOST_REQUIRE(root_db.FlushCacheToDisk(chunk_items, sync));
+                    for (const auto& key : mints) CheckStoredEntry(mint_db, key);
+                    for (const auto& entry : roots) CheckStoredEntry(root_db, entry);
+                    BOOST_REQUIRE(mint_db.FlushCacheToDisk(chunk_items, sync));
+                    BOOST_REQUIRE(root_db.FlushCacheToDisk(chunk_items, sync));
+                }
+                {
+                    CNEVMMintedTxDB mint_db({.path = mint_path, .cache_bytes = 1 << 20});
+                    CNEVMTxRootsDB root_db({.path = root_path, .cache_bytes = 1 << 20});
+                    for (const auto& key : mints) {
+                        BOOST_CHECK(mint_db.ExistsTx(key));
+                        CheckStoredEntry(mint_db, key);
+                    }
+                    for (const auto& entry : roots) {
+                        NEVMTxRoot value;
+                        BOOST_REQUIRE(root_db.ReadTxRoots(entry.first, value));
+                        BOOST_CHECK(value.nTxRoot == entry.second.nTxRoot);
+                        BOOST_CHECK(value.nReceiptRoot == entry.second.nReceiptRoot);
+                        CheckStoredEntry(root_db, entry);
+                    }
+                }
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/nevm_ownership_tests.cpp
+++ b/src/test/nevm_ownership_tests.cpp
@@ -1,0 +1,631 @@
+// Copyright (c) 2026 The Syscoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <dbwrapper.h>
+#include <primitives/transaction.h>
+#include <services/nevmconsensus.h>
+#include <streams.h>
+#include <sync.h>
+#include <test/util/setup_common.h>
+#include <uint256.h>
+#include <util/fs.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace {
+struct LegacyPoDAMetadata
+{
+    uint256 txid;
+    uint32_t size;
+    int64_t median_time;
+
+    SERIALIZE_METHODS(LegacyPoDAMetadata, obj) { READWRITE(obj.txid, obj.size, obj.median_time); }
+};
+
+struct PoDAOwnershipSetup : BasicTestingSetup
+{
+    const bool m_original_testnet{fTestNet};
+
+    PoDAOwnershipSetup()
+    {
+        fTestNet = false;
+        Open(/*memory_only=*/true, /*wipe_data=*/true);
+    }
+
+    ~PoDAOwnershipSetup() { fTestNet = m_original_testnet; }
+
+    void Open(bool memory_only, bool wipe_data)
+    {
+        pnevmdatadb.reset();
+        pnevmdatablobdb.reset();
+        pnevmdatadb = std::make_unique<CNEVMDataDB>(DBParams{
+            .path = m_path_root / "ownership_metadata",
+            .cache_bytes = size_t{1 << 20},
+            .memory_only = memory_only,
+            .wipe_data = wipe_data});
+        pnevmdatablobdb = std::make_unique<CNEVMDataBlobDB>(DBParams{
+            .path = m_path_root / "ownership_payloads",
+            .cache_bytes = size_t{1 << 20},
+            .memory_only = memory_only,
+            .wipe_data = wipe_data});
+    }
+
+    void Store(const std::vector<uint8_t>& version_hash, const uint256& txid,
+               int64_t median_time, PoDAFlushSource source, uint32_t size = 4)
+    {
+        MapPoDAPayloadMeta meta{txid, size, median_time};
+        meta.vchNEVMData = std::make_shared<const std::vector<uint8_t>>(size, uint8_t{1});
+        pnevmdatadb->FlushDataToCache({{version_hash, meta}}, source);
+    }
+
+    void StoreMetadataOnly(const std::vector<uint8_t>& version_hash, const uint256& txid,
+                           int64_t median_time, PoDAFlushSource source, bool empty_payload = false)
+    {
+        MapPoDAPayloadMeta meta{txid, 0, median_time};
+        if (empty_payload) meta.vchNEVMData = std::make_shared<const std::vector<uint8_t>>();
+        pnevmdatadb->FlushDataToCache({{version_hash, meta}}, source);
+    }
+
+    void CheckMetadata(const std::vector<uint8_t>& version_hash, const uint256& txid,
+                       int64_t median_time, uint32_t size = 4, bool expect_blob = true)
+    {
+        MapPoDAPayloadMeta meta;
+        BOOST_REQUIRE(pnevmdatadb->GetBlobMetaData(version_hash, meta));
+        BOOST_CHECK(meta.txid == txid);
+        BOOST_CHECK_EQUAL(meta.nSize, size);
+        BOOST_CHECK_EQUAL(meta.nMedianTime, median_time);
+        BOOST_CHECK_EQUAL(pnevmdatablobdb->Exists(version_hash), expect_blob);
+    }
+
+    void CheckReinsertedLegacyIsRetained(const std::vector<uint8_t>& version_hash, const uint256& txid)
+    {
+        BOOST_REQUIRE(pnevmdatadb->Write(version_hash, LegacyPoDAMetadata{txid, 4, 3000}, true));
+        BOOST_REQUIRE(pnevmdatablobdb->Write(version_hash, std::vector<uint8_t>(4, 1), true));
+        BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(version_hash, txid));
+        CheckMetadata(version_hash, txid, 3000);
+    }
+};
+} // namespace
+
+BOOST_FIXTURE_TEST_SUITE(nevm_ownership_tests, PoDAOwnershipSetup)
+
+BOOST_AUTO_TEST_CASE(block_promotion_retains_same_and_different_transaction_owners)
+{
+    const uint256 mempool_txid{uint256S("01")};
+    uint8_t seed{0};
+    for (bool flush_mempool : {false, true}) {
+        for (bool flush_block : {false, true}) {
+            for (bool same_txid : {false, true}) {
+                const std::vector<uint8_t> key(32, ++seed);
+                const uint256 block_txid{same_txid ? mempool_txid : uint256S("02")};
+                Store(key, mempool_txid, 1000, PoDAFlushSource::Mempool);
+                if (flush_mempool) BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+
+                Store(key, block_txid, 2000, PoDAFlushSource::Block);
+                if (flush_block) BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(2000));
+                BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, mempool_txid));
+                CheckMetadata(key, block_txid, 2000);
+
+                Store(key, block_txid, 3000, PoDAFlushSource::Mempool);
+                BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, block_txid));
+                CheckMetadata(key, block_txid, 2000);
+                BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(3000));
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(mempool_cleanup_requires_matching_exclusive_owner)
+{
+    const uint256 owner{uint256S("01")};
+    uint8_t seed{0};
+    for (bool flush : {false, true}) {
+        const std::vector<uint8_t> key(32, ++seed);
+        Store(key, owner, 1000, PoDAFlushSource::Mempool);
+        if (flush) BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+        BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, uint256S("02")));
+        CheckMetadata(key, owner, 1000);
+        Store(key, owner, 2000, PoDAFlushSource::Mempool);
+        CheckMetadata(key, owner, 1000);
+        BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, owner));
+        BOOST_CHECK(!pnevmdatadb->BlobExists(key));
+        BOOST_CHECK(!pnevmdatablobdb->Exists(key));
+    }
+
+    const std::vector<uint8_t> block_key(32, 3);
+    Store(block_key, owner, 1000, PoDAFlushSource::Block);
+    Store(block_key, owner, 2000, PoDAFlushSource::Mempool);
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(block_key, owner));
+    CheckMetadata(block_key, owner, 1000);
+}
+
+BOOST_AUTO_TEST_CASE(owner_release_requires_the_matching_transaction)
+{
+    const uint256 owner{uint256S("01")};
+    uint8_t seed{0};
+    for (bool flush_first : {false, true}) {
+        const std::vector<uint8_t> key(32, ++seed);
+        Store(key, owner, 1000, PoDAFlushSource::Mempool);
+        if (flush_first) BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+        pnevmdatadb->ReleaseMempoolOwner(key, uint256S("02"));
+        pnevmdatadb->ReleaseMempoolOwner(key, uint256S("02"));
+        CheckMetadata(key, owner, 1000);
+        BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, owner));
+        BOOST_CHECK(!pnevmdatadb->BlobExists(key));
+        BOOST_CHECK(!pnevmdatablobdb->Exists(key));
+        pnevmdatadb->ReleaseMempoolOwner(key, owner);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(owner_release_preserves_cached_and_flushed_data)
+{
+    const uint256 owner{uint256S("01")};
+    uint8_t seed{0};
+    for (bool flush_first : {false, true}) {
+        const std::vector<uint8_t> key(32, ++seed);
+        Store(key, owner, 1000, PoDAFlushSource::Mempool);
+        if (flush_first) BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+        pnevmdatadb->ReleaseMempoolOwner(key, owner);
+        CheckMetadata(key, owner, 1000);
+        BOOST_CHECK_EQUAL(pnevmdatadb->Exists(key), flush_first);
+        {
+            LOCK(pnevmdatadb->cs_cache);
+            BOOST_CHECK_EQUAL(pnevmdatadb->GetCache().count(key), flush_first ? 0 : 1);
+        }
+        std::vector<uint8_t> payload;
+        BOOST_REQUIRE(pnevmdatablobdb->Read(key, payload));
+        BOOST_CHECK(payload == std::vector<uint8_t>(4, 1));
+
+        pnevmdatadb->ReleaseMempoolOwner(key, owner);
+        BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, owner));
+        CheckMetadata(key, owner, 1000);
+        BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+        BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, owner));
+        CheckMetadata(key, owner, 1000);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(repeated_owner_release_cannot_reclaim_a_shared_reference)
+{
+    const uint256 first_txid{uint256S("01")};
+    const uint256 second_txid{uint256S("02")};
+    uint8_t seed{0};
+    for (bool flush_first : {false, true}) {
+        const std::vector<uint8_t> key(32, ++seed);
+        Store(key, first_txid, 1000, PoDAFlushSource::Mempool);
+        if (flush_first) BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+        pnevmdatadb->ReleaseMempoolOwner(key, first_txid);
+        StoreMetadataOnly(key, second_txid, 2000, PoDAFlushSource::Mempool);
+        pnevmdatadb->ReleaseMempoolOwner(key, first_txid);
+        pnevmdatadb->ReleaseMempoolOwner(key, second_txid);
+        BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, first_txid));
+        BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, second_txid));
+        CheckMetadata(key, first_txid, 1000);
+        BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+        Store(key, first_txid, 3000, PoDAFlushSource::Mempool);
+        BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, first_txid));
+        CheckMetadata(key, first_txid, 1000);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(metadata_only_blocks_retain_known_payloads_and_sizes)
+{
+    const uint256 mempool_txid{uint256S("01")};
+    uint8_t seed{0};
+    for (bool flush_first : {false, true}) {
+        for (bool same_txid : {false, true}) {
+            for (bool empty_payload : {false, true}) {
+                const std::vector<uint8_t> key(32, ++seed);
+                const uint256 block_txid{same_txid ? mempool_txid : uint256S("02")};
+                Store(key, mempool_txid, 1000, PoDAFlushSource::Mempool);
+                if (flush_first) BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+                StoreMetadataOnly(key, block_txid, 2000, PoDAFlushSource::Block, empty_payload);
+                StoreMetadataOnly(key, block_txid, 1500, PoDAFlushSource::Block, empty_payload);
+                BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, mempool_txid));
+                BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, block_txid));
+                CheckMetadata(key, block_txid, 2000);
+                BOOST_REQUIRE(pnevmdatadb->PruneStandalone(1001 + NEVM_DATA_EXPIRE_TIME));
+                CheckMetadata(key, block_txid, 2000);
+                BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(2000));
+                CheckMetadata(key, block_txid, 2000);
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(metadata_only_mempool_references_distinguish_shared_ownership)
+{
+    const uint256 first_txid{uint256S("01")};
+    uint8_t seed{0};
+    for (bool flush_first : {false, true}) {
+        for (bool shared : {false, true}) {
+            for (bool empty_payload : {false, true}) {
+                const std::vector<uint8_t> key(32, ++seed);
+                const uint256 observed_txid{shared ? uint256S("02") : first_txid};
+                Store(key, first_txid, 1000, PoDAFlushSource::Mempool);
+                if (flush_first) BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+                StoreMetadataOnly(key, observed_txid, 2000, PoDAFlushSource::Mempool, empty_payload);
+                CheckMetadata(key, first_txid, 1000);
+                BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, first_txid));
+                if (shared) {
+                    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, observed_txid));
+                    CheckMetadata(key, first_txid, 1000);
+                    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+                    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, first_txid));
+                    CheckMetadata(key, first_txid, 1000);
+                } else {
+                    BOOST_CHECK(!pnevmdatadb->BlobExists(key));
+                    BOOST_CHECK(!pnevmdatablobdb->Exists(key));
+                }
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(metadata_only_observations_do_not_fabricate_missing_payloads)
+{
+    const uint256 txid{uint256S("01")};
+    const std::vector<uint8_t> unknown_key(32, 1);
+    StoreMetadataOnly(unknown_key, txid, 1000, PoDAFlushSource::Block);
+    StoreMetadataOnly(unknown_key, txid, 1000, PoDAFlushSource::Mempool);
+    BOOST_CHECK(!pnevmdatadb->BlobExists(unknown_key));
+    BOOST_CHECK(!pnevmdatablobdb->Exists(unknown_key));
+
+    const std::vector<uint8_t> orphan_key(32, 2);
+    BOOST_REQUIRE(pnevmdatablobdb->Write(orphan_key, std::vector<uint8_t>(4, 1)));
+    StoreMetadataOnly(orphan_key, txid, 1000, PoDAFlushSource::Block);
+    BOOST_CHECK(!pnevmdatadb->BlobExists(orphan_key));
+    BOOST_CHECK(pnevmdatablobdb->Exists(orphan_key));
+
+    const std::vector<uint8_t> missing_key(32, 3);
+    Store(missing_key, txid, 1000, PoDAFlushSource::Mempool);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+    BOOST_REQUIRE(pnevmdatablobdb->Erase(missing_key));
+    StoreMetadataOnly(missing_key, txid, 2000, PoDAFlushSource::Block);
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(missing_key, txid));
+    CheckMetadata(missing_key, txid, 2000, /*size=*/4, /*expect_blob=*/false);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(2000));
+    CheckMetadata(missing_key, txid, 2000, /*size=*/4, /*expect_blob=*/false);
+}
+
+BOOST_AUTO_TEST_CASE(retained_block_expiry_is_monotone_across_timestamp_orders)
+{
+    const uint256 first_txid{uint256S("01")};
+    const uint256 second_txid{uint256S("02")};
+    uint8_t seed{0};
+    for (bool newer_block_first : {false, true}) {
+        for (bool flush_first : {false, true}) {
+            for (bool flush_second : {false, true}) {
+                const std::vector<uint8_t> key(32, ++seed);
+                Store(key, first_txid, newer_block_first ? 2000 : 1000, PoDAFlushSource::Block);
+                if (flush_first) BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(2000));
+                Store(key, second_txid, newer_block_first ? 1000 : 2000, PoDAFlushSource::Block);
+                CheckMetadata(key, second_txid, 2000);
+                if (flush_second) BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(2000));
+
+                Store(key, uint256S("03"), 3000, PoDAFlushSource::Block, /*size=*/3);
+                Store(key, second_txid, 4000, PoDAFlushSource::Mempool);
+                CheckMetadata(key, second_txid, 2000);
+                BOOST_REQUIRE(pnevmdatadb->PruneStandalone(1001 + NEVM_DATA_EXPIRE_TIME));
+                CheckMetadata(key, second_txid, 2000);
+                BOOST_REQUIRE(pnevmdatadb->PruneStandalone(2000 + NEVM_DATA_EXPIRE_TIME));
+                CheckMetadata(key, second_txid, 2000);
+                BOOST_REQUIRE(pnevmdatadb->PruneStandalone(2001 + NEVM_DATA_EXPIRE_TIME));
+                BOOST_CHECK(!pnevmdatadb->BlobExists(key));
+                BOOST_CHECK(!pnevmdatablobdb->Exists(key));
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(retained_block_expiry_uses_newest_cache_time_and_survives_flush)
+{
+    Open(/*memory_only=*/false, /*wipe_data=*/true);
+    const std::vector<uint8_t> key(32, 1);
+    const uint256 last_txid{uint256S("03")};
+    Store(key, uint256S("01"), 1000, PoDAFlushSource::Block);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+    Store(key, uint256S("02"), 3000, PoDAFlushSource::Block);
+    Store(key, last_txid, 2000, PoDAFlushSource::Block);
+    CheckMetadata(key, last_txid, 3000);
+    BOOST_REQUIRE(pnevmdatadb->PruneStandalone(2001 + NEVM_DATA_EXPIRE_TIME));
+    CheckMetadata(key, last_txid, 3000);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(3000));
+
+    Open(/*memory_only=*/false, /*wipe_data=*/false);
+    CheckMetadata(key, last_txid, 3000);
+    BOOST_REQUIRE(pnevmdatadb->PruneStandalone(2001 + NEVM_DATA_EXPIRE_TIME));
+    CheckMetadata(key, last_txid, 3000);
+    BOOST_REQUIRE(pnevmdatadb->PruneStandalone(3001 + NEVM_DATA_EXPIRE_TIME));
+    BOOST_CHECK(!pnevmdatadb->BlobExists(key));
+    BOOST_CHECK(!pnevmdatablobdb->Exists(key));
+}
+
+BOOST_AUTO_TEST_CASE(shared_mempool_blobs_revoke_exclusive_cleanup_authority)
+{
+    const uint256 first_txid{uint256S("01")};
+    const uint256 second_txid{uint256S("02")};
+    uint8_t seed{0};
+    NEVMDataVec shared_keys;
+    for (bool flush_first : {false, true}) {
+        for (bool flush_shared : {false, true}) {
+            for (bool erase_first_owner_first : {false, true}) {
+                const std::vector<uint8_t> key(32, ++seed);
+                shared_keys.push_back(key);
+                Store(key, first_txid, 1000, PoDAFlushSource::Mempool);
+                if (flush_first) BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+                Store(key, second_txid, 2000, PoDAFlushSource::Mempool);
+                CheckMetadata(key, first_txid, 1000);
+                if (flush_shared) BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(2000));
+
+                const uint256 first_removed{erase_first_owner_first ? first_txid : second_txid};
+                const uint256 second_removed{erase_first_owner_first ? second_txid : first_txid};
+                BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, first_removed));
+                CheckMetadata(key, first_txid, 1000);
+                BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, second_removed));
+                CheckMetadata(key, first_txid, 1000);
+
+                Store(key, first_txid, 3000, PoDAFlushSource::Mempool);
+                BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, first_txid));
+                CheckMetadata(key, first_txid, 1000);
+            }
+        }
+    }
+    BOOST_REQUIRE(pnevmdatadb->PruneStandalone(1001 + NEVM_DATA_EXPIRE_TIME));
+    for (const auto& key : shared_keys) {
+        BOOST_CHECK(!pnevmdatadb->BlobExists(key));
+        BOOST_CHECK(!pnevmdatablobdb->Exists(key));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(reopened_metadata_does_not_restore_deletion_authority)
+{
+    Open(/*memory_only=*/false, /*wipe_data=*/true);
+    const std::vector<uint8_t> shared_key(32, 1);
+    const std::vector<uint8_t> sole_key(32, 2);
+    const uint256 first_txid{uint256S("01")};
+    const uint256 second_txid{uint256S("02")};
+    Store(shared_key, first_txid, 1000, PoDAFlushSource::Mempool);
+    Store(sole_key, first_txid, 1000, PoDAFlushSource::Mempool);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+    Store(shared_key, second_txid, 2000, PoDAFlushSource::Mempool);
+
+    Open(/*memory_only=*/false, /*wipe_data=*/false);
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(shared_key, first_txid));
+    CheckMetadata(shared_key, first_txid, 1000);
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(shared_key, second_txid));
+    CheckMetadata(shared_key, first_txid, 1000);
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(sole_key, first_txid));
+    CheckMetadata(sole_key, first_txid, 1000);
+
+    const std::vector<uint8_t> current_session_key(32, 3);
+    Store(current_session_key, first_txid, 1000, PoDAFlushSource::Mempool);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(current_session_key, first_txid));
+    BOOST_CHECK(!pnevmdatadb->BlobExists(current_session_key));
+    BOOST_CHECK(!pnevmdatablobdb->Exists(current_session_key));
+}
+
+BOOST_AUTO_TEST_CASE(size_mismatch_cannot_promote_or_refresh_metadata)
+{
+    const uint256 owner{uint256S("01")};
+    uint8_t seed{0};
+    for (bool flush : {false, true}) {
+        const std::vector<uint8_t> key(32, ++seed);
+        Store(key, owner, 1000, PoDAFlushSource::Mempool);
+        if (flush) BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+        Store(key, owner, 2000, PoDAFlushSource::Block, /*size=*/3);
+        Store(key, uint256S("02"), 2000, PoDAFlushSource::Mempool, /*size=*/3);
+        CheckMetadata(key, owner, 1000);
+        BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, owner));
+        BOOST_CHECK(!pnevmdatadb->BlobExists(key));
+        BOOST_CHECK(!pnevmdatablobdb->Exists(key));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(legacy_metadata_without_owner_remains_retained_after_reopen)
+{
+    Open(/*memory_only=*/false, /*wipe_data=*/true);
+    const std::vector<uint8_t> key(32, 1);
+    const uint256 txid{uint256S("01")};
+    const LegacyPoDAMetadata legacy{txid, 4, 1000};
+    DataStream old_format;
+    old_format << legacy;
+    DataStream current_format;
+    current_format << MapPoDAPayloadMeta{txid, 4, 1000};
+    BOOST_CHECK(old_format.str() == current_format.str());
+    BOOST_REQUIRE(pnevmdatadb->Write(key, legacy, true));
+    BOOST_REQUIRE(pnevmdatablobdb->Write(key, std::vector<uint8_t>(4, 1), true));
+
+    Open(/*memory_only=*/false, /*wipe_data=*/false);
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, txid));
+    Store(key, txid, 2000, PoDAFlushSource::Mempool);
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, txid));
+    CheckMetadata(key, txid, 1000);
+
+    Store(key, txid, 3000, PoDAFlushSource::Block);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(3000));
+    Open(/*memory_only=*/false, /*wipe_data=*/false);
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, txid));
+    CheckMetadata(key, txid, 3000);
+}
+
+BOOST_AUTO_TEST_CASE(old_format_metadata_refresh_cannot_restore_session_authority)
+{
+    Open(/*memory_only=*/false, /*wipe_data=*/true);
+    const std::vector<uint8_t> key(32, 1);
+    const uint256 txid{uint256S("01")};
+    Store(key, txid, 1000, PoDAFlushSource::Mempool);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+    // Another session/version may refresh metadata without recording ownership.
+    // Reopening must not infer exclusive authority from the unchanged txid.
+    BOOST_REQUIRE(pnevmdatadb->Write(key, LegacyPoDAMetadata{txid, 4, 2000}, true));
+    Open(/*memory_only=*/false, /*wipe_data=*/false);
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, txid));
+    Store(key, txid, 3000, PoDAFlushSource::Mempool);
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(key, txid));
+    CheckMetadata(key, txid, 2000);
+}
+
+BOOST_AUTO_TEST_CASE(missing_payload_repair_and_orphans_do_not_invent_ownership)
+{
+    const uint256 txid{uint256S("01")};
+    const std::vector<uint8_t> retained_key(32, 1);
+    Store(retained_key, txid, 1000, PoDAFlushSource::Block);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+    BOOST_REQUIRE(pnevmdatablobdb->Erase(retained_key));
+    Store(retained_key, txid, 2000, PoDAFlushSource::Mempool);
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(retained_key, txid));
+    CheckMetadata(retained_key, txid, 1000);
+
+    const std::vector<uint8_t> orphan_key(32, 2);
+    BOOST_REQUIRE(pnevmdatablobdb->Write(orphan_key, std::vector<uint8_t>(4, 1)));
+    Store(orphan_key, txid, 1000, PoDAFlushSource::Mempool);
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(orphan_key, txid));
+    CheckMetadata(orphan_key, txid, 1000);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+
+    const std::vector<uint8_t> mempool_key(32, 3);
+    Store(mempool_key, txid, 1000, PoDAFlushSource::Mempool);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+    BOOST_REQUIRE(pnevmdatablobdb->Erase(mempool_key));
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(mempool_key, txid));
+    BOOST_CHECK(!pnevmdatadb->BlobExists(mempool_key));
+
+    const std::vector<uint8_t> promoted_key(32, 4);
+    Store(promoted_key, txid, 1000, PoDAFlushSource::Mempool);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+    BOOST_REQUIRE(pnevmdatablobdb->Erase(promoted_key));
+    Store(promoted_key, txid, 2000, PoDAFlushSource::Block);
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(promoted_key, txid));
+    CheckMetadata(promoted_key, txid, 2000);
+}
+
+BOOST_AUTO_TEST_CASE(unreadable_metadata_is_not_new_deletion_authority)
+{
+    const uint256 txid{uint256S("01")};
+    const std::vector<uint8_t> unreadable_key(32, 2);
+    BOOST_REQUIRE(pnevmdatadb->Write(unreadable_key, uint8_t{1}));
+    Store(unreadable_key, txid, 1000, PoDAFlushSource::Mempool);
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(unreadable_key, txid));
+    BOOST_CHECK(pnevmdatadb->Exists(unreadable_key));
+    MapPoDAPayloadMeta meta;
+    BOOST_CHECK(!pnevmdatadb->GetBlobMetaData(unreadable_key, meta));
+}
+
+BOOST_AUTO_TEST_CASE(pruning_and_explicit_erase_retire_session_owners)
+{
+    const uint256 txid{uint256S("01")};
+    const std::vector<uint8_t> expired_key(32, 1);
+    const std::vector<uint8_t> refreshed_key(32, 2);
+    const std::vector<uint8_t> pending_key(32, 3);
+    const std::vector<uint8_t> erase_key(32, 4);
+    Store(expired_key, txid, 1000, PoDAFlushSource::Mempool);
+    Store(refreshed_key, txid, 1000, PoDAFlushSource::Mempool);
+    Store(erase_key, txid, 1000, PoDAFlushSource::Mempool);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+    Store(refreshed_key, txid, 2000, PoDAFlushSource::Block);
+    Store(pending_key, txid, 1000, PoDAFlushSource::Mempool);
+
+    BOOST_REQUIRE(pnevmdatadb->PruneStandalone(1000 + NEVM_DATA_EXPIRE_TIME));
+    CheckMetadata(expired_key, txid, 1000);
+    CheckMetadata(pending_key, txid, 1000);
+    BOOST_REQUIRE(pnevmdatadb->FlushErase({erase_key}));
+    BOOST_CHECK(!pnevmdatadb->BlobExists(erase_key));
+    BOOST_CHECK(!pnevmdatablobdb->Exists(erase_key));
+
+    BOOST_REQUIRE(pnevmdatadb->PruneStandalone(1001 + NEVM_DATA_EXPIRE_TIME));
+    for (const auto& key : {expired_key, pending_key}) {
+        BOOST_CHECK(!pnevmdatadb->BlobExists(key));
+        BOOST_CHECK(!pnevmdatablobdb->Exists(key));
+    }
+    CheckMetadata(refreshed_key, txid, 2000);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(2000));
+    CheckMetadata(refreshed_key, txid, 2000);
+
+    for (const auto& key : {expired_key, pending_key, erase_key}) {
+        CheckReinsertedLegacyIsRetained(key, txid);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(testnet_flush_prunes_cached_and_flushed_session_owners)
+{
+    fTestNet = true;
+    const uint256 txid{uint256S("01")};
+    const std::vector<uint8_t> persisted_key(32, 1);
+    const std::vector<uint8_t> pending_key(32, 2);
+    const std::vector<uint8_t> refreshed_key(32, 3);
+    Store(persisted_key, txid, 1000, PoDAFlushSource::Mempool);
+    Store(refreshed_key, txid, 1000, PoDAFlushSource::Mempool);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+    Store(pending_key, txid, 1000, PoDAFlushSource::Mempool);
+    Store(refreshed_key, txid, 2000, PoDAFlushSource::Block);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1001 + NEVM_DATA_EXPIRE_TIME));
+    for (const auto& key : {persisted_key, pending_key}) {
+        BOOST_CHECK(!pnevmdatadb->BlobExists(key));
+        BOOST_CHECK(!pnevmdatablobdb->Exists(key));
+    }
+    CheckMetadata(refreshed_key, txid, 2000);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(2001 + NEVM_DATA_EXPIRE_TIME));
+    BOOST_CHECK(!pnevmdatadb->BlobExists(refreshed_key));
+    BOOST_CHECK(!pnevmdatablobdb->Exists(refreshed_key));
+    for (const auto& key : {persisted_key, pending_key}) {
+        CheckReinsertedLegacyIsRetained(key, txid);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(prune_retry_completes_indexed_missing_payload_cleanup)
+{
+    const uint256 txid{uint256S("01")};
+    uint8_t seed{0};
+    for (bool testnet_flush : {false, true}) {
+        fTestNet = testnet_flush;
+        for (bool flush_first : {false, true}) {
+            const std::vector<uint8_t> key(32, ++seed);
+            Store(key, txid, 1000, PoDAFlushSource::Mempool);
+            if (flush_first) BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+            // This benign intermediate state also occurs after payload cleanup
+            // completes but before its metadata erase is committed.
+            BOOST_REQUIRE(pnevmdatablobdb->Erase(key, true));
+            CheckMetadata(key, txid, 1000, /*size=*/4, /*expect_blob=*/false);
+            if (testnet_flush) {
+                BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1001 + NEVM_DATA_EXPIRE_TIME));
+            } else {
+                BOOST_REQUIRE(pnevmdatadb->PruneStandalone(1001 + NEVM_DATA_EXPIRE_TIME));
+            }
+            BOOST_CHECK(!pnevmdatadb->BlobExists(key));
+            BOOST_CHECK(!pnevmdatablobdb->Exists(key));
+            CheckReinsertedLegacyIsRetained(key, txid);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(prune_retry_after_reopen_preserves_a_new_retained_refresh)
+{
+    Open(/*memory_only=*/false, /*wipe_data=*/true);
+    const uint256 txid{uint256S("01")};
+    const std::vector<uint8_t> expired_key(32, 1);
+    const std::vector<uint8_t> refreshed_key(32, 2);
+    Store(expired_key, txid, 1000, PoDAFlushSource::Mempool);
+    Store(refreshed_key, txid, 1000, PoDAFlushSource::Mempool);
+    BOOST_REQUIRE(pnevmdatadb->FlushCacheToDisk(1000));
+    BOOST_REQUIRE(pnevmdatablobdb->FlushErase({expired_key, refreshed_key}));
+
+    Open(/*memory_only=*/false, /*wipe_data=*/false);
+    Store(refreshed_key, txid, 2000, PoDAFlushSource::Block);
+    BOOST_REQUIRE(pnevmdatadb->PruneStandalone(1001 + NEVM_DATA_EXPIRE_TIME));
+    BOOST_CHECK(!pnevmdatadb->BlobExists(expired_key));
+    BOOST_CHECK(!pnevmdatablobdb->Exists(expired_key));
+    BOOST_REQUIRE(pnevmdatadb->FlushMempoolErase(refreshed_key, txid));
+    CheckMetadata(refreshed_key, txid, 2000);
+    BOOST_REQUIRE(pnevmdatadb->PruneStandalone(2001 + NEVM_DATA_EXPIRE_TIME));
+    BOOST_CHECK(!pnevmdatadb->BlobExists(refreshed_key));
+    BOOST_CHECK(!pnevmdatablobdb->Exists(refreshed_key));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -14,6 +14,7 @@
 #include <consensus/validation.h>
 #include <core_io.h>
 #include <key.h>
+#include <key_io.h>
 #include <nevm/nevm.h>
 #include <nevm/sha3.h>
 #include <policy/policy.h>
@@ -29,6 +30,7 @@
 #include <test/util/random.h>
 #include <test/util/script.h>
 #include <test/util/transaction_utils.h>
+#include <test/util/txmempool.h>
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <validation.h>
@@ -45,6 +47,8 @@
 #include <univalue.h>
 
 typedef std::vector<unsigned char> valtype;
+
+extern NEVMMintTxSet setMintTxsMempool;
 
 static CFeeRate g_dust{DUST_RELAY_TX_FEE};
 static bool g_bare_multi{DEFAULT_PERMIT_BAREMULTISIG};
@@ -529,6 +533,48 @@ BOOST_AUTO_TEST_CASE(syscoin_mint_parent_node_offsets)
     check({}, 0, {}, std::numeric_limits<uint16_t>::max(), false);
 }
 
+BOOST_FIXTURE_TEST_CASE(syscoin_mint_mempool_reservation_ownership, TestingSetup)
+{
+    CMintSyscoin mint;
+    mint.nTxHash = uint256S("a1");
+    mint.voutAssets.emplace_back(1, std::vector<CAssetOutValue>{{0, 1}});
+    mint.vchTxParentNodes = {0x80};
+    mint.vchReceiptParentNodes = {0x80};
+    std::vector<unsigned char> mint_data;
+    mint.SerializeData(mint_data);
+    CMutableTransaction mtx;
+    mtx.nVersion = SYSCOIN_TX_VERSION_ALLOCATION_MINT;
+    mtx.vin.emplace_back(COutPoint{uint256S("a0"), 0});
+    mtx.vout.emplace_back(10000, GetScriptForDestination(WitnessV0KeyHash{uint160(ParseHex("0100000000000000000000000000000000000000"))}));
+    mtx.vout.emplace_back(0, CScript() << OP_RETURN << mint_data);
+    mtx.LoadAssets();
+    const auto tx = MakeTransactionRef(mtx);
+    BOOST_REQUIRE(!CMintSyscoin(*tx).IsNull());
+
+    CTxMemPool& pool = *Assert(m_node.mempool);
+    LOCK2(cs_main, pool.cs);
+    BOOST_REQUIRE_EQUAL(setMintTxsMempool.count(mint.nTxHash), 0U);
+    // This parsed placeholder exercises bookkeeping only; its proof is never submitted for validation.
+    pool.addUnchecked(TestMemPoolEntryHelper{}.FromTx(tx));
+    BOOST_CHECK_EQUAL(setMintTxsMempool.count(mint.nTxHash), 1U);
+
+    for (const bool test_accept : {false, true}) {
+        const auto result = AcceptToMemoryPool(m_node.chainman->ActiveChainstate(), tx,
+                                             GetTime(), false, test_accept);
+        BOOST_CHECK_EQUAL(result.m_result_type, MempoolAcceptResult::ResultType::INVALID);
+        BOOST_CHECK_EQUAL(result.m_state.GetRejectReason(), "txn-already-in-mempool");
+        BOOST_CHECK_EQUAL(setMintTxsMempool.count(mint.nTxHash), 1U);
+    }
+    const auto package_result = ProcessNewPackage(m_node.chainman->ActiveChainstate(), pool,
+                                                  {tx}, /*test_accept=*/true);
+    BOOST_CHECK(package_result.m_state.IsInvalid());
+    BOOST_CHECK_EQUAL(setMintTxsMempool.count(mint.nTxHash), 1U);
+
+    pool.removeRecursive(*tx, MemPoolRemovalReason::EXPIRY);
+    BOOST_CHECK_EQUAL(setMintTxsMempool.count(mint.nTxHash), 0U);
+    BOOST_CHECK(!pool.exists(GenTxid::Txid(tx->GetHash())));
+}
+
 BOOST_AUTO_TEST_CASE(syscoin_mint_compares_roots_before_proof_parsing)
 {
     auto previous_roots_db = std::move(pnevmtxrootsdb);
@@ -622,8 +668,9 @@ BOOST_AUTO_TEST_CASE(syscoin_mint_canonical_receipt_activation)
     topics.append(dev::bytes{1}); // Legacy does not inspect the freezer topic shape.
     topics.append(dev::bytes{});  // Legacy accepts additional topics.
 
-    const std::string witness{"abc"};
-    dev::bytes event_data(128, 0);
+    const WitnessV0KeyHash destination{uint160(ParseHex("0100000000000000000000000000000000000000"))};
+    const std::string witness{EncodeDestination(destination)};
+    dev::bytes event_data(96 + ((witness.size() + 31) & ~size_t{31}), 0);
     event_data[31] = 1; // amount
     event_data[32] = 1; // Legacy ignores the offset's high bits.
     event_data[63] = 64;
@@ -701,6 +748,42 @@ BOOST_AUTO_TEST_CASE(syscoin_mint_canonical_receipt_activation)
     BOOST_CHECK(!CheckSyscoinMintInternal(
         mint, canonical_state, true, true, /*nHeight=*/0, mint_txs, asset_guid, amount, address));
     BOOST_CHECK_EQUAL(canonical_state.GetRejectReason(), "mint-log-invalid-field-count");
+
+    mint.voutAssets.emplace_back(1, std::vector<CAssetOutValue>{{0, 1}});
+    std::vector<unsigned char> mint_data;
+    mint.SerializeData(mint_data);
+    CMutableTransaction mint_mtx;
+    mint_mtx.nVersion = SYSCOIN_TX_VERSION_ALLOCATION_MINT;
+    mint_mtx.vout.emplace_back(0, GetScriptForDestination(destination));
+    mint_mtx.vout.emplace_back(0, CScript() << OP_RETURN << mint_data);
+    mint_mtx.LoadAssets();
+    const CTransaction mint_tx(mint_mtx);
+
+    for (const bool just_check : {false, true}) {
+        NEVMMintTxSet reservations;
+        CAssetsMap assets_in;
+        CAssetsMap assets_out{{1, 2}};
+        TxValidationState output_state;
+        BOOST_CHECK(!CheckSyscoinMint(mint_tx, mint_tx.GetHash(), output_state, 0,
+                                     just_check, reservations, assets_in, assets_out));
+        BOOST_CHECK_EQUAL(output_state.GetRejectReason(), "mint-output-mismatch");
+        BOOST_CHECK(reservations.empty());
+
+        assets_out = {{1, 1}};
+        TxValidationState accepted_state;
+        BOOST_CHECK(CheckSyscoinMint(mint_tx, mint_tx.GetHash(), accepted_state, 0,
+                                    just_check, reservations, assets_in, assets_out));
+        BOOST_CHECK_EQUAL(reservations.size(), 1U);
+        BOOST_CHECK_EQUAL(reservations.count(mint.nTxHash), 1U);
+        BOOST_CHECK(!pnevmtxmintdb->ExistsTx(mint.nTxHash));
+
+        assets_out = {{1, 1}};
+        TxValidationState duplicate_state;
+        BOOST_CHECK(!CheckSyscoinMint(mint_tx, mint_tx.GetHash(), duplicate_state, 0,
+                                     just_check, reservations, assets_in, assets_out));
+        BOOST_CHECK_EQUAL(duplicate_state.GetResult(), TxValidationResult::TX_MINT_DUPLICATE);
+        BOOST_CHECK_EQUAL(reservations.size(), 1U);
+    }
 
     pnevmtxrootsdb = std::move(previous_roots_db);
     pnevmtxmintdb = std::move(previous_mint_db);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -30,6 +30,7 @@
 #include <evo/providertx.h>
 #include <evo/deterministicmns.h>   
 extern bool EraseMempoolNEVMData(const std::vector<uint8_t>&, const uint256&);
+extern void ReleaseMempoolNEVMDataOwner(const std::vector<uint8_t>&, const uint256&);
 extern NEVMMintTxSet setMintTxsMempool;
 extern std::unordered_map<COutPoint, std::pair<CTransactionRef, CTransactionRef>, SaltedOutpointHasher> mapAssetAllocationConflicts;
 
@@ -545,6 +546,12 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, setEntries &setAnces
         }
     }
 
+    // Only admitted transactions own global mint reservations. Validation attempts use local sets.
+    if (IsSyscoinMintTx(tx.nVersion)) {
+        const CMintSyscoin mint(tx);
+        if (!mint.IsNull()) setMintTxsMempool.insert(mint.nTxHash);
+    }
+
     TRACE3(mempool, added,
         entry.GetTx().GetHash().data(),
         entry.GetTxSize(),
@@ -644,11 +651,15 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
         if(!mintSyscoin.IsNull())
             setMintTxsMempool.erase(mintSyscoin.nTxHash);
     }
-    // Remove only mempool-owned PoDA data on expiry/trim; confirmed and duplicate blobs are chain-owned.
-    else if(it->GetTx().IsNEVMData() && (reason == MemPoolRemovalReason::EXPIRY || reason == MemPoolRemovalReason::SIZELIMIT)) {
+    // Only expiry/trim may delete sole-owned payloads. Every removal releases
+    // session ownership so replacement/conflict churn cannot retain owner RAM.
+    else if(it->GetTx().IsNEVMData()) {
         CNEVMData nevmData(it->GetTx());
         if(!nevmData.IsNull()){
-            EraseMempoolNEVMData(nevmData.vchVersionHash, tx_hash);
+            if (reason == MemPoolRemovalReason::EXPIRY || reason == MemPoolRemovalReason::SIZELIMIT) {
+                EraseMempoolNEVMData(nevmData.vchVersionHash, tx_hash);
+            }
+            ReleaseMempoolNEVMDataOwner(nevmData.vchVersionHash, tx_hash);
         }
     }
     cachedInnerUsage -= memusage::DynamicUsage(it->GetMemPoolParentsConst()) + memusage::DynamicUsage(it->GetMemPoolChildrenConst());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -33,6 +33,7 @@
 #include <kernel/notifications_interface.h>
 #include <logging.h>
 #include <logging/timer.h>
+#include <node/blockconnection.h>
 #include <node/blockstorage.h>
 #include <node/utxo_snapshot.h>
 #include <nevm/sha3.h>
@@ -3782,32 +3783,19 @@ bool Chainstate::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew,
     LogPrint(BCLog::BENCHMARK, "  - Load block from disk: %.2fms\n",
              Ticks<MillisecondsDouble>(time_2 - time_1));
     // SYSCOIN
-    NEVMMintTxSet setMintTxs;
-    NEVMTxRootMap mapNEVMTxRoots;
-    PoDAMAPMemory mapPoDA;
-    std::vector<std::pair<uint256, uint32_t> > vecTXIDPairs;
+    node::BlockConnectionState connection{CoinsTip()};
     {
-        auto view = std::make_unique<CCoinsViewCache>(&CoinsTip());
-        bool rv = ConnectBlock(*pthisBlock, state, pindexNew, *view, false /*bJustCheck*/, setMintTxs, mapNEVMTxRoots, mapPoDA, vecTXIDPairs);
-        if (!rv && !pblock && state.GetResult() == BlockValidationResult::BLOCK_AUX_DATA_INVALID && HasNEVMAuxiliaryData(*pthisBlock)) {
-            // Disk blocks omit sidecars; reattaching shared optional data can
-            // change their size. Retry the original disk representation once,
-            // with a fresh view and every consensus/data-availability check.
-            auto committed = std::make_shared<CBlock>();
-            if (!m_blockman.ReadBlockFromDisk(*committed, *pindexNew, /*load_auxiliary_data=*/false)) {
-                return FatalError(m_chainman.GetNotifications(), state, "Failed to reread committed block");
-            }
-            view = std::make_unique<CCoinsViewCache>(&CoinsTip());
-            state = BlockValidationState();
-            setMintTxs.clear();
-            mapNEVMTxRoots.clear();
-            mapPoDA.clear();
-            vecTXIDPairs.clear();
-            pthisBlock = std::move(committed);
-            rv = ConnectBlock(*pthisBlock, state, pindexNew, *view, false /*bJustCheck*/, setMintTxs, mapNEVMTxRoots, mapPoDA, vecTXIDPairs);
+        const auto result = node::ConnectBlockWithAuxiliaryRetry(
+            m_blockman, *pindexNew, /*loaded_from_disk=*/!pblock, pthisBlock, state, CoinsTip(), connection,
+            [&]() EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
+                return ConnectBlock(*pthisBlock, state, pindexNew, *connection.view, false /*bJustCheck*/,
+                                    connection.mint_txs, connection.nevm_tx_roots, connection.poda, connection.txid_pairs);
+            });
+        if (result == node::BlockConnectionResult::DISK_READ_FAILED) {
+            return FatalError(m_chainman.GetNotifications(), state, "Failed to reread committed block");
         }
         GetMainSignals().BlockChecked(*pthisBlock, state);
-        if (!rv) {
+        if (result == node::BlockConnectionResult::FAILED) {
             if (state.GetResult() == BlockValidationResult::BLOCK_AUX_DATA_INVALID) {
                 // Stored blocks acquire sidecars again when read. Stop this
                 // activation attempt without retiring its candidate or looping
@@ -3825,20 +3813,21 @@ bool Chainstate::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew,
                  Ticks<MillisecondsDouble>(time_3 - time_2),
                  Ticks<SecondsDouble>(time_connect_total),
                  Ticks<MillisecondsDouble>(time_connect_total) / num_blocks_total);
-        bool flushed = view->Flush();
+        bool flushed = connection.view->Flush();
         assert(flushed);
+        connection.view.reset();
     }
     const CBlock& blockConnecting = *pthisBlock;
     // SYSCOIN: Stage mint markers in cache; they become durable on the next full
     // UTXO flush (write-ahead of CoinsTip) or on mint-containing disconnect/replay.
     if(pnevmdatadb)
-        pnevmdatadb->FlushDataToCache(mapPoDA, PoDAFlushSource::Block);
+        pnevmdatadb->FlushDataToCache(connection.poda, PoDAFlushSource::Block);
     if(pnevmtxmintdb)
-        pnevmtxmintdb->FlushDataToCache(setMintTxs);
+        pnevmtxmintdb->FlushDataToCache(connection.mint_txs);
     if(pblockindexdb)
-        pblockindexdb->FlushDataToCache(vecTXIDPairs);
+        pblockindexdb->FlushDataToCache(connection.txid_pairs);
     if(pnevmtxrootsdb)
-        pnevmtxrootsdb->FlushDataToCache(mapNEVMTxRoots);
+        pnevmtxrootsdb->FlushDataToCache(connection.nevm_tx_roots);
     const auto time_4{SteadyClock::now()};
     time_flush += time_4 - time_3;
     LogPrint(BCLog::BENCHMARK, "  - Flush: %.2fms [%.2fs (%.2fms/blk)]\n",

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4784,7 +4784,10 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
     if (block.vtx.empty() || block.vtx.size() * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT || ::GetSerializeSize(block, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT) {
         // SYSCOIN, pre NEVM we had larger blocks for SPTs mainly
         if(block.GetBlockTime() >= Params().GetConsensus().nNEVMStartTime) {
-            return state.Invalid(HasNEVMAuxiliaryData(block) ? BlockValidationResult::BLOCK_AUX_DATA_INVALID : BlockValidationResult::BLOCK_CONSENSUS,
+            const bool committed_invalid = block.vtx.empty() || block.vtx.size() * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT ||
+                ::GetSerializeSize(block, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS,
+                                   SER_SIZE | SER_NO_PODA) * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT;
+            return state.Invalid(committed_invalid ? BlockValidationResult::BLOCK_CONSENSUS : BlockValidationResult::BLOCK_AUX_DATA_INVALID,
                                  "bad-blk-length", "size limits failed");
         }
     }
@@ -5121,8 +5124,12 @@ static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& stat
     bool nevmContext = nHeight >= consensusParams.nNEVMStartBlock;
     if ((fRegTest || nevmContext) && GetBlockWeight(block) > MAX_BLOCK_WEIGHT) {
         // Old data may legitimately be omitted, but its presence contributes
-        // to weight without changing the committed block identity.
-        return state.Invalid(HasNEVMAuxiliaryData(block) ? BlockValidationResult::BLOCK_AUX_DATA_INVALID : BlockValidationResult::BLOCK_CONSENSUS,
+        // to weight without changing the committed block identity. Keep witness
+        // weight in the committed measure; only omit the auxiliary sidecars.
+        const int64_t committed_weight =
+            ::GetSerializeSize(block, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS, SER_SIZE | SER_NO_PODA) * (WITNESS_SCALE_FACTOR - 1) +
+            ::GetSerializeSize(block, PROTOCOL_VERSION, SER_SIZE | SER_NO_PODA);
+        return state.Invalid(committed_weight > MAX_BLOCK_WEIGHT ? BlockValidationResult::BLOCK_CONSENSUS : BlockValidationResult::BLOCK_AUX_DATA_INVALID,
                              "bad-blk-weight", strprintf("%s : weight limit failed", __func__));
     }
     bool fNexusActive = nHeight >= consensusParams.nNexusStartBlock;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -715,7 +715,7 @@ private:
     // Looks up inputs, calculates feerate, considers replacement, evaluates
     // package limits, etc. As this function can be invoked for "free" by a peer,
     // only tests that are fast should be done here (to avoid CPU DoS).
-    bool PreChecks(ATMPArgs& args, Workspace& ws) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_pool.cs);
+    bool PreChecks(ATMPArgs& args, Workspace& ws, NEVMMintTxSet& mint_txs) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_pool.cs);
 
     // Run checks for mempool replace-by-fee.
     bool ReplacementChecks(Workspace& ws) EXCLUSIVE_LOCKS_REQUIRED(cs_main, m_pool.cs);
@@ -777,7 +777,7 @@ private:
     bool m_rbf{false};
 };
 
-bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
+bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws, NEVMMintTxSet& mint_txs)
 {
     AssertLockHeld(cs_main);
     AssertLockHeld(m_pool.cs);
@@ -880,6 +880,20 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         }
     }
 
+    // Check sidecars after cheap policy checks, but before a missing-input
+    // result can place an unusable representation in the identity-keyed orphanage.
+    const auto poda_result = ProcessNEVMData(
+        m_active_chainstate.m_blockman, tx,
+        m_active_chainstate.m_chain.Tip()->GetMedianTimePast(),
+        TicksSinceEpoch<std::chrono::seconds>(m_active_chainstate.m_chainman.m_options.adjusted_time_callback()),
+        ws.mapPoDA);
+    if (poda_result == ProcessNEVMDataResult::AUX_DATA_INVALID) {
+        return state.Invalid(TxValidationResult::TX_AUX_DATA_INVALID, "bad-txns-poda-invalid");
+    }
+    if (poda_result == ProcessNEVMDataResult::CONSENSUS_INVALID) {
+        return state.Invalid(TxValidationResult::TX_NOT_STANDARD, "bad-txns-poda-invalid");
+    }
+
     m_view.SetBackend(m_viewmempool);
 
     const CCoinsViewCache& coins_cache = m_active_chainstate.CoinsTip();
@@ -934,15 +948,17 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     // SYSCOIN
     const auto& params = args.m_chainparams.GetConsensus();
-    if (!CheckSyscoinInputs(params, tx, hash, state, (uint32_t)m_active_chainstate.m_chain.Tip()->nHeight + 1, args.m_test_accept, setMintTxsMempool, mapAssetIn, mapAssetOut)) {
+    if (!CheckSyscoinInputs(params, tx, hash, state, (uint32_t)m_active_chainstate.m_chain.Tip()->nHeight + 1, args.m_test_accept, mint_txs, mapAssetIn, mapAssetOut)) {
         return false; // state filled in by CheckSyscoinInputs
-    }      
-    
-    // SYSCOIN
-    if(ProcessNEVMData(m_active_chainstate.m_blockman, tx, m_active_chainstate.m_chain.Tip()->GetMedianTimePast(), TicksSinceEpoch<std::chrono::seconds>(m_active_chainstate.m_chainman.m_options.adjusted_time_callback()), ws.mapPoDA) != ProcessNEVMDataResult::VALID) {
-        return state.Invalid(TxValidationResult::TX_NOT_STANDARD, "bad-txns-poda-invalid");
     }
-     if (m_pool.m_require_standard && !AreInputsStandard(tx, m_view)) {
+    if (IsSyscoinMintTx(tx.nVersion)) {
+        const CMintSyscoin mint(tx);
+        if (!mint.IsNull() && setMintTxsMempool.count(mint.nTxHash)) {
+            return state.Invalid(TxValidationResult::TX_MINT_DUPLICATE, "mint-duplicate-transfer");
+        }
+    }
+
+    if (m_pool.m_require_standard && !AreInputsStandard(tx, m_view)) {
         return state.Invalid(TxValidationResult::TX_INPUTS_NOT_STANDARD, "bad-txns-nonstandard-inputs");
     }
 
@@ -1367,8 +1383,9 @@ MempoolAcceptResult MemPoolAccept::AcceptSingleTransaction(const CTransactionRef
     LOCK(m_pool.cs); // mempool "read lock" (held through GetMainSignals().TransactionAddedToMempool())
 
     Workspace ws(ptx);
+    NEVMMintTxSet mint_txs;
 
-    if (!PreChecks(args, ws)) return MempoolAcceptResult::Failure(ws.m_state);
+    if (!PreChecks(args, ws, mint_txs)) return MempoolAcceptResult::Failure(ws.m_state);
 
     if (m_rbf && !ReplacementChecks(ws)) return MempoolAcceptResult::Failure(ws.m_state);
 
@@ -1410,9 +1427,11 @@ PackageMempoolAcceptResult MemPoolAccept::AcceptMultipleTransactions(const std::
 
     LOCK(m_pool.cs);
 
+    // Each attempt owns its reservations; failed subpackages may be retried with different fees.
+    NEVMMintTxSet mint_txs;
     // Do all PreChecks first and fail fast to avoid running expensive script checks when unnecessary.
     for (Workspace& ws : workspaces) {
-        if (!PreChecks(args, ws)) {
+        if (!PreChecks(args, ws, mint_txs)) {
             package_state.Invalid(PackageValidationResult::PCKG_TX, "transaction failed");
             // Exit early to avoid doing pointless work. Update the failed tx result; the rest are unfinished.
             results.emplace(ws.m_ptx->GetWitnessHash(), MempoolAcceptResult::Failure(ws.m_state));
@@ -1737,16 +1756,6 @@ MempoolAcceptResult AcceptToMemoryPool(Chainstate& active_chainstate, const CTra
             // SYSCOIN
             mapAssetAllocationConflicts.erase(hashTx);
         }
-        // if we had duplicate mint's we don't want to remove the mint tx hash, but only if we had some other error not related to TX_MINT_DUPLICATE
-        if(result.m_state.GetResult() != TxValidationResult::TX_MINT_DUPLICATE) {
-            // remove nevm tx from mempool structure
-            if(IsSyscoinMintTx(tx->nVersion)) {
-                CMintSyscoin mintSyscoin(*tx);
-                if(!mintSyscoin.IsNull()) {
-                    setMintTxsMempool.erase(mintSyscoin.nTxHash);
-                }
-            }
-        }
         TRACE2(mempool, rejected,
                 tx->GetHash().data(),
                 result.m_state.GetRejectReason().c_str()
@@ -2069,7 +2078,7 @@ void Chainstate::ConflictingChainFound(CBlockIndex* pindexNew)
 // which does its own setBlockIndexCandidates management.
 void Chainstate::InvalidBlockFound(CBlockIndex* pindex, const BlockValidationState& state)
 {
-    if (state.GetResult() != BlockValidationResult::BLOCK_MUTATED) {
+    if (IsBlockRejectionCacheable(state.GetResult())) {
         pindex->nStatus |= BLOCK_FAILED_VALID;
         m_chainman.m_failed_blocks.insert(pindex);
         m_blockman.m_dirty_blockindex.insert(pindex);
@@ -2455,6 +2464,10 @@ bool EraseMempoolNEVMData(const std::vector<uint8_t>& vchVersionHash, const uint
     }
     return true;
 }
+void ReleaseMempoolNEVMDataOwner(const std::vector<uint8_t>& vchVersionHash, const uint256& txid)
+{
+    if (pnevmdatadb && !vchVersionHash.empty()) pnevmdatadb->ReleaseMempoolOwner(vchVersionHash, txid);
+}
 class CBlobCheck
 {
 private:
@@ -2494,6 +2507,9 @@ ProcessNEVMDataResult ProcessNEVMDataHelper(const BlockManager& blockman, const 
     CCheckQueueControl<CBlobCheck> control(&blobcheckqueue);
     std::vector<CBlobCheck> vChecks;
     for (const auto &nevmDataPayload : vecNevmDataPayload) {
+        if (nevmDataPayload.vchNEVMData && nevmDataPayload.vchNEVMData->size() > MAX_NEVM_DATA_BLOB) {
+            return ProcessNEVMDataResult::AUX_DATA_INVALID;
+        }
         // if connecting block is over NEVM_DATA_ENFORCE_TIME_NOT_HAVE_DATA seconds old (median) and we have a chainlock less than NEVM_DATA_ENFORCE_TIME_HAVE_DATA seconds old (median)
         const bool enforceNotHaveData = nMedianTimeCL > 0 && nMedianTime < (nTimeNow - NEVM_DATA_ENFORCE_TIME_NOT_HAVE_DATA) && nMedianTimeCL >= (nTimeNow - NEVM_DATA_ENFORCE_TIME_HAVE_DATA);
         const bool enforceHaveData = nMedianTime >= (nTimeNow - NEVM_DATA_ENFORCE_TIME_HAVE_DATA);
@@ -2526,6 +2542,21 @@ ProcessNEVMDataResult ProcessNEVMDataHelper(const BlockManager& blockman, const 
     }
     return ProcessNEVMDataResult::VALID;
 }
+static ProcessNEVMDataResult ExtractNEVMData(const CTransaction& tx, CNEVMData& payload)
+{
+    payload = CNEVMData(tx);
+    if (payload.IsNull()) return ProcessNEVMDataResult::CONSENSUS_INVALID;
+
+    const int data_output = GetSyscoinDataOutput(tx);
+    for (size_t i = 0; i < tx.vout.size(); ++i) {
+        // Only the selected commitment has a corresponding retained sidecar.
+        if (i != static_cast<size_t>(data_output) && !tx.vout[i].vchNEVMData.empty()) {
+            return ProcessNEVMDataResult::AUX_DATA_INVALID;
+        }
+    }
+    return ProcessNEVMDataResult::VALID;
+}
+
 // when we receive blocks/txs from peers we need to strip the OPRETURN NEVM DA payload and store separately
 ProcessNEVMDataResult ProcessNEVMData(const BlockManager& blockman, const CBlock &block, const int64_t &nMedianTime, const int64_t& nTimeNow, PoDAMAPMemory &mapPoDA) {
     std::vector<CNEVMData> vecNevmDataPayload;
@@ -2537,10 +2568,9 @@ ProcessNEVMDataResult ProcessNEVMData(const BlockManager& blockman, const CBlock
                 LogPrintf("ProcessNEVMData nCountBlobs > MAX_DATA_BLOBS, nCountBlobs: %d\n", nCountBlobs);
                 return ProcessNEVMDataResult::CONSENSUS_INVALID;
             }
-            const CNEVMData nevmDataPayload(*tx);
-            if(nevmDataPayload.IsNull()) {
-                return ProcessNEVMDataResult::CONSENSUS_INVALID;
-            }
+            CNEVMData nevmDataPayload;
+            const auto result = ExtractNEVMData(*tx, nevmDataPayload);
+            if (result != ProcessNEVMDataResult::VALID) return result;
             vecNevmDataPayload.emplace_back(nevmDataPayload);
         }
     }
@@ -2553,10 +2583,9 @@ ProcessNEVMDataResult ProcessNEVMData(const BlockManager& blockman, const CTrans
     if(!tx.IsNEVMData()) {
         return ProcessNEVMDataResult::VALID;
     }
-    const CNEVMData nevmDataPayload(tx);
-    if(nevmDataPayload.IsNull()) {
-        return ProcessNEVMDataResult::CONSENSUS_INVALID;
-    }
+    CNEVMData nevmDataPayload;
+    const auto result = ExtractNEVMData(tx, nevmDataPayload);
+    if (result != ProcessNEVMDataResult::VALID) return result;
     std::vector<CNEVMData> vecPayload{nevmDataPayload};
     return ProcessNEVMDataHelper(blockman, vecPayload, nMedianTime, nTimeNow, mapPoDA);
 }
@@ -2818,6 +2847,19 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         return true;
     }
 
+    // Special-transaction processing mutates quorum and masternode caches.
+    // Reject replaceable data before those effects so retry starts cleanly.
+    if (pindex->nHeight >= params.GetConsensus().nPODAStartBlock) {
+        const auto poda_result = ProcessNEVMData(m_chainman.m_blockman, block, pindex->GetMedianTimePast(),
+            TicksSinceEpoch<std::chrono::seconds>(m_chainman.m_options.adjusted_time_callback()), mapPoDA);
+        if (poda_result == ProcessNEVMDataResult::CONSENSUS_INVALID) {
+            return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "poda-validation-failed");
+        }
+        if (poda_result == ProcessNEVMDataResult::AUX_DATA_INVALID) {
+            return state.Invalid(BlockValidationResult::BLOCK_AUX_DATA_INVALID, "poda-aux-data-invalid");
+        }
+    }
+
     // SYSCOIN: Persist BTCPREV commitment in block index only for consensus-relevant
     // sign-offset BTCC heights. Reuse the contextual-validation cache in the common
     // accept->connect flow; otherwise fall back to reparsing.
@@ -3048,7 +3090,7 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
             }
             // SYSCOIN
             TxValidationState tx_statesys;
-            // just temp var not used in !fJustCheck mode
+            // Keep block-local reservations even in TestBlockValidity's check-only mode.
             if (!CheckSyscoinInputs(params.GetConsensus(), tx, txHash, tx_statesys, (uint32_t)pindex->nHeight, fJustCheck, setMintTxs, mapAssetIn, mapAssetOut)){
                 // Any transaction validation failure in ConnectBlock is a block consensus failure
                 state.Invalid(BlockValidationResult::BLOCK_CONSENSUS,
@@ -3111,17 +3153,6 @@ bool Chainstate::ConnectBlock(const CBlock& block, BlockValidationState& state, 
         }
         UpdateCoins(tx, view, i == 0 ? undoDummy : blockundo.vtxundo.back(), pindex->nHeight);
     }
-    bool PODAContext = pindex->nHeight >= params.GetConsensus().nPODAStartBlock;
-    if(PODAContext && state.IsValid()) {
-        const auto poda_result = ProcessNEVMData(m_chainman.m_blockman, block, pindex->GetMedianTimePast(), TicksSinceEpoch<std::chrono::seconds>(m_chainman.m_options.adjusted_time_callback()), mapPoDA);
-        if(poda_result == ProcessNEVMDataResult::CONSENSUS_INVALID) {
-            state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "poda-validation-failed");
-        }
-        if(poda_result == ProcessNEVMDataResult::AUX_DATA_INVALID) {
-            state.Invalid(BlockValidationResult::BLOCK_MUTATED, "poda-aux-data-invalid");
-        }
-    }
-
     const auto time_3{SteadyClock::now()};
     time_connect += time_3 - time_2;
     LogPrint(BCLog::BENCHMARK, "      - Connect %u transactions: %.2fms (%.3fms/tx, %.3fms/txin) [%.2fs (%.2fms/blk)]\n", (unsigned)block.vtx.size(),
@@ -3743,7 +3774,6 @@ bool Chainstate::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew,
         LogPrint(BCLog::BENCHMARK, "  - Using cached block\n");
         pthisBlock = pblock;
     }
-    const CBlock& blockConnecting = *pthisBlock;
     // Apply the block atomically to the chain state.
     const auto time_2{SteadyClock::now()};
     SteadyClock::time_point time_3;
@@ -3757,10 +3787,33 @@ bool Chainstate::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew,
     PoDAMAPMemory mapPoDA;
     std::vector<std::pair<uint256, uint32_t> > vecTXIDPairs;
     {
-        CCoinsViewCache view(&CoinsTip());
-        bool rv = ConnectBlock(blockConnecting, state, pindexNew, view, false /*bJustCheck*/, setMintTxs, mapNEVMTxRoots, mapPoDA, vecTXIDPairs);
-        GetMainSignals().BlockChecked(blockConnecting, state);
+        auto view = std::make_unique<CCoinsViewCache>(&CoinsTip());
+        bool rv = ConnectBlock(*pthisBlock, state, pindexNew, *view, false /*bJustCheck*/, setMintTxs, mapNEVMTxRoots, mapPoDA, vecTXIDPairs);
+        if (!rv && !pblock && state.GetResult() == BlockValidationResult::BLOCK_AUX_DATA_INVALID && HasNEVMAuxiliaryData(*pthisBlock)) {
+            // Disk blocks omit sidecars; reattaching shared optional data can
+            // change their size. Retry the original disk representation once,
+            // with a fresh view and every consensus/data-availability check.
+            auto committed = std::make_shared<CBlock>();
+            if (!m_blockman.ReadBlockFromDisk(*committed, *pindexNew, /*load_auxiliary_data=*/false)) {
+                return FatalError(m_chainman.GetNotifications(), state, "Failed to reread committed block");
+            }
+            view = std::make_unique<CCoinsViewCache>(&CoinsTip());
+            state = BlockValidationState();
+            setMintTxs.clear();
+            mapNEVMTxRoots.clear();
+            mapPoDA.clear();
+            vecTXIDPairs.clear();
+            pthisBlock = std::move(committed);
+            rv = ConnectBlock(*pthisBlock, state, pindexNew, *view, false /*bJustCheck*/, setMintTxs, mapNEVMTxRoots, mapPoDA, vecTXIDPairs);
+        }
+        GetMainSignals().BlockChecked(*pthisBlock, state);
         if (!rv) {
+            if (state.GetResult() == BlockValidationResult::BLOCK_AUX_DATA_INVALID) {
+                // Stored blocks acquire sidecars again when read. Stop this
+                // activation attempt without retiring its candidate or looping
+                // over the same replaceable representation as an invalid chain.
+                state.Error("Auxiliary block data requires refresh");
+            }
             if (state.IsInvalid())
                 InvalidBlockFound(pindexNew, state);
             return error("%s: ConnectBlock %s failed, %s", __func__, pindexNew->GetBlockHash().ToString(), state.ToString());
@@ -3772,9 +3825,10 @@ bool Chainstate::ConnectTip(BlockValidationState& state, CBlockIndex* pindexNew,
                  Ticks<MillisecondsDouble>(time_3 - time_2),
                  Ticks<SecondsDouble>(time_connect_total),
                  Ticks<MillisecondsDouble>(time_connect_total) / num_blocks_total);
-        bool flushed = view.Flush();
+        bool flushed = view->Flush();
         assert(flushed);
     }
+    const CBlock& blockConnecting = *pthisBlock;
     // SYSCOIN: Stage mint markers in cache; they become durable on the next full
     // UTXO flush (write-ahead of CoinsTip) or on mint-containing disconnect/replay.
     if(pnevmdatadb)
@@ -3970,7 +4024,7 @@ bool Chainstate::ActivateBestChainStep(BlockValidationState& state, CBlockIndex*
             if (!ConnectTip(state, pindexConnect, pindexConnect == pindexMostWork ? pblock : std::shared_ptr<const CBlock>(), connectTrace, disconnectpool)) {
                 if (state.IsInvalid()) {
                     // The block violates a consensus rule.
-                    if (state.GetResult() != BlockValidationResult::BLOCK_MUTATED) {
+                    if (IsBlockRejectionCacheable(state.GetResult())) {
                         InvalidChainFound(vpindexToConnect.front());
                     }
                     state = BlockValidationState();
@@ -4730,7 +4784,8 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
     if (block.vtx.empty() || block.vtx.size() * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT || ::GetSerializeSize(block, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT) {
         // SYSCOIN, pre NEVM we had larger blocks for SPTs mainly
         if(block.GetBlockTime() >= Params().GetConsensus().nNEVMStartTime) {
-            return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-blk-length", "size limits failed");
+            return state.Invalid(HasNEVMAuxiliaryData(block) ? BlockValidationResult::BLOCK_AUX_DATA_INVALID : BlockValidationResult::BLOCK_CONSENSUS,
+                                 "bad-blk-length", "size limits failed");
         }
     }
     // SYSCOIN
@@ -4753,10 +4808,11 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
     for (const auto& tx : block.vtx) {
         TxValidationState tx_state;
         if (!CheckTransaction(*tx, tx_state)) {
-            // CheckBlock() does context-free validation checks. The only
-            // possible failures are consensus failures.
-            assert(tx_state.GetResult() == TxValidationResult::TX_CONSENSUS);
-            return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, tx_state.GetRejectReason(),
+            assert(tx_state.GetResult() == TxValidationResult::TX_CONSENSUS ||
+                   tx_state.GetResult() == TxValidationResult::TX_AUX_DATA_INVALID);
+            return state.Invalid(tx_state.GetResult() == TxValidationResult::TX_AUX_DATA_INVALID ?
+                                     BlockValidationResult::BLOCK_AUX_DATA_INVALID : BlockValidationResult::BLOCK_CONSENSUS,
+                                 tx_state.GetRejectReason(),
                                  strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), tx_state.GetDebugMessage()));
         }
     }
@@ -5064,7 +5120,10 @@ static bool ContextualCheckBlock(const CBlock& block, BlockValidationState& stat
     const auto& consensusParams = chainman.GetParams().GetConsensus();
     bool nevmContext = nHeight >= consensusParams.nNEVMStartBlock;
     if ((fRegTest || nevmContext) && GetBlockWeight(block) > MAX_BLOCK_WEIGHT) {
-        return state.Invalid(BlockValidationResult::BLOCK_CONSENSUS, "bad-blk-weight", strprintf("%s : weight limit failed", __func__));
+        // Old data may legitimately be omitted, but its presence contributes
+        // to weight without changing the committed block identity.
+        return state.Invalid(HasNEVMAuxiliaryData(block) ? BlockValidationResult::BLOCK_AUX_DATA_INVALID : BlockValidationResult::BLOCK_CONSENSUS,
+                             "bad-blk-weight", strprintf("%s : weight limit failed", __func__));
     }
     bool fNexusActive = nHeight >= consensusParams.nNexusStartBlock;
     // Ensure the coinbase transaction is either standard or explicitly allowed
@@ -5329,23 +5388,12 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
     }
 
     const CChainParams& params{GetParams()};
-    if (!CheckBlock(block, state, params.GetConsensus(), true, true) ||
-        !ContextualCheckBlock(block, state, *this, pindex->pprev)) {
-        if (state.IsInvalid() && state.GetResult() != BlockValidationResult::BLOCK_MUTATED) {
+    if (!CheckBlock(block, state, params.GetConsensus(), true, true)) {
+        if (state.IsInvalid() && IsBlockRejectionCacheable(state.GetResult())) {
             pindex->nStatus |= BLOCK_FAILED_VALID;
             m_blockman.m_dirty_blockindex.insert(pindex);
         }
         return error("%s: %s", __func__, state.ToString());
-    }
-    // SYSCOIN: cache the contextually validated BTCPREV so ConnectBlock can reuse it
-    // without reparsing the coinbase payload in the common accept->connect flow.
-    {
-        const bool btcp_required = IsBTCCSignHeight(params.GetConsensus(), pindex->nHeight) &&
-                                   block.auxpow;
-        if (btcp_required) {
-            pindex->m_btcp_prev_contextually_validated = true;
-            pindex->m_btcp_prev_contextual_commitment = block.auxpow->getParentPrevBlockHash();
-        }
     }
     // SYSCOIN ProcessNEVMData/FlushDataToCache so we have the data from processing out-of-order blocks and it reads from disk (recreating PoDA data in block) prior to validation in ConnectTip()
     bool PODAContext = pindex->nHeight >= params.GetConsensus().nPODAStartBlock;
@@ -5359,8 +5407,25 @@ bool ChainstateManager::AcceptBlock(const std::shared_ptr<const CBlock>& pblock,
             return error("%s: %s", __func__, state.ToString());
         }
         if(poda_result == ProcessNEVMDataResult::AUX_DATA_INVALID) {
-            state.Invalid(BlockValidationResult::BLOCK_MUTATED, "poda-aux-data-invalid");
+            state.Invalid(BlockValidationResult::BLOCK_AUX_DATA_INVALID, "poda-aux-data-invalid");
             return error("%s: %s", __func__, state.ToString());
+        }
+    }
+    if (!ContextualCheckBlock(block, state, *this, pindex->pprev)) {
+        if (state.IsInvalid() && IsBlockRejectionCacheable(state.GetResult())) {
+            pindex->nStatus |= BLOCK_FAILED_VALID;
+            m_blockman.m_dirty_blockindex.insert(pindex);
+        }
+        return error("%s: %s", __func__, state.ToString());
+    }
+    // SYSCOIN: cache the contextually validated BTCPREV so ConnectBlock can reuse it
+    // without reparsing the coinbase payload in the common accept->connect flow.
+    {
+        const bool btcp_required = IsBTCCSignHeight(params.GetConsensus(), pindex->nHeight) &&
+                                   block.auxpow;
+        if (btcp_required) {
+            pindex->m_btcp_prev_contextually_validated = true;
+            pindex->m_btcp_prev_contextual_commitment = block.auxpow->getParentPrevBlockHash();
         }
     }
     if(pnevmdatadb)

--- a/src/validation.h
+++ b/src/validation.h
@@ -1374,6 +1374,7 @@ bool DisconnectNEVMCommitment(ChainstateManager& chainman, BlockValidationState&
 bool GetNEVMData(BlockValidationState& state, const CBlock& block, CNEVMHeader &evmBlock, std::vector<unsigned char>* coinbase_payload = nullptr);
 bool FillNEVMData(CBlock &block);
 bool EraseMempoolNEVMData(const std::vector<uint8_t>& vchVersionHash, const uint256& txid);
+void ReleaseMempoolNEVMDataOwner(const std::vector<uint8_t>& vchVersionHash, const uint256& txid);
 enum class ProcessNEVMDataResult {
     VALID,
     CONSENSUS_INVALID,


### PR DESCRIPTION
Keep NEVM auxiliary-data handling and cache bookkeeping consistent across validation, mempool admission, disk reloads, and cleanup.

- Distinguish committed validation results from replaceable auxiliary-data results, including disk reload and rejection-cache handling.
- Preserve pending mint/root cache entries until their database batch succeeds.
- Keep mint reservations local to validation attempts and pair global reservations with actual mempool admission/removal.
- Track exclusive mempool blob ownership independently of retained metadata, preserving shared/block references and cleanup retryability.
- Add focused coverage for auxiliary representations, writeback batches, admission ownership, retained references, and persistence compatibility.

No transaction wire-format or persisted PoDA metadata-format changes. This branch is based directly on current master and contains no PQ/recovery branch changes.

Validation on macOS ARM64:

- Built `syscoind` and `test/test_syscoin`.
- Focused suites: 65 cases passed.
- Full unit suite: 720 cases passed; the optional external `DIR_UNIT_TEST_DATA` case was unavailable.
- Functional tests passed: `mempool_accept.py`, `mempool_packages.py`, `mempool_reorg.py`, `feature_loadblock.py`, and `feature_nevm_data.py`.
- `git diff --check` passed.